### PR TITLE
Update link color on about page

### DIFF
--- a/Aurora/public/about.html
+++ b/Aurora/public/about.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8">
   <title>About Alfe AI</title>
   <link rel="stylesheet" href="/styles.css">
+  <style>
+    a, a:visited { color: cyan; }
+  </style>
 </head>
 <body style="padding:1rem;">
   <h2>About Alfe AI</h2>


### PR DESCRIPTION
## Summary
- style links on `about.html` with a cyan color

## Testing
- `npm test` in `AutoPR` (shows "No tests specified")
- `npm test` in `Aurora` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_684570de99a48323ad31a86a09c9c4bb