### PR TITLE
Add DISABLE_2FA option

### DIFF
--- a/Aurora/.env.example
+++ b/Aurora/.env.example
@@ -31,6 +31,9 @@ GITHUB_REPO=yourRepo
 # Port for the Aurora web server (optional)
 # AURORA_PORT=3000
 
+# Disable TOTP requirement on login (optional)
+# DISABLE_2FA=true
+
 # PostgreSQL connection string for AWS RDS (optional)
 # AWS_DB_URL=postgres://user:password@hostname:5432/dbname
 

--- a/Aurora/README.md
+++ b/Aurora/README.md
@@ -26,6 +26,7 @@ npm start
 | `HTTPS_KEY_PATH` | (Optional) Path to SSL private key for HTTPS |
 | `HTTPS_CERT_PATH` | (Optional) Path to SSL certificate for HTTPS |
 | `AURORA_PORT` | (Optional) Port for the web server (default: 3000) |
+| `DISABLE_2FA` | (Optional) Set to `true` to skip TOTP verification during login |
 | `AWS_DB_URL` | (Optional) PostgreSQL connection string for AWS RDS. If set, the local SQLite DB is ignored |
 | `AWS_DB_HOST` | (Optional) Hostname for AWS RDS. If set (with other credentials), enables the RDS integration |
 | `AWS_DB_USER` | (Optional) Username for AWS RDS |

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -869,7 +869,8 @@ app.post("/api/login", (req, res) => {
       return res.status(400).json({ error: "invalid credentials" });
     }
 
-    if (account.totp_secret) {
+    const disable2fa = process.env.DISABLE_2FA === 'true' || process.env.DISABLE_2FA === '1';
+    if (account.totp_secret && !disable2fa) {
       if (!token) {
         return res.status(400).json({ error: "totp required" });
       }


### PR DESCRIPTION
## Summary
- allow skipping TOTP verification using `DISABLE_2FA` env var
- document the new variable
- update `.env.example`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68457819d78c83238d397f7d4534ef07