### PR TITLE
Add portfolio flag to Aurora images

### DIFF
--- a/Aurora/public/Image.html
+++ b/Aurora/public/Image.html
@@ -17,6 +17,7 @@
   <div id="fileContainer"></div>
   <div id="resolutionDisplay" style="margin-top:0.5rem;"></div>
   <div id="statusControl" style="margin-top:0.5rem;"></div>
+  <div id="portfolioControl" style="margin-top:0.5rem;"></div>
   <h3>Jobs for this Image</h3>
   <table id="jobsTable" style="width:100%;border-collapse:collapse;">
     <thead>
@@ -115,6 +116,28 @@
       }
     }
 
+    async function loadPortfolio(){
+      try{
+        const res = await fetch('/api/upload/list?sessionId=' + encodeURIComponent(sessionId));
+        const list = await res.json();
+        const item = list.find(f => f.name === file);
+        return item ? !!item.portfolio : false;
+      }catch(err){
+        console.error('Failed to load portfolio =>', err);
+        return false;
+      }
+    }
+
+    async function checkPortfolio(){
+      if(!file) return;
+      try{
+        const current = await loadPortfolio();
+        if(portfolioCheck && portfolioCheck.checked !== current) portfolioCheck.checked = current;
+      }catch(e){
+        console.error('Failed to check portfolio =>', e);
+      }
+    }
+
 
     const container = document.getElementById('fileContainer');
     const resEl = document.getElementById('resolutionDisplay');
@@ -141,6 +164,22 @@
         body: JSON.stringify({ name: file, status: statusSelect.value })
       });
       await checkStatus();
+    });
+
+    const portfolioDiv = document.getElementById('portfolioControl');
+    portfolioDiv.innerHTML = '<label><input type="checkbox" id="portfolioCheck"/> Publish to portfolio</label>';
+    const portfolioCheck = document.getElementById('portfolioCheck');
+    portfolioCheck.disabled = !file;
+    (async () => {
+      portfolioCheck.checked = file ? await loadPortfolio() : false;
+    })();
+    portfolioCheck.addEventListener('change', async () => {
+      if(!file) return;
+      await fetch('/api/upload/portfolio', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: file, portfolio: portfolioCheck.checked })
+      });
     });
     const origImg = document.createElement('img');
     const upscaledImg = document.createElement('img');
@@ -418,6 +457,8 @@
       setInterval(checkUpscaled, 5000);
       checkStatus();
       setInterval(checkStatus, 5000);
+      checkPortfolio();
+      setInterval(checkPortfolio, 5000);
     } else {
       upscaleBtn.disabled = true;
       printifyBtn.disabled = true;

--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -118,6 +118,7 @@
             <th data-col="title">Title</th>
             <th data-col="source">Source</th>
             <th data-col="status">Status</th>
+            <th data-col="portfolio">Portfolio</th>
             <th data-col="size">Size (KB)</th>
             <th data-col="mtime">Last Modified</th>
             <th>Action</th>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3037,6 +3037,18 @@ function renderFileList(){
     const tdStatus = document.createElement("td");
     tdStatus.textContent = f.status || "";
     tdStatus.className = "img-status-cell";
+    const tdPortfolio = document.createElement("td");
+    const portCheck = document.createElement("input");
+    portCheck.type = "checkbox";
+    portCheck.checked = !!f.portfolio;
+    portCheck.addEventListener("change", async () => {
+      await fetch('/api/upload/portfolio', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: f.name, portfolio: portCheck.checked })
+      });
+    });
+    tdPortfolio.appendChild(portCheck);
     const tdSize = document.createElement("td");
     tdSize.textContent = Math.round(f.size / 1024) + " KB";
     const tdMtime = document.createElement("td");
@@ -3069,6 +3081,7 @@ function renderFileList(){
     tr.appendChild(tdTitle);
     tr.appendChild(tdSource);
     tr.appendChild(tdStatus);
+    tr.appendChild(tdPortfolio);
     tr.appendChild(tdSize);
     tr.appendChild(tdMtime);
     tr.appendChild(tdAction);

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1863,7 +1863,8 @@ app.get("/api/upload/list", (req, res) => {
       const uuid = db.getImageUuidForUrl(`/uploads/${name}`);
       const source = db.isGeneratedImage(`/uploads/${name}`) ? 'Generated' : 'Uploaded';
       const status = db.getImageStatusForUrl(`/uploads/${name}`) || (source === 'Generated' ? 'Generated' : 'Uploaded');
-      files.push({ id, uuid, name, size, mtime, title, source, status });
+      const portfolio = db.getImagePortfolioForUrl(`/uploads/${name}`) ? 1 : 0;
+      files.push({ id, uuid, name, size, mtime, title, source, status, portfolio });
     }
     res.json(files);
   } catch (err) {
@@ -1920,6 +1921,21 @@ app.post("/api/upload/status", (req, res) => {
     res.json({ success: true });
   } catch(err){
     console.error("[Server Debug] /api/upload/status error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+app.post("/api/upload/portfolio", (req, res) => {
+  try {
+    const { name, portfolio } = req.body || {};
+    if(!name){
+      return res.status(400).json({ error: "Missing name" });
+    }
+    const url = `/uploads/${name}`;
+    db.setImagePortfolio(url, portfolio ? 1 : 0);
+    res.json({ success: true });
+  } catch(err){
+    console.error("[Server Debug] /api/upload/portfolio error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -2393,7 +2409,7 @@ app.post("/api/image/generate", async (req, res) => {
       const tab = parseInt(tabId, 10) || 1;
       const imageTitle = await deriveImageTitle(prompt);
       const modelId = model ? `stable-diffusion/${model}` : 'stable-diffusion';
-      db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress, modelId);
+      db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress, modelId, 0);
       return res.json({ success: true, url: localUrl, title: imageTitle });
     }
 
@@ -2485,7 +2501,7 @@ app.post("/api/image/generate", async (req, res) => {
     const tab = parseInt(tabId, 10) || 1;
     const imageTitle = await deriveImageTitle(prompt, openaiClient);
     const modelId = `openai/${modelName}`;
-    db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress, modelId);
+    db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress, modelId, 0);
 
     res.json({ success: true, url: localUrl, title: imageTitle });
   } catch (err) {


### PR DESCRIPTION
## Summary
- expand `chat_pairs` schema with `publish_portfolio` column
- expose flag in API via `/api/upload/list` and new `/api/upload/portfolio`
- store flag when creating image records
- show and toggle portfolio setting in Image page
- list portfolio checkbox in image table

## Testing
- `npm run lint` *(Aurora)*

------
https://chatgpt.com/codex/tasks/task_b_684583db36408323a6964bc9c75f35d4