### PR TITLE
Randomize portfolio display

### DIFF
--- a/Aurora/public/portfolio.html
+++ b/Aurora/public/portfolio.html
@@ -21,7 +21,7 @@
       overflow:hidden;
     }
     .grid-item img {
-      max-width:400px;
+      max-width:320px;
       width:100%;
       border:1px solid #444;
       transition:transform 0.2s;
@@ -43,7 +43,10 @@
         const data = await resp.json();
         const grid = document.getElementById('grid');
         grid.innerHTML = '';
-        data.filter(f => f.portfolio).forEach(f => {
+        data
+          .filter(f => f.portfolio)
+          .sort(() => Math.random() - 0.5)
+          .forEach(f => {
           const wrap = document.createElement('div');
           wrap.className = 'grid-item';
           const link = document.createElement('a');


### PR DESCRIPTION
## Summary
- randomize display order of portfolio images
- reduce display max size from 400px to 320px

## Testing
- `npm run lint` in Aurora

------
https://chatgpt.com/codex/tasks/task_b_684589cec2d88323bebb17f15648a30c