### PR TITLE
Add infinite scroll to portfolio images

### DIFF
--- a/Aurora/public/portfolio.html
+++ b/Aurora/public/portfolio.html
@@ -43,22 +43,40 @@
         const data = await resp.json();
         const grid = document.getElementById('grid');
         grid.innerHTML = '';
-        data
+
+        const allImages = data
           .filter(f => f.portfolio)
-          .sort(() => Math.random() - 0.5)
-          .forEach(f => {
-          const wrap = document.createElement('div');
-          wrap.className = 'grid-item';
-          const link = document.createElement('a');
-          link.href = `/Image.html?file=${encodeURIComponent(f.name)}`;
-          link.target = '_blank';
-          const img = document.createElement('img');
-          img.src = `/uploads/${encodeURIComponent(f.name)}`;
-          img.alt = f.title || f.name;
-          link.appendChild(img);
-          wrap.appendChild(link);
-          grid.appendChild(wrap);
+          .sort(() => Math.random() - 0.5);
+
+        let currentIndex = 0;
+        const batchSize = 12;
+
+        function renderNext(){
+          const slice = allImages.slice(currentIndex, currentIndex + batchSize);
+          slice.forEach(f => {
+            const wrap = document.createElement('div');
+            wrap.className = 'grid-item';
+            const link = document.createElement('a');
+            link.href = `/Image.html?file=${encodeURIComponent(f.name)}`;
+            link.target = '_blank';
+            const img = document.createElement('img');
+            img.src = `/uploads/${encodeURIComponent(f.name)}`;
+            img.alt = f.title || f.name;
+            link.appendChild(img);
+            wrap.appendChild(link);
+            grid.appendChild(wrap);
+          });
+          currentIndex += slice.length;
+        }
+
+        renderNext();
+
+        window.addEventListener('scroll', () => {
+          if(window.innerHeight + window.scrollY >= document.body.offsetHeight - 100){
+            renderNext();
+          }
         });
+
       } catch(err){
         console.error('Failed to load portfolio images', err);
       }


### PR DESCRIPTION
## Summary
- lazy load portfolio images 12 at a time

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68458c09475483238daed4823b8ef883