### PR TITLE
Adjust table thumbnail size

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -406,8 +406,8 @@ body {
 
 /* Thumbnail images in the secure uploader table */
 .table-thumb {
-  max-width: 40px;
-  max-height: 40px;
+  max-width: 52px;
+  max-height: 52px;
   border: 1px solid #555;
 }
 

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -409,8 +409,8 @@ body {
 
 /* Thumbnail images in the secure uploader table */
 .table-thumb {
-  max-width: 40px;
-  max-height: 40px;
+  max-width: 52px;
+  max-height: 52px;
   border: 1px solid #ccc;
 }
 


### PR DESCRIPTION
## Summary
- make the secure uploader thumbnails 30% larger for light and dark styles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6845953d14b48323b731a1ddcf79e15b