### PR TITLE
Fix infinite scroll on portfolio page

### DIFF
--- a/Aurora/public/portfolio.html
+++ b/Aurora/public/portfolio.html
@@ -80,6 +80,10 @@
         const sentinel = document.getElementById('sentinel');
         let loading = false;
         let observer;
+        function sentinelInView(){
+          const rect = sentinel.getBoundingClientRect();
+          return rect.top <= (window.innerHeight + 100);
+        }
 
         function renderNext(){
           if(loading) return;
@@ -107,6 +111,9 @@
                 loading = false;
                 if(currentIndex >= allImages.length){
                   observer.disconnect();
+                } else if(sentinelInView()){
+                  // if user hasn't scrolled and sentinel is still visible
+                  renderNext();
                 }
               }
             };


### PR DESCRIPTION
## Summary
- ensure the portfolio page keeps loading images even when the sentinel is already in view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68459875e4f483238ca80c442959c5c6