### PR TITLE
Update default portfolio option

### DIFF
--- a/Aurora/public/image_generator.html
+++ b/Aurora/public/image_generator.html
@@ -38,12 +38,14 @@
     <option value="openai">OpenAI</option>
     <option value="stable-diffusion">Stable Diffusion</option>
   </select>
+  <label style="margin-left:4px;"><input type="checkbox" id="portfolioCheck" checked/> Portfolio</label>
   <button id="generateBtn">Generate</button>
   <div id="result"></div>
 
 <script>
   const promptInput = document.getElementById('promptInput');
   const providerSelect = document.getElementById('providerSelect');
+  const portfolioCheck = document.getElementById('portfolioCheck');
   const generateBtn = document.getElementById('generateBtn');
   const resultDiv = document.getElementById('result');
 
@@ -52,7 +54,7 @@
     if(!prompt) return;
     resultDiv.textContent = 'Generating...';
     try {
-      const payload = { prompt, provider: providerSelect.value };
+      const payload = { prompt, provider: providerSelect.value, portfolio: portfolioCheck.checked ? 1 : 0 };
       console.debug('Sending /api/image/generate', payload);
       const resp = await fetch('/api/image/generate', {
         method: 'POST',

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -5019,7 +5019,7 @@ registerActionHook("generateImage", async ({response}) => {
     isImageGenerating = true;
     if(chatSendBtnEl) chatSendBtnEl.disabled = true;
     showImageGenerationIndicator();
-    const payload = { prompt, tabId: currentTabId, provider: imageGenService, sessionId };
+    const payload = { prompt, tabId: currentTabId, provider: imageGenService, sessionId, portfolio: 1 };
     console.log('[Hook generateImage] sending request to /api/image/generate', payload);
     let r;
     try {
@@ -5092,7 +5092,7 @@ registerActionHook("embedMockImages", async ({response}) => {
       const r = await fetch('/api/image/generate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: alt, tabId: currentTabId, provider: imageGenService, sessionId })
+        body: JSON.stringify({ prompt: alt, tabId: currentTabId, provider: imageGenService, sessionId, portfolio: 1 })
       });
       const data = await r.json();
       if(r.ok && data.url){

--- a/Aurora/public/nexum.html
+++ b/Aurora/public/nexum.html
@@ -879,7 +879,7 @@
       document.getElementById('chat').appendChild(aiEl);
       document.getElementById('chat').scrollTop=document.getElementById('chat').scrollHeight;
       try{
-        const payload={prompt:text, tabId:currentTabId, sessionId};
+        const payload={prompt:text, tabId:currentTabId, sessionId, portfolio:1};
         console.debug('Sending /api/image/generate', payload);
         const resp=await fetch('/api/image/generate',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
         console.debug('/api/image/generate status', resp.status);

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1863,7 +1863,8 @@ app.get("/api/upload/list", (req, res) => {
       const uuid = db.getImageUuidForUrl(`/uploads/${name}`);
       const source = db.isGeneratedImage(`/uploads/${name}`) ? 'Generated' : 'Uploaded';
       const status = db.getImageStatusForUrl(`/uploads/${name}`) || (source === 'Generated' ? 'Generated' : 'Uploaded');
-      files.push({ id, uuid, name, size, mtime, title, source, status });
+      const portfolio = db.getImagePortfolioForUrl(`/uploads/${name}`);
+      files.push({ id, uuid, name, size, mtime, title, source, status, portfolio });
     }
     res.json(files);
   } catch (err) {
@@ -2315,11 +2316,11 @@ app.get("/api/upscale/result", (req, res) => {
 // Generate an image using OpenAI's image API.
 app.post("/api/image/generate", async (req, res) => {
   try {
-    const { prompt, n, size, model, provider, tabId, sessionId } = req.body || {};
+    const { prompt, n, size, model, provider, tabId, sessionId, portfolio = 1 } = req.body || {};
     const ipAddress = (req.headers["x-forwarded-for"] || req.ip || "").split(",")[0].trim();
     console.debug(
       "[Server Debug] /api/image/generate =>",
-      JSON.stringify({ prompt, n, size, model, provider, tabId, sessionId })
+      JSON.stringify({ prompt, n, size, model, provider, tabId, sessionId, portfolio })
     );
     const account = sessionId ? db.getAccountBySession(sessionId) : null;
     if (!prompt) {
@@ -2393,7 +2394,7 @@ app.post("/api/image/generate", async (req, res) => {
       const tab = parseInt(tabId, 10) || 1;
       const imageTitle = await deriveImageTitle(prompt);
       const modelId = model ? `stable-diffusion/${model}` : 'stable-diffusion';
-      db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress, modelId);
+      db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress, modelId, portfolio ? 1 : 0);
       return res.json({ success: true, url: localUrl, title: imageTitle });
     }
 
@@ -2485,7 +2486,7 @@ app.post("/api/image/generate", async (req, res) => {
     const tab = parseInt(tabId, 10) || 1;
     const imageTitle = await deriveImageTitle(prompt, openaiClient);
     const modelId = `openai/${modelName}`;
-    db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress, modelId);
+    db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress, modelId, portfolio ? 1 : 0);
 
     res.json({ success: true, url: localUrl, title: imageTitle });
   } catch (err) {


### PR DESCRIPTION
## Summary
- store new `portfolio` flag in `chat_pairs`
- send portfolio flag from image generator and chat UI
- allow `/api/image/generate` to accept portfolio option
- include portfolio data in image listings

## Testing
- `npm --prefix Aurora run lint`
- `npm --prefix Aurora test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68459a2dc22883238e85a81acfc4f19d