### PR TITLE
Hide portfolio link for non-admin users

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -44,7 +44,7 @@
         <li><button id="navFileTreeBtn" class="tree-button">File Tree</button></li>
         <li><button id="navAiModelsBtn" class="tree-button" data-url="/ai_models">AI Models</button></li>
         <li><button id="navImageGeneratorBtn" class="tree-button" data-url="/image_generator">Image Generator</button></li>
-        <li><button id="navPortfolioBtn" class="tree-button" data-url="/portfolio.html">Portfolio</button></li>
+        <li><button id="navPortfolioBtn" class="tree-button" data-url="/portfolio.html" hidden>Portfolio</button></li>
         <li><button id="navJobsBtn" class="tree-button" data-url="/jobs.html" data-target="_blank" hidden>Jobs</button></li>
         <li><button id="navPipelineQueueBtn" class="tree-button" data-url="/pipeline_queue.html" data-target="_blank">Queue</button></li>
         <li><button id="navActivityIframeBtn" class="tree-button">Activity IFrame</button></li>
@@ -61,7 +61,7 @@
       <button id="navFileTreeIcon" class="icon-btn" title="File Tree">📁</button>
       <button id="navAiModelsIcon" class="icon-btn" title="AI Models">🤖</button>
       <button id="navImageGeneratorIcon" class="icon-btn" title="Image Generator">🎨</button>
-      <button id="navPortfolioIcon" class="icon-btn" title="Portfolio">🖼️</button>
+      <button id="navPortfolioIcon" class="icon-btn" title="Portfolio" hidden>🖼️</button>
       <button id="navJobsIcon" class="icon-btn" title="Jobs">💼</button>
       <button id="navPipelineQueueIcon" class="icon-btn" title="Queue">📄</button>
       <button id="navActivityIframeIcon" class="icon-btn" title="Activity">🌐</button>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -326,6 +326,7 @@ function updateAccountButton(info){
     if(favBtn){
       favBtn.style.display = info.id === 1 ? "inline-block" : "none";
     }
+    togglePortfolioMenu(info.id === 1);
   } else {
     accountInfo = null;
     btn.textContent = "Sign Up / Login";
@@ -333,6 +334,7 @@ function updateAccountButton(info){
     if(favBtn){
       favBtn.style.display = "none";
     }
+    togglePortfolioMenu(false);
   }
 }
 
@@ -2942,6 +2944,16 @@ function toggleJobsMenu(visible){
   btn.hidden = !visible;
   const li = btn.closest('li');
   if(li) li.style.display = visible ? "" : "none";
+}
+function togglePortfolioMenu(visible){
+  const btn = document.getElementById("navPortfolioBtn");
+  if(btn){
+    btn.hidden = !visible;
+    const li = btn.closest('li');
+    if(li) li.style.display = visible ? "" : "none";
+  }
+  const icon = document.getElementById("navPortfolioIcon");
+  if(icon) icon.style.display = visible ? "" : "none";
 }
 function toggleNewTabProjectField(visible){
   const lbl = document.getElementById("newTabProjectLabel");


### PR DESCRIPTION
## Summary
- hide portfolio buttons by default
- add togglePortfolioMenu helper in main.js
- update account button logic to show portfolio link only for user id 1

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68459e7949888323bd75bcd75250514a