### PR TITLE
Enable portfolio by default for generated images

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2409,7 +2409,7 @@ app.post("/api/image/generate", async (req, res) => {
       const tab = parseInt(tabId, 10) || 1;
       const imageTitle = await deriveImageTitle(prompt);
       const modelId = model ? `stable-diffusion/${model}` : 'stable-diffusion';
-      db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress, modelId, 0);
+      db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress, modelId, 1);
       return res.json({ success: true, url: localUrl, title: imageTitle });
     }
 
@@ -2501,7 +2501,7 @@ app.post("/api/image/generate", async (req, res) => {
     const tab = parseInt(tabId, 10) || 1;
     const imageTitle = await deriveImageTitle(prompt, openaiClient);
     const modelId = `openai/${modelName}`;
-    db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress, modelId, 0);
+    db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress, modelId, 1);
 
     res.json({ success: true, url: localUrl, title: imageTitle });
   } catch (err) {


### PR DESCRIPTION
## Summary
- mark generated images as ready for portfolio by default

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_6845a0bad4908323a364a69df1cb4b4b