### PR TITLE
Improve Printify error message

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2119,8 +2119,13 @@ app.post("/api/printify", async (req, res) => {
     }
 
     if (!fs.existsSync(scriptPath)) {
-      console.debug("[Server Debug] /api/printify => script not found:", scriptPath);
-      return res.status(500).json({ error: "Printify script missing" });
+      console.debug(
+        "[Server Debug] /api/printify => script not found:",
+        scriptPath
+      );
+      return res
+        .status(500)
+        .json({ error: `Printify script missing at ${scriptPath}` });
     }
 
     const job = jobManager.createJob(scriptPath, [filePath], { cwd: scriptCwd, file });


### PR DESCRIPTION
## Summary
- show Printify script path in error response

## Testing
- `npm --prefix Aurora run lint`

------
https://chatgpt.com/codex/tasks/task_b_6845a2f5753083239074d78689f149f9