### PR TITLE
Add Shop link on portfolio page

### DIFF
--- a/Aurora/public/portfolio.html
+++ b/Aurora/public/portfolio.html
@@ -34,6 +34,18 @@
       transform:scale(1.05);
     }
     a { color:#0ff; text-decoration:none; }
+    .shop-btn {
+      display:inline-block;
+      margin-bottom:1rem;
+      padding:6px 12px;
+      background:#333;
+      color:#0ff;
+      border:1px solid #444;
+      border-radius:4px;
+    }
+    .shop-btn:hover {
+      background:#444;
+    }
     #sentinel { height:1px; }
     #loadingIndicator {
       display:none;
@@ -52,6 +64,11 @@
 <body>
   <h1>Confused Art - Powered by Alfe AI</h1>
   <h2>Portfolio</h2>
+  <a
+    href="https://www.ebay.com/sch/11450/i.html?_dkr=1&iconV2Request=true&_blrs=recall_filtering&_ssn=confused_apparel&_oac=1&_sop=10"
+    target="_blank"
+    class="shop-btn"
+  >Shop</a>
   <div id="grid" class="grid"></div>
   <div id="sentinel"></div>
   <div id="loadingIndicator">Loading...</div>


### PR DESCRIPTION
## Summary
- add a styled button linking to Confused Apparel's eBay shop on `portfolio.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6845af7810808323bc42c579f0b0dd75