### PR TITLE
Fix portfolio image links

### DIFF
--- a/Aurora/public/portfolio.html
+++ b/Aurora/public/portfolio.html
@@ -124,7 +124,7 @@
             const wrap = document.createElement('div');
             wrap.className = 'grid-item';
             const link = document.createElement('a');
-            link.href = `/Image.html?file=${encodeURIComponent(f.name)}`;
+            link.href = `/uploads/${encodeURIComponent(f.name)}`;
             link.target = '_blank';
             const img = document.createElement('img');
             img.src = `/uploads/${encodeURIComponent(f.name)}`;


### PR DESCRIPTION
## Summary
- open portfolio images directly in new tab when clicked

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6845b240a0c08323a0437f23097a2d76