### PR TITLE
Add Printify API update step

### DIFF
--- a/Aurora/.env.example
+++ b/Aurora/.env.example
@@ -18,6 +18,9 @@ GITHUB_REPO=yourRepo
 
 # Path to the Printify submission script (optional)
 # PRINTIFY_SCRIPT_PATH=/path/to/run.sh
+# Printify API credentials
+# PRINTIFY_API_TOKEN=yourToken
+# PRINTIFY_SHOP_ID=yourShopId
 
 # Base URL of your self-hosted Stable Diffusion API (optional)
 # STABLE_DIFFUSION_URL=http://localhost:7860

--- a/Aurora/README.md
+++ b/Aurora/README.md
@@ -22,6 +22,8 @@ npm start
 | `OPENAI_MODEL`   | (Optional) Model ID for completions (default: deepseek/deepseek-chat)  |
 | `UPSCALE_SCRIPT_PATH` | (Optional) Path to the image upscale script. Defaults to the included loop.sh |
 | `PRINTIFY_SCRIPT_PATH` | (Optional) Path to the Printify submission script. Defaults to the included run.sh |
+| `PRINTIFY_API_TOKEN` | (Optional) API token for Printify REST API |
+| `PRINTIFY_SHOP_ID` | (Optional) Shop ID for Printify API requests |
 | `STABLE_DIFFUSION_URL` | (Optional) Base URL for a self-hosted Stable Diffusion API |
 | `HTTPS_KEY_PATH` | (Optional) Path to SSL private key for HTTPS |
 | `HTTPS_CERT_PATH` | (Optional) Path to SSL certificate for HTTPS |

--- a/Aurora/public/Image.html
+++ b/Aurora/public/Image.html
@@ -58,9 +58,10 @@
       { name: 'Generated' },
       { name: 'Border Added', disabled: true },
       { name: 'Upscaled', disabled: true },
-      // { name: 'Printify Step' },
-      // { name: 'Ebay Shipping Updated' },
-      // { name: 'Done' }
+      { name: 'Printify Puppet', disabled: true },
+      { name: 'Printify API Updates', disabled: true },
+      { name: 'Ebay Shipping Updated', disabled: true },
+      { name: 'Done', disabled: true }
     ];
 
     const stageList = document.getElementById('stageList');
@@ -81,9 +82,10 @@
       'Upscaled',
       'Background Removed',
       'Border Added',
-      //'Printify Step',
-      //'Ebay Shipping Updated',
-      //'Done'
+      'Printify Step',
+      'Printify API Updates',
+      'Ebay Shipping Updated',
+      'Done'
     ];
 
     async function loadStatus(){
@@ -103,9 +105,13 @@
       try{
         const current = await loadStatus();
         if(statusSelect.value !== current) statusSelect.value = current;
-        if(current === 'Ebay Shipping Updated'){
+        if(current === 'Printify API Updates'){
           if(stageItems[3]) stageItems[3].classList.add('completed');
           if(stageItems[4]) stageItems[4].classList.add('current');
+        } else if(current === 'Ebay Shipping Updated'){
+          if(stageItems[3]) stageItems[3].classList.add('completed');
+          if(stageItems[4]) stageItems[4].classList.add('completed');
+          if(stageItems[5]) stageItems[5].classList.add('current');
         } else if(current === 'Done'){
           if(stageItems[3]) stageItems[3].classList.add('completed');
           if(stageItems[4]) stageItems[4].classList.add('completed');

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3191,6 +3191,7 @@ document.addEventListener("click", async ev => {
     "Background Removed",
     "Border Added",
     "Printify Step",
+    "Printify API Updates",
     "Ebay Shipping Updated",
     "Done"
   ].forEach(v => {


### PR DESCRIPTION
## Summary
- expose Printify API credentials in `.env.example` and docs
- show Printify API stage and status options in the UI
- implement `updatePrintifyProduct` helper and endpoint
- call Printify API update automatically after Printify Puppet step

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6845b0cff4c88323b78ec0757c00f9d5