### PR TITLE
Remove portfolio subheading

### DIFF
--- a/Aurora/public/portfolio.html
+++ b/Aurora/public/portfolio.html
@@ -71,7 +71,6 @@
 </head>
 <body>
   <h1>Confused Art - Powered by <a href="https://alfe.sh">Alfe AI</a></h1>
-  <h2>Portfolio</h2>
   <a
     href="https://www.ebay.com/sch/11450/i.html?_dkr=1&iconV2Request=true&_blrs=recall_filtering&_ssn=confused_apparel&_oac=1&_sop=10"
     target="_blank"


### PR DESCRIPTION
## Summary
- remove the `<h2>Portfolio</h2>` subheading from the portfolio page

## Testing
- `npm run lint` in Aurora

------
https://chatgpt.com/codex/tasks/task_b_6845bed6593c8323ae9ec8cc1a874072