### PR TITLE
Add LochnerLander landing page

### DIFF
--- a/LochnerLander/README.md
+++ b/LochnerLander/README.md
@@ -1,0 +1,10 @@
+# Lochner Tech Landing Page
+
+A very simple static page for **lochner.tech**. It presents three panels linking
+to related sites:
+
+- **Alfe AI** - [https://alfe.sh](https://alfe.sh)
+- **Confused Art** - [https://confused.art](https://confused.art)
+- **More Projects** - [https://njlochner.com](https://njlochner.com)
+
+Open `index.html` in a browser or serve it from any static web server.

--- a/LochnerLander/index.html
+++ b/LochnerLander/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lochner Tech</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: Arial, sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      background: #f5f5f5;
+    }
+    .container {
+      display: flex;
+      gap: 1rem;
+    }
+    .panel {
+      background: white;
+      padding: 1.5rem;
+      text-align: center;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      width: 150px;
+    }
+    .panel a {
+      display: block;
+      font-size: 1.2rem;
+      font-weight: bold;
+      margin-bottom: 0.5rem;
+      text-decoration: none;
+      color: #333;
+    }
+    .panel p {
+      margin: 0;
+      font-size: 0.9rem;
+      color: #555;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="panel">
+      <a href="https://alfe.sh">Alfe AI</a>
+      <p>Software and image design platform</p>
+    </div>
+    <div class="panel">
+      <a href="https://confused.art">Confused Art</a>
+      <p>Explore AI generated art</p>
+    </div>
+    <div class="panel">
+      <a href="https://njlochner.com">More Projects</a>
+      <p>Personal site and portfolio</p>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `LochnerLander` subdirectory with README
- create simple static landing page for lochner.tech with links to Alfe AI, Confused Art, and Nick Lochner's site

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6845c72903908323a288f926cf41c181