### PR TITLE
Fix Alfe AI link target

### DIFF
--- a/Aurora/public/portfolio.html
+++ b/Aurora/public/portfolio.html
@@ -71,7 +71,7 @@
   </style>
 </head>
 <body>
-  <h1>Confused Art - Powered by <a href="https://alfe.sh">Alfe AI</a></h1>
+  <h1>Confused Art - Powered by <a href="https://alfe.sh" target="_blank">Alfe AI</a></h1>
   <a
     href="https://www.ebay.com/sch/11450/i.html?_dkr=1&iconV2Request=true&_blrs=recall_filtering&_ssn=confused_apparel&_oac=1&_sop=10"
     target="_blank"


### PR DESCRIPTION
## Summary
- make the Alfe AI link open in a new tab on the Confused Art page

## Testing
- `npm run lint` in `Aurora`
- `npm test` in `AutoPR`
- `npm test` in `VMRunner` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6845c8c912a08323b6252a5954c39c74