### PR TITLE
Add finance orders table

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1105,6 +1105,39 @@ app.get("/api/activity", (req, res) => {
   }
 });
 
+app.get("/api/orders", (req, res) => {
+  console.debug("[Server Debug] GET /api/orders called.");
+  try {
+    const orders = db.listOrders();
+    res.json(orders);
+  } catch (err) {
+    console.error("[TaskQueue] GET /api/orders failed:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+app.post("/api/orders", (req, res) => {
+  console.debug("[Server Debug] POST /api/orders =>", req.body);
+  try {
+    const { orderId, source, amount, fees, shipping, metadata } = req.body || {};
+    if (!orderId) {
+      return res.status(400).json({ error: "orderId required" });
+    }
+    const id = db.createOrder(
+      orderId,
+      source || '',
+      parseFloat(amount) || 0,
+      parseFloat(fees) || 0,
+      parseFloat(shipping) || 0,
+      metadata || {}
+    );
+    res.json({ success: true, id });
+  } catch (err) {
+    console.error("[TaskQueue] POST /api/orders failed:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 /*
   We combine both OpenAI and OpenRouter models (if available),
   prefixing IDs with "openai/" or "openrouter/",


### PR DESCRIPTION
## Summary
- create `orders` table in TaskDB schema
- support order creation and listing through new DB helpers
- expose `/api/orders` routes for reading and writing orders

## Testing
- `npm run lint` *(no linter configured)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6845d54ddc30832398f9058a8d903ed2