### PR TITLE
Fix printify update product middleware

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -164,6 +164,8 @@ if (db.getSetting("show_session_id") === undefined) {
 }
 
 const app = express();
+// Body parser must come before any routes that access req.body
+app.use(bodyParser.json());
 const jobManager = new JobManager();
 
 /**
@@ -486,8 +488,6 @@ app.options("*", cors({
 }), (req, res) => {
   res.sendStatus(200);
 });
-
-app.use(bodyParser.json());
 
 // Restrict access by IP when WHITELIST_IP is set
 const whitelistIp = process.env.whitelist_ip || process.env.WHITELIST_IP;


### PR DESCRIPTION
## Summary
- parse request body before validating `/api/printify/updateProduct`
- remove duplicate body-parser middleware

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6845e223d3548323b48a85e7edea5c0e