### PR TITLE
Add metadata toggle in Aurora settings

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -723,6 +723,9 @@
     <div id="autoScrollSection" style="margin-top:10px;">
       <label><input type="checkbox" id="accountAutoScrollCheck"/> Keep chat pinned to bottom</label>
     </div>
+    <div id="chatMetadataSection" style="margin-top:10px;">
+      <label><input type="checkbox" id="accountShowMetadataCheck"/> Show chat pair metadata</label>
+    </div>
     <div class="modal-buttons">
       <button id="settingsCloseBtn">Close</button>
     </div>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -300,6 +300,10 @@ function openSettingsModal(e){
   if(autoScrollCheck){
     autoScrollCheck.checked = chatAutoScroll;
   }
+  const metaCheck = document.getElementById('accountShowMetadataCheck');
+  if(metaCheck){
+    metaCheck.checked = !chatHideMetadata;
+  }
   showModal(document.getElementById("settingsModal"));
 }
 
@@ -2037,6 +2041,14 @@ if(accountAutoScrollCheck){
       setTimeout(scrollChatToBottom, 0);
     }
     await setSetting('chat_auto_scroll', chatAutoScroll);
+  });
+}
+
+const accountShowMetadataCheck = document.getElementById('accountShowMetadataCheck');
+if(accountShowMetadataCheck){
+  accountShowMetadataCheck.addEventListener('change', async () => {
+    chatHideMetadata = !accountShowMetadataCheck.checked;
+    await setSetting('chat_hide_metadata', chatHideMetadata);
   });
 }
 


### PR DESCRIPTION
## Summary
- add **Show chat pair metadata** checkbox in `settingsModal`
- sync new checkbox with saved setting
- store toggle with `chat_hide_metadata` when changed

## Testing
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_b_6845e1c8f36083239b03d0567ef50a4a