### PR TITLE
Fix Printify API update with variant data

### DIFF
--- a/Aurora/public/Image.html
+++ b/Aurora/public/Image.html
@@ -412,12 +412,27 @@
       printifyApiBtn.addEventListener('click', async () => {
         const productId = prompt('Enter Printify Product ID:');
         if(!productId) return;
+        const priceStr = prompt('Enter new price for all variants:', '19.44');
+        if(priceStr === null) return;
+        const qtyStr = prompt('Enter inventory quantity for all variants:', '20');
+        if(qtyStr === null) return;
+        const price = parseFloat(priceStr) || 0;
+        const quantity = parseInt(qtyStr, 10) || 0;
         terminalEl.textContent = '';
         try {
+          const vRes = await fetch(`/api/printify/product/${encodeURIComponent(productId)}`);
+          const vData = await vRes.json();
+          if(!vRes.ok){
+            terminalEl.textContent = vData.error || 'Failed to load product.';
+            return;
+          }
+          const variants = Array.isArray(vData.variants)
+            ? vData.variants.map(v => ({ id: v.id, price, inventory_quantity: quantity }))
+            : [];
           const res = await fetch('/api/printify/updateProduct', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ productId, file: upscaledPath || upscaledFile || file })
+            body: JSON.stringify({ productId, variants, file: upscaledPath || upscaledFile || file })
           });
           const data = await res.json().catch(() => ({}));
           if(res.ok && data.updated){

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -324,6 +324,20 @@ app.use('/api/printify/updateProduct', (req, res, next) => {
   next();
 });
 
+app.get('/api/printify/product/:id', async (req, res) => {
+  const productId = req.params.id;
+  try {
+    const response = await axios.get(
+      `https://api.printify.com/v1/shops/${shopId}/products/${productId}`,
+      { headers: { Authorization: `Bearer ${printifyToken}` } }
+    );
+    res.json(response.data);
+  } catch (err) {
+    console.error('Error in /api/printify/product:', err);
+    res.status(500).json({ error: 'Failed to load product' });
+  }
+});
+
 
 async function deriveImageTitle(prompt, client = null) {
   if (!prompt) return '';


### PR DESCRIPTION
## Summary
- fetch Printify product variants via new API endpoint
- prompt user for price and quantity then send variants with update request

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6845e6a8b4b48323a2e2bb75646f717e