### PR TITLE
Define Printify shopId constant

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -168,6 +168,10 @@ const app = express();
 app.use(bodyParser.json());
 const jobManager = new JobManager();
 
+// Printify configuration
+const printifyToken = process.env.PRINTIFY_TOKEN || "";
+const shopId = 18663958; // Default shop ID used when none is provided
+
 /**
  * Returns a configured OpenAI client, depending on "ai_service" setting.
  * Added checks to help diagnose missing or invalid API keys.


### PR DESCRIPTION
## Summary
- fix undefined `shopId` error by defining Printify configuration constants

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6845e9f6e60c8323be956d9be141e5e3