### PR TITLE
Add Confused Art about page

### DIFF
--- a/Aurora/public/about_confused.html
+++ b/Aurora/public/about_confused.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>About Confused Art</title>
+  <link rel="stylesheet" href="/styles.css">
+  <style>
+    a, a:visited { color: cyan; }
+  </style>
+</head>
+<body style="padding:1rem;">
+  <h2>About Confused Art</h2>
+  <p>Confused Art showcases AI-generated artwork created with the help of Alfe AI.</p>
+  <p>This project is maintained by Nicholas Lochner.</p>
+  <hr>
+  <p>Copyright (c) 2024-2025 Nicholas Lochner</p>
+</body>
+</html>

--- a/Aurora/public/portfolio.html
+++ b/Aurora/public/portfolio.html
@@ -82,6 +82,7 @@
   </style>
 </head>
 <body>
+  <a href="/about_confused.html" style="position:absolute; top:8px; left:8px; font-size:0.8rem; color:#0ff;">About</a>
   <h1>Confused Art - Powered by <a href="https://alfe.sh" target="_blank">Alfe AI</a></h1>
   <a
     href="https://www.ebay.com/sch/11450/i.html?_dkr=1&iconV2Request=true&_blrs=recall_filtering&_ssn=confused_apparel&_oac=1&_sop=10"


### PR DESCRIPTION
## Summary
- create About page for Confused Art with copyright notice
- link to the About page from portfolio

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6845eb0e06388323b712b8b8a5275caa