### PR TITLE
Fix Printify env variable handling

### DIFF
--- a/Aurora/.env.example
+++ b/Aurora/.env.example
@@ -20,6 +20,7 @@ GITHUB_REPO=yourRepo
 # PRINTIFY_SCRIPT_PATH=/path/to/run.sh
 # Printify API credentials
 # PRINTIFY_API_TOKEN=yourToken
+# Alternatively you can use the older PRINTIFY_TOKEN variable
 # PRINTIFY_SHOP_ID=yourShopId
 
 # Base URL of your self-hosted Stable Diffusion API (optional)

--- a/Aurora/README.md
+++ b/Aurora/README.md
@@ -22,7 +22,7 @@ npm start
 | `OPENAI_MODEL`   | (Optional) Model ID for completions (default: deepseek/deepseek-chat)  |
 | `UPSCALE_SCRIPT_PATH` | (Optional) Path to the image upscale script. Defaults to the included loop.sh |
 | `PRINTIFY_SCRIPT_PATH` | (Optional) Path to the Printify submission script. Defaults to the included run.sh |
-| `PRINTIFY_API_TOKEN` | (Optional) API token for Printify REST API |
+| `PRINTIFY_API_TOKEN` | (Optional) API token for Printify REST API (legacy `PRINTIFY_TOKEN` also supported) |
 | `PRINTIFY_SHOP_ID` | (Optional) Shop ID for Printify API requests |
 | `STABLE_DIFFUSION_URL` | (Optional) Base URL for a self-hosted Stable Diffusion API |
 | `HTTPS_KEY_PATH` | (Optional) Path to SSL private key for HTTPS |

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -169,8 +169,11 @@ app.use(bodyParser.json());
 const jobManager = new JobManager();
 
 // Printify configuration
-const printifyToken = process.env.PRINTIFY_TOKEN || "";
-const shopId = 18663958; // Default shop ID used when none is provided
+// Support both legacy PRINTIFY_TOKEN and the newer PRINTIFY_API_TOKEN env vars
+const printifyToken =
+  process.env.PRINTIFY_API_TOKEN || process.env.PRINTIFY_TOKEN || "";
+// Allow overriding the default shop ID via PRINTIFY_SHOP_ID
+const shopId = process.env.PRINTIFY_SHOP_ID || 18663958;
 
 /**
  * Returns a configured OpenAI client, depending on "ai_service" setting.


### PR DESCRIPTION
## Summary
- read Printify API token from `PRINTIFY_API_TOKEN` with fallback to `PRINTIFY_TOKEN`
- allow overriding shop ID via `PRINTIFY_SHOP_ID`
- update docs and env example for the new variables

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6845ecb6005083238a6c13b85b0e2480