### PR TITLE
Remove personal reference from Confused Art page

### DIFF
--- a/Aurora/public/about_confused.html
+++ b/Aurora/public/about_confused.html
@@ -11,8 +11,7 @@
 <body style="padding:1rem;">
   <h2>About Confused Art</h2>
   <p>Confused Art showcases AI-generated artwork created with the help of Alfe AI.</p>
-  <p>This project is maintained by Nicholas Lochner.</p>
   <hr>
-  <p>Copyright (c) 2024-2025 Nicholas Lochner</p>
+  <p>Copyright (c) 2024-2025</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update `about_confused.html` to omit personal attribution

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6845fbaecdac8323b793bed9c8c3e86e