### PR TITLE
Add Printify shortcut in collapsed sidebar

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -198,6 +198,7 @@
     <button id="thinIconChats" class="thin-icon" title="Chats">💬</button>
     <button id="thinIconImages" class="thin-icon" title="Images">🖼️</button>
     <button id="thinIconArchived" class="thin-icon" title="Archived">&#128452;</button>
+    <button id="thinIconPrintify" class="thin-icon" title="Printify Products">🛍️</button>
   </div>
 
   <main class="chat-panel">

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3630,6 +3630,7 @@ const btnNexumTabsIcon = document.getElementById("navNexumTabsIcon");
 const thinChatIcon = document.getElementById("thinIconChats");
 const thinImagesIcon = document.getElementById("thinIconImages");
 const thinArchiveIcon = document.getElementById("thinIconArchived");
+const thinPrintifyIcon = document.getElementById("thinIconPrintify");
 
 btnTasks.addEventListener("click", showTasksPanel);
 btnUploader.addEventListener("click", showUploaderPanel);
@@ -3695,6 +3696,11 @@ thinArchiveIcon?.addEventListener("click", ev => {
   ev.stopPropagation();
   openPanelWithSidebar(showArchiveTabsPanel);
 });
+thinPrintifyIcon?.addEventListener("click", ev => {
+  ev.preventDefault();
+  ev.stopPropagation();
+  openPanelWithSidebar(showPrintifyProductsPanel);
+});
 // Ensure taps on mobile trigger the same actions
 thinChatIcon?.addEventListener("touchstart", ev => {
   ev.preventDefault();
@@ -3710,6 +3716,11 @@ thinArchiveIcon?.addEventListener("touchstart", ev => {
   ev.preventDefault();
   ev.stopPropagation();
   openPanelWithSidebar(showArchiveTabsPanel);
+});
+thinPrintifyIcon?.addEventListener("touchstart", ev => {
+  ev.preventDefault();
+  ev.stopPropagation();
+  openPanelWithSidebar(showPrintifyProductsPanel);
 });
 
 (async function init(){


### PR DESCRIPTION
## Summary
- expose Printify Products from the thin sidebar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68460065a6988323b4658d3e73a640c9