### PR TITLE
Fix Printify price update

### DIFF
--- a/Aurora/public/Image.html
+++ b/Aurora/public/Image.html
@@ -420,7 +420,7 @@
         if(priceStr === null) return;
         const qtyStr = prompt('Enter inventory quantity for all variants:', '20');
         if(qtyStr === null) return;
-        const price = parseFloat(priceStr) || 0;
+        const price = Math.round((parseFloat(priceStr) || 0) * 100);
         const quantity = parseInt(qtyStr, 10) || 0;
         terminalEl.textContent = '';
         try {

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -281,13 +281,22 @@ async function updatePrintifyProduct(productId, variants) {
     }
 
     // Verify variants structure
-    if (!Array.isArray(variants) || !variants.every(v => v.id && v.price)) {
+    if (
+      !Array.isArray(variants) ||
+      !variants.every(v => v.id && v.price !== undefined)
+    ) {
       throw new Error('Invalid variants format');
     }
 
+    const formattedVariants = variants.map(v => ({
+      id: v.id,
+      price: Math.round(Number(v.price)),
+      inventory_quantity: v.inventory_quantity
+    }));
+
     const response = await axios.put(
       `https://api.printify.com/v1/shops/${shopId}/products/${productId}/variants.json`,
-      { variants },
+      { variants: formattedVariants },
       {
         headers: {
           Authorization: `Bearer ${printifyToken}`,


### PR DESCRIPTION
## Summary
- ensure front-end converts prices to integer cents
- sanitize variants in `updatePrintifyProduct` before calling Printify API

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6846160b34448323b3f5e9e1488ceb76