### PR TITLE
Implement Printify URL extraction

### DIFF
--- a/Aurora/src/jobManager.js
+++ b/Aurora/src/jobManager.js
@@ -14,6 +14,7 @@ export default class JobManager {
       cwd,
       file,
       resultPath: null,
+      productUrl: null,
       status: "running",
       startTime: Date.now(),
       log: "",
@@ -70,6 +71,7 @@ export default class JobManager {
       status: j.status,
       startTime: j.startTime,
       resultPath: j.resultPath,
+      productUrl: j.productUrl,
     }));
   }
 

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { extractProductUrl } from './printifyUtils.js';
 
 export default class PrintifyJobQueue {
   constructor(jobManager, options = {}) {
@@ -52,6 +53,7 @@ export default class PrintifyJobQueue {
       status: 'queued',
       jobId: null,
       resultPath: null,
+      productUrl: null,
       dbId,
       variant
     };
@@ -69,6 +71,7 @@ export default class PrintifyJobQueue {
       status: j.status,
       jobId: j.jobId,
       resultPath: j.resultPath || null,
+      productUrl: j.productUrl || null,
       dbId: j.dbId || null,
       variant: j.variant || null
     }));
@@ -193,6 +196,16 @@ export default class PrintifyJobQueue {
             const originalUrl = `/uploads/${job.file}`;
             this.db.setUpscaledImage(originalUrl, job.resultPath);
             this.db.setImageStatus(originalUrl, 'Upscaled');
+          }
+        }
+      } else if (job.type === 'printify') {
+        const url = extractProductUrl(jmJob.log);
+        if (url) {
+          job.productUrl = url;
+          jmJob.productUrl = url;
+          if (this.db) {
+            const originalUrl = `/uploads/${job.file}`;
+            this.db.setImageStatus(originalUrl, `Printify URL: ${url}`);
           }
         }
       }

--- a/Aurora/src/printifyUtils.js
+++ b/Aurora/src/printifyUtils.js
@@ -1,0 +1,6 @@
+export function extractProductUrl(log = '') {
+  if (!log) return null;
+  const matches = [...log.matchAll(/Product URL:\s*(https?:\/\/\S+)/i)];
+  const m = matches[matches.length - 1];
+  return m ? m[1].trim() : null;
+}


### PR DESCRIPTION
## Summary
- add `extractProductUrl` helper
- capture Printify product URLs when jobs finish
- expose `productUrl` via job listings

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6846246e5f5c8323ad5c31574cf996c7