### PR TITLE
Fix Printify job result parsing

### DIFF
--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -195,6 +195,12 @@ export default class PrintifyJobQueue {
             this.db.setImageStatus(originalUrl, 'Upscaled');
           }
         }
+      } else if (job.type === 'printify') {
+        const matches = [...jmJob.log.matchAll(/Product URL:\s*(https?:\S+)/i)];
+        const m = matches[matches.length - 1];
+        if (m) {
+          job.resultPath = m[1].trim();
+        }
       }
       this.current = null;
       this._saveJobs();


### PR DESCRIPTION
## Summary
- parse product URL from Printify job logs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6846297d34f883239d66f207c58da2b3