### PR TITLE
Fix shop link position on Confused Art portfolio page

### DIFF
--- a/Aurora/public/portfolio.html
+++ b/Aurora/public/portfolio.html
@@ -82,12 +82,13 @@
   </style>
 </head>
 <body>
-  <a href="/about_confused.html" style="position:absolute; top:8px; left:8px; font-size:0.8rem; color:#0ff;">About</a>
+  <a href="/about_confused.html" style="position:fixed; top:8px; left:72px; font-size:0.8rem; color:#0ff; z-index:1000;">About</a>
   <h1>Confused Art - Powered by <a href="https://alfe.sh" target="_blank">Alfe AI</a></h1>
   <a
     href="https://www.ebay.com/sch/11450/i.html?_dkr=1&iconV2Request=true&_blrs=recall_filtering&_ssn=confused_apparel&_oac=1&_sop=10"
     target="_blank"
     class="shop-btn"
+    style="position:fixed; top:8px; left:8px; z-index:1000;"
   >Shop</a>
   <div id="imageCounter">0 / 0</div>
   <div id="grid" class="grid"></div>


### PR DESCRIPTION
## Summary
- ensure the shop link stays fixed at the top-left
- move the about link slightly right so both links are visible

## Testing
- `npm test` in `AutoPR` (prints `No tests specified`)

------
https://chatgpt.com/codex/tasks/task_b_68475bbc09688323847ad42bfff4d8f2