### PR TITLE
Update jobs terminal height

### DIFF
--- a/Aurora/public/jobs.html
+++ b/Aurora/public/jobs.html
@@ -9,7 +9,7 @@
   <h2>Jobs</h2>
   <button id="stopBtn" style="display:none;margin-bottom:0.5rem;">Stop Job</button>
   <ul id="jobsList"></ul>
-  <pre id="terminal" style="background:#000;color:#0f0;padding:0.5rem;margin-top:0.5rem;height:200px;overflow:auto;font-family:monospace;resize:vertical;"></pre>
+  <pre id="terminal" style="background:#000;color:#0f0;padding:0.5rem;margin-top:0.5rem;height:80vh;overflow:auto;font-family:monospace;resize:vertical;"></pre>
 <script>
 async function loadJobs() {
   const res = await fetch('/api/jobs');


### PR DESCRIPTION
## Summary
- make the job log terminal occupy most of the page by default

## Testing
- `git show --stat --oneline`

------
https://chatgpt.com/codex/tasks/task_b_684763ebf7d083238830fd4908c32efe