### PR TITLE
Fix chat scroll after image load

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4202,6 +4202,7 @@ async function loadChatHistory(tabId = 1, reset=false) {
           if(p.image_title) img.title = p.image_title;
           img.style.maxWidth = "min(100%, 400px)";
           img.style.height = "auto";
+          img.addEventListener('load', () => setTimeout(scrollChatToBottom, 1000));
           botDiv.appendChild(img);
         }
 


### PR DESCRIPTION
## Summary
- ensure chat scrolls to bottom when image pairs load

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684777b521a48323a1105d2475b5a740