### PR TITLE
Fix Nexum splash redirect

### DIFF
--- a/Aurora/public/nexum.html
+++ b/Aurora/public/nexum.html
@@ -214,6 +214,7 @@
       </div>
     </div>
   </div>
+  <script src="/session.js"></script>
   <script>
     const splashPhrases = [
       "AI Software Engineer",


### PR DESCRIPTION
## Summary
- include `session.js` on `nexum.html` so sessionId is available

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6847a2e5b85483239f9b936f5fe0e795