### PR TITLE
Add cookie banner to Aurora

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -758,8 +758,28 @@
   <span class="loading-spinner"></span>
 </div>
 <div id="toast" class="toast"></div>
+<div id="cookieBanner">
+  This site uses cookies to store your preferences.
+  <button id="cookieMoreInfoBtn">More Info</button>
+  <button id="cookieAcceptBtn">Accept</button>
+</div>
 <script src="/session.js"></script>
 <script src="/main.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const banner = document.getElementById('cookieBanner');
+    if(banner){
+      if(!localStorage.getItem('cookieAccepted')) banner.style.display = 'block';
+      document.getElementById('cookieAcceptBtn').addEventListener('click', () => {
+        localStorage.setItem('cookieAccepted', 'yes');
+        banner.style.display = 'none';
+      });
+      document.getElementById('cookieMoreInfoBtn').addEventListener('click', () => {
+        window.open('cookies.html', '_blank');
+      });
+    }
+  });
+</script>
 </body>
 </html>
 

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1136,4 +1136,28 @@ button:disabled {
   display: none !important;
 }
 
+/* Cookie consent banner */
+#cookieBanner {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--bg-alt);
+  color: var(--text-color);
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--border);
+  display: none;
+  z-index: 1000;
+  text-align: center;
+}
+
+#cookieBanner button {
+  margin-left: 1rem;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+}
+
 

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -1139,4 +1139,28 @@ button:disabled {
   display: none !important;
 }
 
+/* Cookie consent banner */
+#cookieBanner {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--bg-alt);
+  color: var(--text-color);
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--border);
+  display: none;
+  z-index: 1000;
+  text-align: center;
+}
+
+#cookieBanner button {
+  margin-left: 1rem;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+}
+
 


### PR DESCRIPTION
## Summary
- include cookie consent banner on Aurora
- style the banner for both dark and light themes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6847a0f4947c832389c1c51da41acdd0