### PR TITLE
Disable code and project buttons on Nexum splash

### DIFF
--- a/Aurora/public/nexum.html
+++ b/Aurora/public/nexum.html
@@ -213,7 +213,7 @@
             <div class="icon">💬</div>
             <div>Chat</div>
           </button>
-          <button data-type="code" class="start-type-btn">
+          <button data-type="code" class="start-type-btn disabled" disabled>
             <div class="icon">💻</div>
             <div>Code</div>
           </button>
@@ -221,7 +221,7 @@
             <div class="icon">🎨</div>
             <div>Design</div>
           </button>
-          <button data-type="task" class="start-type-btn">
+          <button data-type="task" class="start-type-btn disabled" disabled>
             <div class="icon">📋</div>
             <div>Project</div>
           </button>


### PR DESCRIPTION
## Summary
- disable unused `code` and `project` buttons on the Nexum splash screen
- keep new tab dialog buttons unaffected

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_6847a90ce5fc83239f807b036123f9f7