### PR TITLE
Expand Nexum splash content

### DIFF
--- a/Aurora/public/nexum.html
+++ b/Aurora/public/nexum.html
@@ -265,8 +265,32 @@
       "AI Monet",
       "AI CTO",
       "AI Solutions Architect",
+      "AI Logo Designer",
+      "AI Product Designer",
+      "AI Photographer",
+      "AI Digital Artist",
+      "AI Concept Artist",
+      "AI Graphic Designer",
+      "AI Animator",
+      "AI Character Designer",
+      "AI Landscape Painter",
+      "AI Michelangelo",
+      "AI Da Vinci",
+      "AI Salvador Dali",
+      "AI Rembrandt",
+      "AI Frida Kahlo",
+      "AI Warhol",
+      "AI Hokusai",
+      "AI Banksy",
+      "AI Escher",
+      "AI Drone Photographer",
+      "AI Fashion Designer",
+      "AI Industrial Designer",
+      "AI UX Researcher",
+      "AI Motion Designer",
       "Beta Rollout"
     ];
+    splashPhrases.sort(() => Math.random() - 0.5);
     let splashIdx = 0;
     let splashTimer = null;
     // default feature flags / state vars


### PR DESCRIPTION
## Summary
- add many more artist and design themed phrases to Nexum splash page
- shuffle phrases so they appear in random order

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_6847aa4ce0b48323ab04ff69fa72fb9d