### PR TITLE
Update nexum cookie banner to always show

### DIFF
--- a/Aurora/public/nexum.html
+++ b/Aurora/public/nexum.html
@@ -1162,10 +1162,10 @@
       });
 
       const banner = document.getElementById('cookieBanner');
-      if(banner){
-        if(!localStorage.getItem('cookieAccepted')) banner.style.display = 'block';
+      if (banner) {
+        // Always show banner; hide only for the current session when accepted
+        banner.style.display = 'block';
         document.getElementById('cookieAcceptBtn').addEventListener('click', () => {
-          localStorage.setItem('cookieAccepted', 'yes');
           banner.style.display = 'none';
         });
         document.getElementById('cookieMoreInfoBtn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- show nexum cookie banner on every visit
- remove persistent localStorage check

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6847ac4ecffc83238cdb922ca721c6c6