### PR TITLE
Fix Printify title fix productId parsing

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2488,7 +2488,13 @@ app.post("/api/printifyTitleFix", async (req, res) => {
     if (!productUrl) {
       return res.status(400).json({ error: "Missing Printify URL" });
     }
-    const productId = productUrl.split("/").pop();
+    const productId = (() => {
+      try {
+        return new URL(productUrl).pathname.split("/").pop();
+      } catch {
+        return productUrl.split("/").pop().split("?")[0];
+      }
+    })();
 
     const scriptPath =
       process.env.PRINTIFY_TITLE_FIX_SCRIPT_PATH ||


### PR DESCRIPTION
## Summary
- handle query parameters when parsing Printify product URL in the title fix endpoint

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_b_6847c08378b883239bab55c9ef95e579