### PR TITLE
Update Printify title fix script

### DIFF
--- a/Aurora/scripts/printifyTitleFix.js
+++ b/Aurora/scripts/printifyTitleFix.js
@@ -25,12 +25,31 @@ async function main() {
     const { data } = await axios.get(url, {
       headers: { Authorization: `Bearer ${token}` }
     });
-    console.log('Title:', data.title || '');
+
+    const currentTitle = data.title || '';
+    console.log('Title:', currentTitle);
+
+    const cleanedTitle = currentTitle.replace(/,?\s*\[\.\.\.\]\s*$/, '').trim();
+    if (cleanedTitle !== currentTitle) {
+      await axios.put(
+        url,
+        { title: cleanedTitle },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json'
+          }
+        }
+      );
+      console.log('Updated Title:', cleanedTitle);
+    } else {
+      console.log('No trailing pattern detected; nothing to update.');
+    }
   } catch (err) {
     const status = err.response?.status;
     const msg = err.response?.data || err.message;
     console.error(
-      `Failed to fetch product ${productId} (status: ${status ?? 'unknown'}):`,
+      `Failed to update product ${productId} (status: ${status ?? 'unknown'}):`,
       msg
     );
     process.exit(1);


### PR DESCRIPTION
## Summary
- remove trailing `, [...]` from product titles
- update the product title on Printify when needed

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6847c2abe4e08323a597045729796da8