### PR TITLE
Add queued chat messages feature

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -276,6 +276,7 @@
       </div>
 
       <div id="waitingCounter"></div>
+      <div id="chatQueueContainer" class="chat-queue-container"></div>
       <div class="chat-input-container">
         <!-- Hidden file input for image uploading -->
         <input type="file" id="imageUploadInput" accept="image/*" style="display:none" multiple />
@@ -409,6 +410,8 @@
     <label><input type="checkbox" id="showSubroutinePanelCheck"/> Show chat subroutines panel</label>
     <br/>
     <label><input type="checkbox" id="enterSubmitCheck" checked/> Enter submits message</label>
+    <br/>
+    <label><input type="checkbox" id="chatQueueCheck"/> Queue messages while waiting</label>
     <br/>
     <label><input type="checkbox" id="showNavMenuCheck" checked/> Show navigation menu</label>
     <br/>

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1136,4 +1136,26 @@ button:disabled {
   display: none !important;
 }
 
+/* Queued chat bubbles */
+.chat-queue-container {
+  position: absolute;
+  bottom: 60px;
+  right: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  pointer-events: none;
+  z-index: 1000;
+}
+
+.chat-queue-bubble {
+  background: rgba(100, 100, 100, 0.5);
+  color: #ddd;
+  border-radius: 12px;
+  padding: 6px 10px;
+  max-width: 250px;
+  font-size: 0.9rem;
+  opacity: 0.7;
+}
+
 


### PR DESCRIPTION
## Summary
- allow queuing chat messages in Aurora
- show queued messages as semi-transparent bubbles
- expose queue option in Chat Settings

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6847e71e27f8832395575176ab06d9c2