### PR TITLE
Add logo to Nexum page

### DIFF
--- a/Aurora/public/nexum.html
+++ b/Aurora/public/nexum.html
@@ -51,6 +51,8 @@
       <div id="archiveList" style="position:relative; top: 40px; display:none;"></div>
       <button id="newTabBtn" style="position:relative; top: 40px;">New Tab</button>
     </aside>
+    <img id="collapsedSidebarLogo" src="/alfe_favicon_64x64.ico" title="Expand sidebar" alt="Alfe AI logo" style="height:32px; position:absolute; top:8px; left:8px; cursor:pointer; display:none; z-index:1000;"/>
+    <span id="expandSidebarArrow" title="Expand sidebar" style="position:absolute; top:20px; left:48px; font-size:1.4rem; cursor:pointer; display:none; z-index:1000;">&raquo;</span>
     <main>
       <div id="viewTabsBar" style="display:flex;gap:0.5rem;margin-bottom:0.5rem;align-items:center;">
         <button id="viewTabChat" class="view-tab active" style="position:relative; left: 40px;">💬 Chat</button>
@@ -1155,11 +1157,19 @@
       }
       init();
 
-      document.getElementById('sidebarToggle').addEventListener('click', () => {
+      const collapsedLogo = document.getElementById('collapsedSidebarLogo');
+      const expandArrow = document.getElementById('expandSidebarArrow');
+      function toggleSidebar(){
         const sb = document.getElementById('sidebar');
-        if(sb.style.display === 'none') sb.style.display = '';
-        else sb.style.display = 'none';
-      });
+        const hidden = sb.style.display === 'none';
+        sb.style.display = hidden ? '' : 'none';
+        if(collapsedLogo) collapsedLogo.style.display = hidden ? 'none' : 'block';
+        if(expandArrow) expandArrow.style.display = hidden ? 'none' : 'block';
+      }
+
+      document.getElementById('sidebarToggle').addEventListener('click', toggleSidebar);
+      collapsedLogo?.addEventListener('click', toggleSidebar);
+      expandArrow?.addEventListener('click', toggleSidebar);
 
     });
 


### PR DESCRIPTION
## Summary
- restore collapsed sidebar logo on `nexum.html`
- handle sidebar toggle to show/hide the logo and arrow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6848611376ec832389504f5f674f901f