### PR TITLE
Add dynamic favicon on jobs page

### DIFF
--- a/Aurora/public/jobs.html
+++ b/Aurora/public/jobs.html
@@ -4,6 +4,12 @@
   <meta charset="UTF-8">
   <title>Jobs</title>
   <link rel="stylesheet" href="/styles.css">
+  <link
+    id="favicon"
+    rel="icon"
+    type="image/svg+xml"
+    href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><polygon points='32,4 4,60 60,60' fill='black' /></svg>"
+  >
 </head>
 <body style="padding:1rem;">
   <h2>Jobs</h2>
@@ -11,6 +17,10 @@
   <ul id="jobsList"></ul>
   <pre id="terminal" style="background:#000;color:#0f0;padding:0.5rem;margin-top:0.5rem;height:80vh;overflow:auto;font-family:monospace;resize:vertical;"></pre>
 <script>
+const defaultFavicon = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><polygon points='32,4 4,60 60,60' fill='black' /></svg>";
+const rotatingFavicon = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><polygon points='10,4 58,32 10,60' fill='black' /><path d='M32,4 A28,28 0 0 1 32,60' stroke='black' stroke-width='4' fill='none'><animateTransform attributeName='transform' type='rotate' from='0 32 32' to='360 32 32' dur='1s' repeatCount='indefinite' /></path></svg>";
+let favElement = document.getElementById('favicon');
+if(favElement) favElement.href = defaultFavicon;
 async function loadJobs() {
   const res = await fetch('/api/jobs');
   const jobs = await res.json();
@@ -37,6 +47,7 @@ async function openJob(id) {
   const logRes = await fetch(`/api/jobs/${id}/log`);
   term.textContent = await logRes.text();
   evt = new EventSource(`/api/jobs/${id}/stream`);
+  if(favElement) favElement.href = rotatingFavicon;
   document.getElementById('stopBtn').style.display = 'inline';
   evt.addEventListener('log', e => {
     term.textContent += JSON.parse(e.data);
@@ -45,12 +56,14 @@ async function openJob(id) {
   evt.addEventListener('done', () => {
     evt.close();
     document.getElementById('stopBtn').style.display = 'none';
+    if(favElement) favElement.href = defaultFavicon;
   });
 }
 
 async function stopJob(){
   if(!currentJobId) return;
   await fetch(`/api/jobs/${currentJobId}/stop`, { method: 'POST' });
+  if(favElement) favElement.href = defaultFavicon;
 }
 
 document.getElementById('stopBtn').addEventListener('click', stopJob);


### PR DESCRIPTION
## Summary
- show default favicon on Jobs page
- animate favicon while job stream is active

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68487b46834483238432adf5455ba5d5