### PR TITLE
Add subbubble editing in Aurora

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4360,7 +4360,27 @@ function addChatMessage(pairId, userText, userTs, aiText, aiTs, model, systemCon
         navigator.clipboard.writeText(stripPlaceholderImageLines(userText) || "");
         showToast("Copied to clipboard");
       });
+      const userEditBtn = document.createElement("button");
+      userEditBtn.className = "bubble-edit-btn";
+      userEditBtn.textContent = "✎";
+      userEditBtn.title = "Edit user message";
+      userEditBtn.addEventListener("click", async () => {
+        const newText = prompt("Edit user message:", userText);
+        if (newText === null) return;
+        const resp = await fetch(`/api/chat/pair/${pairId}/user`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ text: newText })
+        });
+        if (resp.ok) {
+          userText = newText;
+          userBody.textContent = newText;
+        } else {
+          alert("Failed to edit message.");
+        }
+      });
       userHead.appendChild(userCopyBtn);
+      userHead.appendChild(userEditBtn);
       userHead.appendChild(userDelBtn);
       userDiv.appendChild(userHead);
 
@@ -4419,7 +4439,27 @@ function addChatMessage(pairId, userText, userTs, aiText, aiTs, model, systemCon
     navigator.clipboard.writeText(stripPlaceholderImageLines(aiText) || "");
     showToast("Copied to clipboard");
   });
+  const aiEditBtn = document.createElement("button");
+  aiEditBtn.className = "bubble-edit-btn";
+  aiEditBtn.textContent = "✎";
+  aiEditBtn.title = "Edit AI reply";
+  aiEditBtn.addEventListener("click", async () => {
+    const newText = prompt("Edit AI reply:", aiText);
+    if (newText === null) return;
+    const resp = await fetch(`/api/chat/pair/${pairId}/ai`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: newText })
+    });
+    if (resp.ok) {
+      aiText = newText;
+      botBody.textContent = stripPlaceholderImageLines(newText);
+    } else {
+      alert("Failed to edit AI reply.");
+    }
+  });
   botHead.appendChild(aiCopyBtn);
+  botHead.appendChild(aiEditBtn);
   botHead.appendChild(aiDelBtn);
   botDiv.appendChild(botHead);
 

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -299,6 +299,18 @@ body {
   cursor: pointer;
 }
 
+.bubble-edit-btn {
+  position: absolute;
+  top: 4px;
+  right: 20px;
+  background: transparent;
+  border: none;
+  color: #4da3ff;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
 .bubble-copy-btn:hover {
   color: #6cb8ff;
 }

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -302,6 +302,18 @@ body {
   cursor: pointer;
 }
 
+.bubble-edit-btn {
+  position: absolute;
+  top: 4px;
+  right: 20px;
+  background: transparent;
+  border: none;
+  color: #4da3ff;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
 .bubble-copy-btn:hover {
   color: #6cb8ff;
 }

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -3026,6 +3026,38 @@ app.delete("/api/chat/pair/:id/user", (req, res) => {
   }
 });
 
+app.post("/api/chat/pair/:id/user", (req, res) => {
+  console.debug("[Server Debug] POST /api/chat/pair/:id/user =>", req.params.id);
+  try {
+    const pairId = parseInt(req.params.id, 10);
+    const { text = "" } = req.body || {};
+    if (Number.isNaN(pairId)) {
+      return res.status(400).json({ error: "Invalid pair ID" });
+    }
+    db.updateUserText(pairId, text);
+    res.json({ success: true });
+  } catch (err) {
+    console.error("[TaskQueue] POST /api/chat/pair/:id/user error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+app.post("/api/chat/pair/:id/ai", (req, res) => {
+  console.debug("[Server Debug] POST /api/chat/pair/:id/ai =>", req.params.id);
+  try {
+    const pairId = parseInt(req.params.id, 10);
+    const { text = "" } = req.body || {};
+    if (Number.isNaN(pairId)) {
+      return res.status(400).json({ error: "Invalid pair ID" });
+    }
+    db.updateAiText(pairId, text);
+    res.json({ success: true });
+  } catch (err) {
+    console.error("[TaskQueue] POST /api/chat/pair/:id/ai error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 app.post("/api/createSterlingChat", async (req, res) => {
   db.logActivity("Create Sterling Chat", "User triggered createSterlingChat endpoint.");
 

--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -832,10 +832,22 @@ export default class TaskDB {
     ).run(id);
   }
 
+  updateAiText(id, text) {
+    this.db.prepare(
+        "UPDATE chat_pairs SET ai_text=? WHERE id=?"
+    ).run(text, id);
+  }
+
   deleteUserPart(id) {
     this.db.prepare(
         "UPDATE chat_pairs SET user_text='' WHERE id=?"
     ).run(id);
+  }
+
+  updateUserText(id, text) {
+    this.db.prepare(
+        "UPDATE chat_pairs SET user_text=? WHERE id=?"
+    ).run(text, id);
   }
 
   listProjectBranches() {


### PR DESCRIPTION
## Summary
- enable updating user/AI text in DB
- expose POST endpoints to change user/AI text
- allow editing subbubbles in the chat UI
- style new edit buttons

## Testing
- `npm --prefix Aurora run lint`

------
https://chatgpt.com/codex/tasks/task_b_684f398cc52c83238c400a1065b2cc9e