### PR TITLE
Use modal for editing chat messages

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -762,7 +762,7 @@
     <div class="modal-buttons">
       <button id="settingsCloseBtn">Close</button>
     </div>
-  </div>
+</div>
 </div>
 
 <!-- Subscription Plans modal -->
@@ -776,6 +776,18 @@
     <p>Can Mix and Match different Tiers for multiple users.</p>
     <div class="modal-buttons">
       <button id="subscribeCloseBtn">Close</button>
+    </div>
+  </div>
+</div>
+
+<!-- Edit Message modal -->
+<div id="editMessageModal" class="modal">
+  <div class="modal-content">
+    <h2 id="editMessageTitle">Edit Message</h2>
+    <textarea id="editMessageTextarea" rows="6" style="width:100%;"></textarea>
+    <div class="modal-buttons">
+      <button id="editMessageSaveBtn">Save</button>
+      <button id="editMessageCancelBtn">Cancel</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add new Edit Message modal markup
- support editing chat messages via a custom modal
- refactor edit handlers for AI/user messages to use the new modal

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684f4fda1c448323bdd085af6ed74c99