### PR TITLE
Add date headers to sidebar chat tabs

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1662,7 +1662,16 @@ function renderTabs(){
 function renderSidebarTabs(){
   const container = document.getElementById("verticalTabsContainer");
   container.innerHTML="";
+  let lastDate = null;
   chatTabs.filter(t => showArchivedTabs || !t.archived).forEach(tab => {
+    const tabDate = isoDate(tab.created_at);
+    if(tabDate !== lastDate){
+      const header = document.createElement("div");
+      header.className = "tab-date-header";
+      header.textContent = tabDate;
+      container.appendChild(header);
+      lastDate = tabDate;
+    }
     const wrapper = document.createElement("div");
     wrapper.style.display = "flex";
     wrapper.style.alignItems = "center";

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -796,6 +796,14 @@ body {
   white-space: nowrap;
 }
 
+/* Date header separating chat tabs by day */
+#verticalTabsContainer .tab-date-header {
+  margin: 4px 0;
+  text-align: center;
+  font-size: 0.8rem;
+  color: #aaa;
+}
+
 #verticalTabsContainer button.active {
   background-color: #555;
   border-color: #aaa;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -799,6 +799,14 @@ body {
   white-space: nowrap;
 }
 
+/* Date header separating chat tabs by day */
+#verticalTabsContainer .tab-date-header {
+  margin: 4px 0;
+  text-align: center;
+  font-size: 0.8rem;
+  color: #666;
+}
+
 #verticalTabsContainer button.active {
   background-color: #ccc;
   border-color: #aaa;


### PR DESCRIPTION
## Summary
- group sidebar chat tabs by creation date
- style new date headers for both themes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684f56b84b80832390a39b0460e2dd6b