### PR TITLE
Add delayed scroll after AI response

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2415,7 +2415,9 @@ chatSendBtnEl.addEventListener("click", async () => {
   appendChatElement(seqDiv);
   if(chatAutoScroll){
     chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
-    setTimeout(scrollChatToBottom, 0);
+    // After the AI response has fully rendered, scroll once more
+    // with a slight delay to ensure any late DOM updates are captured.
+    setTimeout(scrollChatToBottom, 1000);
   }
 
   let combinedUserText = "";


### PR DESCRIPTION
## Summary
- in Aurora chat send handler, add delayed scroll to the bottom after rendering

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684f53cb4b1c83238dc6cd573570b57d