### PR TITLE
Fix deepseek model service

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -187,6 +187,13 @@ const shopId = process.env.PRINTIFY_SHOP_ID || 18663958;
  */
 function getOpenAiClient() {
   let service = db.getSetting("ai_service") || "openrouter";
+  const currentModel = db.getSetting("ai_model") || "";
+  const { provider } = parseProviderModel(currentModel);
+
+  if (provider === "openrouter") {
+    service = "openrouter";
+  }
+
   const openAiKey = process.env.OPENAI_API_KEY || "";
   const openRouterKey = process.env.OPENROUTER_API_KEY || "";
 


### PR DESCRIPTION
## Summary
- ensure deepseek/openrouter models always select the openrouter service

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684f613c9a988323b2c34f69b0b369b2