### PR TITLE
Fix mosaic code block parsing

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -254,7 +254,12 @@ function addFilesFromCodeBlocks(text){
   const blocks = text.match(/```[\s\S]*?```/g) || [];
   blocks.forEach(b => {
     const inner = b.slice(3, -3).trim();
-    const first = inner.split(/\r?\n/)[0].trim();
+    let first = inner.split(/\r?\n/)[0].trim();
+    // Allow leading markdown headers like "# filename" which are
+    // common when users copy code blocks from chat responses.
+    if(first.startsWith('#')){
+      first = first.replace(/^#+\s*/, '');
+    }
     if(/^[\w./-]+\.[\w-]+$/.test(first)){
       addFileToMosaic(first);
     }


### PR DESCRIPTION
## Summary
- improve parsing for code blocks that start with markdown headers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684f671260148323bf27df02fe6c3eb2