### PR TITLE
Fix code block parsing for mosaic

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -281,6 +281,11 @@ function addFilesFromCodeBlocks(text){
     const inner = b.slice(3, -3).trim();
     const lines = inner.split(/\r?\n/);
     let first = lines[0].trim();
+    // Skip a leading language spec like "markdown" or "bash"
+    if(/^[a-zA-Z]+$/.test(first) && lines.length > 1){
+      lines.shift();
+      first = lines[0].trim();
+    }
     // Allow leading markdown headers like "# filename" which are
     // common when users copy code blocks from chat responses.
     if(first.startsWith('#')){


### PR DESCRIPTION
## Summary
- handle language spec lines when scanning code blocks to add mosaic files

## Testing
- `npm run lint` within Aurora
- `npm test` within AutoPR and VMRunner

------
https://chatgpt.com/codex/tasks/task_b_684f6c8f38508323877e67b0949e556c