### PR TITLE
Enable file links in mosaic panel

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -256,9 +256,14 @@ function addFileToMosaic(file){
   if(!file) return;
   const list = ensureMosaicList();
   if(!list) return;
-  if([...list.children].some(li => li.textContent === file)) return;
+  if([...list.children].some(li => li.dataset.file === file)) return;
   const li = document.createElement("li");
-  li.textContent = file;
+  li.dataset.file = file;
+  const link = document.createElement("a");
+  link.href = "/mosaic/files/" + file;
+  link.target = "_blank";
+  link.textContent = file;
+  li.appendChild(link);
   list.appendChild(li);
 }
 

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -637,6 +637,7 @@ const printifyQueue = new PrintifyJobQueue(jobManager, {
 
 // Serve static files
 app.use("/uploads", express.static(uploadsDir));
+app.use("/mosaic/files", express.static(mosaicDir));
 
 // Allow loading images from absolute paths produced by the upscale script.
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- make mosaic list items clickable links that open in a new tab
- serve saved mosaic files via a new static route

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684f703f67708323997070e665c519f8