### PR TITLE
Add git init for mosaic repo and UI button

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -264,6 +264,7 @@
     <!-- Mosaic panel -->
     <div id="mosaicPanel" style="display:none;border:1px dashed #666; padding:8px; margin:8px 0;">
       <h2 style="margin:0;font-size:1.1rem;">Mosaic</h2>
+      <button id="mosaicInitGitBtn">Initialize Git Repository</button>
       <ul id="mosaicList" style="margin:4px 0; padding-left:1.2em;"></ul>
     </div>
 

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -5433,6 +5433,21 @@ document.getElementById("mosaicEditCancelBtn").addEventListener("click", () => {
   mosaicEditingFile = null;
 });
 
+document.getElementById("mosaicInitGitBtn").addEventListener("click", async () => {
+  try {
+    const r = await fetch('/api/mosaic/git-init', { method: 'POST' });
+    if(r.ok){
+      const data = await r.json();
+      alert(data.already ? 'Repository already initialized.' : 'Initialized git repository.');
+    } else {
+      alert('Failed to initialize repository');
+    }
+  } catch(e){
+    console.error('Error initializing mosaic repo', e);
+    alert('Error initializing repository');
+  }
+});
+
 // ----------------------------------------------------------------------
 // Handling the global markdown save button
 // ----------------------------------------------------------------------

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -3405,6 +3405,21 @@ app.get('/api/mosaic/get', (req, res) => {
   }
 });
 
+app.post('/api/mosaic/git-init', (req, res) => {
+  try {
+    fs.mkdirSync(mosaicDir, { recursive: true });
+    const gitDir = path.join(mosaicDir, '.git');
+    if (fs.existsSync(gitDir)) {
+      return res.json({ success: true, already: true });
+    }
+    child_process.execSync('git init', { cwd: mosaicDir });
+    res.json({ success: true, already: false });
+  } catch (err) {
+    console.error('Error in /api/mosaic/git-init:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 const PORT =
   process.env.AURORA_PORT ||
   process.env.PORT ||


### PR DESCRIPTION
## Summary
- enable initializing a Git repository for Mosaic via new endpoint
- expose `Initialize Git Repository` button in the Mosaic panel
- wire up button to `/api/mosaic/git-init` endpoint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684f79704b388323b00f427fcc1990fa