### PR TITLE
Add copy button for code blocks

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -241,6 +241,23 @@ function formatCodeBlocks(text){
   }).join("");
 }
 
+function addCodeCopyButtons(root){
+  if(!root) return;
+  root.querySelectorAll('pre').forEach(pre => {
+    if(pre.querySelector('.code-copy-btn')) return;
+    const btn = document.createElement('button');
+    btn.className = 'code-copy-btn';
+    btn.innerHTML = '\u2398';
+    btn.title = 'Copy code';
+    btn.addEventListener('click', () => {
+      navigator.clipboard.writeText(pre.innerText);
+      showToast('Copied to clipboard');
+    });
+    pre.style.position = 'relative';
+    pre.appendChild(btn);
+  });
+}
+
 // ------------------ Mosaic Helpers ------------------
 function ensureMosaicList(){
   const panel = document.getElementById("mosaicPanel");
@@ -2589,6 +2606,7 @@ chatSendBtnEl.addEventListener("click", async () => {
       const descBubble = document.createElement("div");
       descBubble.className = "user-subbubble";
       descBubble.innerHTML = formatCodeBlocks(d);
+      addCodeCopyButtons(descBubble);
       descBubble.style.marginBottom = "8px";
       descBubble.style.borderLeft = "2px solid #ccc";
       descBubble.style.paddingLeft = "6px";
@@ -2600,6 +2618,7 @@ chatSendBtnEl.addEventListener("click", async () => {
       const userBody = document.createElement("div");
       userBody.className = "user-subbubble";
       userBody.innerHTML = formatCodeBlocks(userMessage);
+      addCodeCopyButtons(userBody);
       userDiv.appendChild(userBody);
     }
 
@@ -2680,6 +2699,7 @@ chatSendBtnEl.addEventListener("click", async () => {
       }
       // Update once more without the loader after streaming finishes
       botBody.innerHTML = formatCodeBlocks(stripPlaceholderImageLines(partialText));
+      addCodeCopyButtons(botBody);
       addFilesFromCodeBlocks(partialText);
       if(chatAutoScroll) chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
       clearInterval(ellipsisInterval);
@@ -4417,6 +4437,7 @@ async function loadChatHistory(tabId = 1, reset=false) {
             const userBody = document.createElement("div");
             userBody.className = "user-subbubble";
             userBody.innerHTML = formatCodeBlocks(p.user_text);
+            addCodeCopyButtons(userBody);
             userDiv.appendChild(userBody);
           }
 
@@ -4486,6 +4507,7 @@ async function loadChatHistory(tabId = 1, reset=false) {
 
         const botBody = document.createElement("div");
         botBody.innerHTML = formatCodeBlocks(stripPlaceholderImageLines(p.ai_text || ""));
+        addCodeCopyButtons(botBody);
         botDiv.appendChild(botBody);
         addFilesFromCodeBlocks(p.ai_text || "");
 
@@ -4607,6 +4629,7 @@ function addChatMessage(pairId, userText, userTs, aiText, aiTs, model, systemCon
       const userBody = document.createElement("div");
       userBody.className = "user-subbubble";
       userBody.innerHTML = formatCodeBlocks(userText);
+      addCodeCopyButtons(userBody);
       userDiv.appendChild(userBody);
     }
 
@@ -4686,6 +4709,7 @@ function addChatMessage(pairId, userText, userTs, aiText, aiTs, model, systemCon
 
   const botBody = document.createElement("div");
   botBody.innerHTML = formatCodeBlocks(stripPlaceholderImageLines(aiText || ""));
+  addCodeCopyButtons(botBody);
   botDiv.appendChild(botBody);
   addFilesFromCodeBlocks(aiText || "");
 

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -315,6 +315,21 @@ body {
   color: #6cb8ff;
 }
 
+.code-copy-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: transparent;
+  border: none;
+  color: #4da3ff;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.code-copy-btn:hover {
+  color: #6cb8ff;
+}
+
 /* Avatars replaced with name ovals */
 .name-oval {
   display: inline-block;
@@ -423,6 +438,7 @@ body {
   border-radius: 4px;
   white-space: pre-wrap;
   overflow-x: auto;
+  position: relative;
 }
 
 /* Thumbnail images in the secure uploader table */

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -318,6 +318,21 @@ body {
   color: #6cb8ff;
 }
 
+.code-copy-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: transparent;
+  border: none;
+  color: #4da3ff;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.code-copy-btn:hover {
+  color: #6cb8ff;
+}
+
 /* Avatars replaced with name ovals */
 .name-oval {
   display: inline-block;
@@ -426,6 +441,7 @@ body {
   border-radius: 4px;
   white-space: pre-wrap;
   overflow-x: auto;
+  position: relative;
 }
 
 /* Thumbnail images in the secure uploader table */


### PR DESCRIPTION
## Summary
- add helper to attach copy buttons to `<pre>` blocks
- show copy button when chat messages render code
- style new `.code-copy-btn` for dark and light themes
- make code blocks relative positioned for button overlay

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684f871fb8048323be9a1189d9e5d0c3