### PR TITLE
Fix about link on portfolio page

### DIFF
--- a/Aurora/public/portfolio.html
+++ b/Aurora/public/portfolio.html
@@ -89,14 +89,17 @@
   </style>
 </head>
 <body>
-  <a href="/about_confused.html" style="position:fixed; top:8px; left:72px; font-size:0.8rem; color:#0ff; z-index:1000;">About</a>
-  <h1>Confused Art - Powered by <a href="https://alfe.sh" target="_blank">Alfe AI</a></h1>
   <a
     href="https://www.ebay.com/sch/11450/i.html?_dkr=1&iconV2Request=true&_blrs=recall_filtering&_ssn=confused_apparel&_oac=1&_sop=10"
     target="_blank"
     class="shop-btn"
-    style="position:fixed; top:8px; left:8px; z-index:1000;"
+    style="position:fixed; top:8px; left:8px; z-index:1001;"
   >Shop</a>
+  <a
+    href="/about_confused.html"
+    style="position:fixed; top:8px; left:100px; font-size:0.8rem; color:#0ff; z-index:1001;"
+  >About</a>
+  <h1>Confused Art - Powered by <a href="https://alfe.sh" target="_blank">Alfe AI</a></h1>
   <div id="imageCounter">0 / 0</div>
   <div id="grid" class="grid"></div>
   <div id="sentinel"></div>


### PR DESCRIPTION
## Summary
- ensure About link is positioned next to the Shop button
- bump z-index so About link stays above sticky header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684fb564af38832390bac09de4d9a4ab