### PR TITLE
Handle Printify URL from puppet log

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -120,7 +120,7 @@ import os from "os";
 import child_process from "child_process";
 import JobManager from "./jobManager.js";
 import PrintifyJobQueue from "./printifyJobQueue.js";
-import { extractPrintifyUrl } from "./printifyUtils.js";
+import { extractProductUrl, extractPrintifyUrl } from "./printifyUtils.js";
 
 const db = new TaskDB();
 console.debug("[Server Debug] Checking or setting default 'ai_model' in DB...");
@@ -2406,6 +2406,12 @@ app.post("/api/printify", async (req, res) => {
         const url = `/uploads/${file}`;
         if (productId && Array.isArray(variants)) {
           await updatePrintifyProduct(productId, variants);
+        }
+        const productUrl =
+          extractProductUrl(job.log) || extractPrintifyUrl(job.log);
+        if (productUrl) {
+          db.setProductUrl(url, productUrl);
+          job.productUrl = productUrl;
         }
         db.setImageStatus(url, 'Printify Price Puppet');
       } catch (e) {


### PR DESCRIPTION
## Summary
- import `extractProductUrl` to parse puppet logs
- when the `/api/printify` job finishes, capture the Printify URL from the log and store it as the image's product URL

## Testing
- `npm run lint` (no linter configured)


------
https://chatgpt.com/codex/tasks/task_b_6851bbd9b2488323bcc2a2eb4cc16638