### PR TITLE
Redirect root for non-whitelisted users

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -596,6 +596,10 @@ if (whitelistIp) {
       return next();
     }
 
+    if (req.path === "/" || req.path === "/index.html") {
+      return res.redirect("https://alfe.sh");
+    }
+
     res.status(403).send("Forbidden");
   });
 }


### PR DESCRIPTION
## Summary
- update IP whitelist logic to redirect `/` to https://alfe.sh when access is denied

## Testing
- `node --check Aurora/src/server.js`
- `npm run lint` in `Aurora`
- `npm test` in `Aurora` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685205f50ac48323b2008971c7d8c6fe