### PR TITLE
Add rename modal with mosaic toggle

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -395,6 +395,20 @@
   </div>
 </div>
 
+<div id="renameTabModal" class="modal">
+  <div class="modal-content">
+    <h2>Rename Chat</h2>
+    <label>New name:<br/>
+      <input type="text" id="renameTabInput" style="width:100%;" />
+    </label>
+    <label style="display:block;margin-top:8px;"><input type="checkbox" id="renameShowMosaicCheck"/> Show mosaic panel</label>
+    <div class="modal-buttons">
+      <button id="renameTabSaveBtn">Save</button>
+      <button id="renameTabCancelBtn">Cancel</button>
+    </div>
+  </div>
+</div>
+
 
 <div id="chatSettingsModal" class="modal">
   <div class="modal-content">


### PR DESCRIPTION
## Summary
- replace prompt-based chat renaming with a modal dialog
- include option in the rename modal to show or hide the mosaic panel

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685ad95e128c8323933842763f8ca891