### PR TITLE
Add Task tab type

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -391,6 +391,10 @@
         <div class="icon">🎨</div>
         <div>Design</div>
       </button>
+      <button data-type="task" class="start-type-btn">
+        <div class="icon">📋</div>
+        <div>Task</div>
+      </button>
     </div>
   </div>
 </div>
@@ -402,6 +406,13 @@
       <input type="text" id="renameTabInput" style="width:100%;" />
     </label>
     <label style="display:block;margin-top:8px;"><input type="checkbox" id="renameShowMosaicCheck"/> Show mosaic panel</label>
+    <label style="display:block;margin-top:8px;">Tab type:<br/>
+      <select id="renameTabTypeSelect" style="width:100%;">
+        <option value="chat">Chat</option>
+        <option value="design">Design</option>
+        <option value="task">Task</option>
+      </select>
+    </label>
     <div class="modal-buttons">
       <button id="renameTabSaveBtn">Save</button>
       <button id="renameTabCancelBtn">Cancel</button>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -149,7 +149,7 @@ const defaultFavicon = "/alfe_favicon_64x64.ico";
 const rotatingFavicon = "/alfe_favicon_64x64.ico";
 let favElement = null;
 
-const tabTypeIcons = { chat: "💬", design: "🎨" };
+const tabTypeIcons = { chat: "💬", design: "🎨", task: "📋" };
 let newTabSelectedType = 'chat';
 
 const $  = (sel, ctx=document) => ctx.querySelector(sel);
@@ -1705,6 +1705,8 @@ function openRenameTabModal(tabId){
   }
   input.value = t ? t.name : "";
   $("#renameShowMosaicCheck").checked = mosaicPanelVisible;
+  const typeSel = $("#renameTabTypeSelect");
+  if(typeSel) typeSel.value = t ? t.tab_type || 'chat' : 'chat';
   const modal = $("#renameTabModal");
   if(!modal){
     renameTab(tabId);
@@ -1720,11 +1722,24 @@ $("#renameTabSaveBtn").addEventListener("click", async () => {
   const modal = $("#renameTabModal");
   const tabId = parseInt(modal.dataset.tabId, 10);
   const name = $("#renameTabInput").value.trim();
+  const type = $("#renameTabTypeSelect")?.value || 'chat';
   mosaicPanelVisible = $("#renameShowMosaicCheck").checked;
   const pnl = document.getElementById("mosaicPanel");
   if(pnl) pnl.style.display = mosaicPanelVisible ? "" : "none";
   await setSetting("mosaic_panel_visible", mosaicPanelVisible);
   if(name) await renameTab(tabId, name);
+  const tab = chatTabs.find(t => t.id === tabId) || {};
+  const project = tab.project_name || '';
+  const repo = tab.repo_ssh_url || '';
+  await fetch('/api/chat/tabs/config', {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({tabId, project, repo, type, sessionId})
+  });
+  await loadTabs();
+  renderTabs();
+  renderSidebarTabs();
+  renderArchivedSidebarTabs();
   hideModal(modal);
 });
 $("#renameTabCancelBtn").addEventListener("click", () => hideModal($("#renameTabModal")));


### PR DESCRIPTION
## Summary
- allow creating Task tabs alongside Chat and Design
- let rename modal change a tab's type via dropdown

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685ae4558a2483239d14b4b1445d4ebf