### PR TITLE
Rename Task tab label to Tasks

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -393,7 +393,7 @@
       </button>
       <button data-type="task" class="start-type-btn">
         <div class="icon">📋</div>
-        <div>Task</div>
+        <div>Tasks</div>
       </button>
     </div>
   </div>
@@ -410,7 +410,7 @@
       <select id="renameTabTypeSelect" style="width:100%;">
         <option value="chat">Chat</option>
         <option value="design">Design</option>
-        <option value="task">Task</option>
+        <option value="task">Tasks</option>
       </select>
     </label>
     <div class="modal-buttons">


### PR DESCRIPTION
## Summary
- update UI labels to use "Tasks" for the task chat tab type

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685ae6245d388323810280bd20923b58