### PR TITLE
Enable right‑click opening of chat tabs

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1918,10 +1918,9 @@ function renderTabs(){
 
     tabBtn.addEventListener("contextmenu", e=>{
       e.preventDefault();
-      const choice = prompt("Type 'rename', 'fork', or 'delete':", "");
-      if(choice==="rename") openRenameTabModal(tab.id);
-      else if(choice==="fork") duplicateTab(tab.id);
-      else if(choice==="delete") deleteTab(tab.id);
+      if(tab.tab_uuid){
+        window.open(`/chat/${tab.tab_uuid}`, "_blank");
+      }
     });
     tc.appendChild(tabBtn);
   });
@@ -1972,10 +1971,9 @@ function renderSidebarTabs(){
     });
     b.addEventListener("contextmenu", e => {
       e.preventDefault();
-      const choice = prompt("Type 'rename', 'fork', or 'delete':", "");
-      if (choice === "rename") openRenameTabModal(tab.id);
-      else if (choice === "fork") duplicateTab(tab.id);
-      else if (choice === "delete") deleteTab(tab.id);
+      if(tab.tab_uuid){
+        window.open(`/chat/${tab.tab_uuid}`, "_blank");
+      }
     });
 
     const dateSpan = document.createElement("span");


### PR DESCRIPTION
## Summary
- update Aurora web interface so right‑clicking a chat tab opens that chat in a new browser tab

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_685b4b6d88608323867278b737ff10cc