### PR TITLE
Add Programatic Printify Finish button

### DIFF
--- a/Aurora/public/Image.html
+++ b/Aurora/public/Image.html
@@ -42,13 +42,14 @@
       <span id="nobgPath"></span>
     </label>
   </div>
-  <div style="margin-top:0.5rem;">
+  <div style="margin-top:0.5rem; display:flex; gap:0.5rem; align-items:center;">
     <button id="upscaleButton" hidden>Submit to Upscale</button>
     <button id="printifyButton" hidden>Submit to Printify</button>
     <button id="printifyTitleFixButton" hidden>Title Fix</button>
     <button id="printifyPriceButton" hidden>Submit Price Update</button>
     <button id="setProductUrlButton" hidden>Set Product URL</button>
     <button id="printifyApiButton">Submit Printify API Updates</button>
+    <button id="printifyFinishButton" style="margin-left:auto;">Programatic: Printify Finish</button>
   </div>
   <pre id="upscaleTerminal" style="background:#000;color:#0f0;padding:0.5rem;margin-top:0.5rem;height:200px;overflow:auto;font-family:monospace;"></pre>
   <script src="/session.js"></script>


### PR DESCRIPTION
## Summary
- show printify buttons in a flex container
- add 'Programatic: Printify Finish' button and keep it visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685c5e09102c832398160837a8775ec8