### PR TITLE
Add queue link

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -20,7 +20,7 @@
     <img id="sidebarToggleIcon" class="sidebar-toggle-icon" src="/alfe_favicon_64x64.ico" alt="Toggle sidebar" title="Toggle sidebar"/>
     <span id="sidebarBrandText" class="sidebar-brand-text">Alfe AI</span>
     <span id="closeSidebarIcon" class="close-sidebar-icon">&laquo;</span>
-    <div id="versionInfo" class="version-info" style="margin-bottom: 5px;"><span id="versionSpan">beta-...</span> <a href="/about.html" target="_blank" style="color: cyan">about</a></div>
+    <div id="versionInfo" class="version-info" style="margin-bottom: 5px;"><span id="versionSpan">beta-...</span> <a href="/about.html" target="_blank" style="color: cyan">about</a> <a href="/pipeline_queue.html" target="_blank" style="color: cyan; margin-left:4px;">queue</a></div>
     <span id="sessionIdText" class="session-id"></span>
     <button id="hideSidebarBtn" class="hide-sidebar-btn">Hide Sidebar</button>
     <span id="imageLimitInfo" class="session-limit"></span>


### PR DESCRIPTION
## Summary
- link the pipeline queue page in Aurora's sidebar

## Testing
- `npm test` *(fails: ENOENT, network required)*

------
https://chatgpt.com/codex/tasks/task_b_685ee588bf7c832389104e7e05b3ca74