### PR TITLE
Fix secure uploader ID column

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -114,7 +114,7 @@
       <table id="secureFilesList" class="file-table">
         <thead>
           <tr>
-            <th data-col="uuid">#</th>
+            <th data-col="id">#</th>
             <th>Thumb</th>
             <th data-col="name">File</th>
             <th data-col="title">Title</th>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3029,7 +3029,7 @@ function renderFileList(){
     const tr = document.createElement("tr");
     tr.dataset.fileName = f.name;
     const tdIndex = document.createElement("td");
-    tdIndex.textContent = f.uuid ?? f.id ?? "";
+    tdIndex.textContent = (f.id ?? f.uuid ?? "");
     const tdThumb = document.createElement("td");
     const thumbImg = document.createElement("img");
     thumbImg.src = `/uploads/${encodeURIComponent(f.name)}`;


### PR DESCRIPTION
## Summary
- show numeric database IDs in the secure uploader file list
- keep the ID column sortable as a number

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685ee8bc278c8323b0726d3df11ac7f6