### PR TITLE
Improve Printify title generation

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2569,10 +2569,18 @@ app.post("/api/printifyTitleFix", async (req, res) => {
         .json({ error: `Printify script missing at ${scriptPath}` });
     }
 
-    const job = jobManager.createJob("node", [scriptPath, productId], {
-      cwd: scriptCwd,
-      file,
-    });
+    const filePath = path.isAbsolute(file)
+      ? file
+      : path.join(uploadsDir, file);
+
+    const job = jobManager.createJob(
+      "node",
+      [scriptPath, productId, filePath],
+      {
+        cwd: scriptCwd,
+        file,
+      }
+    );
     console.debug("[Server Debug] /api/printifyTitleFix => job started", job.id);
 
     jobManager.addDoneListener(job, () => {


### PR DESCRIPTION
## Summary
- enhance the `printifyTitleFix` script to use OpenAI vision for title generation
- pass image path from the server so the script can call OpenAI

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685ede553778832387477dff214a36ce