### PR TITLE
Fix matchAll regex to avoid runtime error

### DIFF
--- a/Aurora/src/printifyUtils.js
+++ b/Aurora/src/printifyUtils.js
@@ -1,6 +1,6 @@
 export function extractProductUrl(log = '') {
   if (!log) return null;
-  const matches = [...log.matchAll(/Product URL:\s*(https?:\/\/\S+)/i)];
+  const matches = [...log.matchAll(/Product URL:\s*(https?:\/\/\S+)/gi)];
   const m = matches[matches.length - 1];
   return m ? m[1].trim() : null;
 }


### PR DESCRIPTION
## Summary
- fix `extractProductUrl` to use global regex

## Testing
- `npm test` *(fails: no package.json in root)*

------
https://chatgpt.com/codex/tasks/task_b_685f0d31d6948323b2b51e8daaafe30d