### PR TITLE
Add 'All' option to production queue page

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -65,6 +65,7 @@
         <option value="printify">Printify</option>
         <option value="printifyPrice">Printify Price</option>
         <option value="printifyTitleFix">Printify Title Fix</option>
+        <option value="all">All</option>
       </select>
     </label>
     <label>Image:
@@ -166,7 +167,7 @@
             optionsDiv.style.display = 'none';
             updatePreview(f.name);
             const type = document.getElementById('jobType').value;
-            if(type === 'printify' || type === 'printifyPrice'){
+            if(type === 'printify' || type === 'printifyPrice' || type === 'all'){
               updateVariantUI(f.name);
             }
           });
@@ -197,7 +198,7 @@
 
     document.getElementById('jobType').addEventListener('change', () => {
       const type = document.getElementById('jobType').value;
-      if(type === 'printify' || type === 'printifyPrice'){
+      if(type === 'printify' || type === 'printifyPrice' || type === 'all'){
         updateVariantUI(document.getElementById('imageSelect').dataset.value);
       } else {
         document.getElementById('variantChoice').style.display = 'none';
@@ -260,11 +261,22 @@ async function updateVariantUI(file){
       const variant = variantChoice ? variantChoice.value : null;
       if(!file) return;
       try{
-        await fetch('/api/pipelineQueue', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ file, type, dbId, variant })
-        });
+        if(type === 'all'){
+          const steps = ['upscale','printify','printifyPrice'];
+          for(const step of steps){
+            await fetch('/api/pipelineQueue', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ file, type: step, dbId, variant })
+            });
+          }
+        } else {
+          await fetch('/api/pipelineQueue', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ file, type, dbId, variant })
+          });
+        }
         await loadQueue();
       }catch(e){
         console.error('Failed to enqueue job', e);


### PR DESCRIPTION
## Summary
- add an `All` option to the job type dropdown
- show variant selector when All is selected
- enqueue all job steps when All is chosen

## Testing
- `npm --prefix Aurora run lint`

------
https://chatgpt.com/codex/tasks/task_b_685f0beac7bc8323aae31d10d34bf4f8