### PR TITLE
Add printify product link to queue table

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -99,6 +99,7 @@
         <th>Status</th>
         <th>Job ID</th>
         <th>Result Path</th>
+        <th>Product URL</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -127,6 +128,7 @@
             <td>${job.status}</td>
             <td>${jobLink}</td>
             <td>${job.resultPath || ''}</td>
+            <td>${job.productUrl ? `<a href="${job.productUrl}" target="_blank">${job.productUrl}</a>` : ''}</td>
             <td><button data-id="${job.id}" class="removeBtn">Remove</button></td>
           `;
           tbody.appendChild(tr);


### PR DESCRIPTION
## Summary
- show Printify product URL in the Design Production Queue table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685f0bc9c0e88323a4e58a3d281608b6