### PR TITLE
Fix queue dropdown

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -279,6 +279,11 @@ async function updateVariantUI(file){
 
     loadQueue();
     loadImages();
+    // Ensure deprecated "Printify Price" option is removed if present
+    const jobTypeSel = document.getElementById('jobType');
+    [...jobTypeSel.options].forEach(opt => {
+      if(opt.textContent.trim().toLowerCase() === 'printify price') opt.remove();
+    });
     document.getElementById('jobType').dispatchEvent(new Event('change'));
     setInterval(loadQueue, 5000);
   </script>


### PR DESCRIPTION
## Summary
- remove stray "Printify Price" option if present in queue page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685f12a2a9648323a83558273dc74068