### PR TITLE
Remove Printify Price from queue dropdown

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -63,7 +63,6 @@
       <select id="jobType">
         <option value="upscale">Upscale</option>
         <option value="printify">Printify</option>
-        <option value="printifyPrice">Printify Price</option>
         <option value="printifyTitleFix">Printify Title Fix</option>
         <option value="all">All</option>
       </select>


### PR DESCRIPTION
## Summary
- remove `Printify Price` option from the queue dropdown on `Design Production Queue`

## Testing
- `npm run lint` in `Aurora`
- `npm test` in `AutoPR`


------
https://chatgpt.com/codex/tasks/task_b_685f13ed101c8323a57a6b3e1ffe83d9