### PR TITLE
Add spinner to running job status

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -126,7 +126,7 @@
             <td>${dbLink}</td>
             <td>${job.type}</td>
             <td>${job.variant || ''}</td>
-            <td>${job.status}</td>
+            <td>${job.status === 'running' ? 'Running <span class="loading-spinner"></span>' : job.status}</td>
             <td>${jobLink}</td>
             <td>${job.resultPath || ''}</td>
             <td>${job.productUrl ? `<a href="${job.productUrl}" target="_blank">${job.productUrl}</a>` : ''}</td>


### PR DESCRIPTION
## Summary
- show a loading spinner beside the Running status in the pipeline queue table

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_685f14628a1083239f9cd67db6c726b1