### PR TITLE
Update pipeline queue to use Printify title fix

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -168,7 +168,7 @@
             optionsDiv.style.display = 'none';
             updatePreview(f.name);
             const type = document.getElementById('jobType').value;
-            if(type === 'printify' || type === 'printifyPrice' || type === 'all'){
+            if(type === 'printify' || type === 'printifyPrice' || type === 'printifyTitleFix' || type === 'all'){
               updateVariantUI(f.name);
             }
           });
@@ -199,7 +199,7 @@
 
     document.getElementById('jobType').addEventListener('change', () => {
       const type = document.getElementById('jobType').value;
-      if(type === 'printify' || type === 'printifyPrice' || type === 'all'){
+      if(type === 'printify' || type === 'printifyPrice' || type === 'printifyTitleFix' || type === 'all'){
         updateVariantUI(document.getElementById('imageSelect').dataset.value);
       } else {
         document.getElementById('variantChoice').style.display = 'none';
@@ -263,7 +263,7 @@ async function updateVariantUI(file){
       if(!file) return;
       try{
         if(type === 'all'){
-          const steps = ['upscale','printify','printifyPrice'];
+          const steps = ['upscale','printify','printifyTitleFix'];
           for(const step of steps){
             await fetch('/api/pipelineQueue', {
               method: 'POST',

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -636,6 +636,9 @@ const printifyQueue = new PrintifyJobQueue(jobManager, {
   printifyPriceScript:
     process.env.PRINTIFY_PRICE_SCRIPT_PATH ||
     "/home/admin/Puppets/PrintifyPricePuppet/run.sh",
+  printifyTitleFixScript:
+    process.env.PRINTIFY_TITLE_FIX_SCRIPT_PATH ||
+    path.join(__dirname, "../scripts/printifyTitleFix.js"),
   db,
 });
 


### PR DESCRIPTION
## Summary
- support new `printifyTitleFix` job type in the Printify job queue
- pass the title fix script path when creating the queue
- update UI to enqueue the title fix step for `All` jobs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685f15a0e9c08323b8c8f060cfed4d0f