### PR TITLE
Add printifyTitleFix support in queue

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -636,6 +636,9 @@ const printifyQueue = new PrintifyJobQueue(jobManager, {
   printifyPriceScript:
     process.env.PRINTIFY_PRICE_SCRIPT_PATH ||
     "/home/admin/Puppets/PrintifyPricePuppet/run.sh",
+  printifyTitleFixScript:
+    process.env.PRINTIFY_TITLE_FIX_SCRIPT_PATH ||
+    path.join(__dirname, "../scripts/printifyTitleFix.js"),
   db,
 });
 


### PR DESCRIPTION
## Summary
- include `printifyTitleFixScript` option in `PrintifyJobQueue`
- handle `printifyTitleFix` jobs by deriving product ID and running the correct script
- expose `PRINTIFY_TITLE_FIX_SCRIPT_PATH` when creating the queue

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685f175b9b9083238fcce4fc048d87ef