### PR TITLE
Link job IDs on Image page

### DIFF
--- a/Aurora/public/Image.html
+++ b/Aurora/public/Image.html
@@ -413,7 +413,11 @@
             tr.addEventListener('click', () => window.open(`jobs.html?jobId=${j.id}`, '_blank'));
 
             const tdId = document.createElement('td');
-            tdId.textContent = j.id;
+            const idLink = document.createElement('a');
+            idLink.href = `jobs.html?jobId=${j.id}`;
+            idLink.target = '_blank';
+            idLink.textContent = j.id;
+            tdId.appendChild(idLink);
             const tdStatus = document.createElement('td');
             tdStatus.textContent = j.status;
             const tdPath = document.createElement('td');


### PR DESCRIPTION
## Summary
- make job IDs in the image details table hyperlinks so that they open the job page in a new tab

## Testing
- `npm run lint` in Aurora
- `npm test` in AutoPR
- `npm test` in Sterling *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685f1a812db88323abb67141cc18f749