### PR TITLE
Fix upscale log and queue script path

### DIFF
--- a/Aurora/scripts/upscale.js
+++ b/Aurora/scripts/upscale.js
@@ -10,6 +10,8 @@ if (!API_KEY) {
   process.exit(1);
 }
 
+console.log('Using Stability AI upscaler');
+
 const input = process.argv[2];
 if (!input) {
   console.error('Usage: upscale.js <imagePath>');

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -223,6 +223,7 @@ export default class PrintifyJobQueue {
     } else {
       args.push(filePath);
     }
+    console.log(`[PrintifyJobQueue] Running ${job.type} with script: ${script}`);
     const jmJob = this.jobManager.createJob(script, args, { cwd, file: job.file });
     job.jobId = jmJob.id;
     this.jobManager.addDoneListener(jmJob, () => {

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2265,6 +2265,7 @@ app.post("/api/upscale", async (req, res) => {
         });
     }
 
+    console.debug('[Server Debug] launching upscale job with script =>', scriptPath);
     const job = jobManager.createJob(scriptPath, [filePath], { cwd: scriptCwd, file });
     jobManager.addDoneListener(job, () => {
       const matches = [...job.log.matchAll(/Final output saved to:\s*(.+)/gi)];


### PR DESCRIPTION
## Summary
- clarify that the Stability AI upscaler is used
- log the script path used by the pipeline queue and /api/upscale

## Testing
- `npm run lint` in Aurora
- `npm run lint` in PriceScript (fails: Missing script)
- `npm run lint` in Sterling (fails: Missing script)
- `npm run lint` in AuroraMobile (fails: Missing script)
- `npm run lint` in VMRunner (fails: Missing script)
- `npm run lint` in AlfeRedirect (fails: Missing script)
- `npm run lint` in AutoPR (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_b_685f3edf7fd48323b2483de552a24dd5