### PR TITLE
Fix upscale script path

### DIFF
--- a/Aurora/.env.example
+++ b/Aurora/.env.example
@@ -15,8 +15,6 @@ GITHUB_REPO=yourRepo
 
 # Stability AI API key for the upscale script (optional)
 # STABILITY_API_KEY=sk-xxxxxxxx
-# Path to the image upscale script (optional)
-# UPSCALE_SCRIPT_PATH=./scripts/upscale.js
 
 # Path to the Printify submission script (optional)
 # PRINTIFY_SCRIPT_PATH=/path/to/run.sh

--- a/Aurora/README.md
+++ b/Aurora/README.md
@@ -21,7 +21,6 @@ npm start
 | `OPENAI_API_KEY` | OpenAI API key for AI features ([get here](https://platform.openai.com/api-keys)) |
 | `OPENAI_MODEL`   | (Optional) Model ID for completions (default: deepseek/deepseek-chat)  |
 | `STABILITY_API_KEY` | (Optional) API key for the Stability AI upscaler |
-| `UPSCALE_SCRIPT_PATH` | (Optional) Path to the image upscale script. Defaults to `scripts/upscale.js` |
 | `PRINTIFY_SCRIPT_PATH` | (Optional) Path to the Printify submission script. Defaults to the included run.sh |
 | `PRINTIFY_PRICE_SCRIPT_PATH` | (Optional) Path to the Printify price update script. Defaults to `/home/admin/Puppets/PrintifyPricePuppet/run.sh` |
 | `PRINTIFY_TITLE_FIX_SCRIPT_PATH` | (Optional) Path to the script used for the Printify API Title Fix step. Defaults to `scripts/printifyTitleFix.js` |

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -627,9 +627,7 @@ const queueDataPath = path.join(__dirname, "../printifyQueue.json");
 const printifyQueue = new PrintifyJobQueue(jobManager, {
   uploadsDir,
   persistencePath: queueDataPath,
-  upscaleScript:
-    process.env.UPSCALE_SCRIPT_PATH ||
-    path.join(__dirname, "../scripts/upscale.js"),
+  upscaleScript: path.join(__dirname, "../scripts/upscale.js"),
   printifyScript:
     process.env.PRINTIFY_SCRIPT_PATH ||
     "/home/admin/Puppets/PrintifyPuppet/run.sh",
@@ -2231,9 +2229,7 @@ app.post("/api/upscale", async (req, res) => {
       return res.status(403).json({ error: "upscale restricted" });
     }
 
-    const scriptPath =
-      process.env.UPSCALE_SCRIPT_PATH ||
-      path.join(__dirname, "../scripts/upscale.js");
+    const scriptPath = path.join(__dirname, "../scripts/upscale.js");
     console.debug(
       "[Server Debug] /api/upscale => using scriptPath =>",
       scriptPath
@@ -2260,9 +2256,7 @@ app.post("/api/upscale", async (req, res) => {
       );
       return res
         .status(500)
-        .json({
-          error: `Upscale script missing. Expected at ${scriptPath} (set UPSCALE_SCRIPT_PATH to override).`,
-        });
+        .json({ error: `Upscale script missing at ${scriptPath}` });
     }
 
     console.debug('[Server Debug] launching upscale job with script =>', scriptPath);


### PR DESCRIPTION
## Summary
- default to built-in Stability AI upscaler
- update docs and env example

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685f448df9608323922dd5e61760bf9e