### PR TITLE
Fix default RIBT script path

### DIFF
--- a/Aurora/scripts/upscale.js
+++ b/Aurora/scripts/upscale.js
@@ -32,7 +32,7 @@ const nobgPath = path.join(path.dirname(inputPath), `${base}_upscaled_nobg${ext}
 
 const RIBT_SCRIPT =
   process.env.RIBT_SCRIPT_PATH ||
-  '/mnt/part5/dot_fayra/Whimsical/git/LogisticaRIBT/run.sh';
+  '/home/admin/git/LogisticaRIBT/run.sh';
 const ribtCwd = path.dirname(RIBT_SCRIPT);
 const ribtOutput = path.join(ribtCwd, 'output.png');
 

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2276,7 +2276,7 @@ app.post("/api/upscale", async (req, res) => {
         // RIBT step
         const ribtScript =
           process.env.RIBT_SCRIPT_PATH ||
-          '/mnt/part5/dot_fayra/Whimsical/git/LogisticaRIBT/run.sh';
+          '/home/admin/git/LogisticaRIBT/run.sh';
         const ribtCwd = path.dirname(ribtScript);
         const ribtOutput = path.join(ribtCwd, 'output.png');
         try {


### PR DESCRIPTION
## Summary
- correct default path to `run.sh` in server and CLI script

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685f4e4c09cc8323809b315e5e434a33