### PR TITLE
Add ProgramaticPuppet steps

### DIFF
--- a/Aurora/.env.example
+++ b/Aurora/.env.example
@@ -22,6 +22,8 @@ GITHUB_REPO=yourRepo
 # PRINTIFY_PRICE_SCRIPT_PATH=/path/to/run_price.sh
 # Path to the Printify title fix script (optional)
 # PRINTIFY_TITLE_FIX_SCRIPT_PATH=./scripts/printifyTitleFix.js
+# Base URL for the ProgramaticPuppet API (optional)
+# PROGRAMATIC_PUPPET_API_BASE=https://localhost:3005
 # Printify API credentials
 # PRINTIFY_API_TOKEN=yourToken
 # Alternatively you can use the older PRINTIFY_TOKEN variable

--- a/Aurora/README.md
+++ b/Aurora/README.md
@@ -24,6 +24,7 @@ npm start
 | `PRINTIFY_SCRIPT_PATH` | (Optional) Path to the Printify submission script. Defaults to the included run.sh |
 | `PRINTIFY_PRICE_SCRIPT_PATH` | (Optional) Path to the Printify price update script. Defaults to `/home/admin/Puppets/PrintifyPricePuppet/run.sh` |
 | `PRINTIFY_TITLE_FIX_SCRIPT_PATH` | (Optional) Path to the script used for the Printify API Title Fix step. Defaults to `scripts/printifyTitleFix.js` |
+| `PROGRAMATIC_PUPPET_API_BASE` | (Optional) Base URL for the ProgramaticPuppet API used for Fix Mockups and Finalize steps (default: `https://localhost:3005`) |
 | `PRINTIFY_API_TOKEN` | (Optional) API token for Printify REST API (legacy `PRINTIFY_TOKEN` also supported) |
 | `PRINTIFY_SHOP_ID` | (Optional) Shop ID for Printify API requests |
 | `STABLE_DIFFUSION_URL` | (Optional) Base URL for a self-hosted Stable Diffusion API |

--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -64,6 +64,8 @@
         <option value="upscale">Upscale</option>
         <option value="printify">Printify</option>
         <option value="printifyTitleFix">Printify Title Fix</option>
+        <option value="printifyFixMockups">Printify Fix Mockups</option>
+        <option value="printifyFinalize">Printify Finalize</option>
         <option value="all">All</option>
       </select>
     </label>
@@ -169,7 +171,7 @@
             optionsDiv.style.display = 'none';
             updatePreview(f.name);
             const type = document.getElementById('jobType').value;
-            if(type === 'printify' || type === 'printifyPrice' || type === 'printifyTitleFix' || type === 'all'){
+            if(type === 'printify' || type === 'printifyPrice' || type === 'printifyTitleFix' || type === 'printifyFixMockups' || type === 'printifyFinalize' || type === 'all'){
               updateVariantUI(f.name);
             }
           });
@@ -200,7 +202,7 @@
 
     document.getElementById('jobType').addEventListener('change', () => {
       const type = document.getElementById('jobType').value;
-      if(type === 'printify' || type === 'printifyPrice' || type === 'printifyTitleFix' || type === 'all'){
+      if(type === 'printify' || type === 'printifyPrice' || type === 'printifyTitleFix' || type === 'printifyFixMockups' || type === 'printifyFinalize' || type === 'all'){
         updateVariantUI(document.getElementById('imageSelect').dataset.value);
       } else {
         document.getElementById('variantChoice').style.display = 'none';
@@ -264,7 +266,7 @@ async function updateVariantUI(file){
       if(!file) return;
       try{
         if(type === 'all'){
-          const steps = ['upscale','printify','printifyTitleFix'];
+          const steps = ['upscale','printify','printifyTitleFix','printifyFixMockups','printifyFinalize'];
           for(const step of steps){
             await fetch('/api/pipelineQueue', {
               method: 'POST',

--- a/Aurora/scripts/runPuppet.js
+++ b/Aurora/scripts/runPuppet.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import axios from 'axios';
+import https from 'https';
+
+const base = process.env.PROGRAMATIC_PUPPET_API_BASE || 'https://localhost:3005';
+const puppet = process.argv[2];
+const productUrl = process.argv[3];
+
+if (!puppet) {
+  console.error('Usage: runPuppet.js <puppetName> [productUrl]');
+  process.exit(1);
+}
+
+const agent = base.startsWith('https://')
+  ? new https.Agent({ rejectUnauthorized: false })
+  : undefined;
+
+(async () => {
+  try {
+    const resp = await axios.post(
+      base + '/runPuppet',
+      productUrl ? { puppetName: puppet, printifyProductURL: productUrl } : { puppetName: puppet },
+      { responseType: 'stream', httpsAgent: agent }
+    );
+    await new Promise((resolve, reject) => {
+      resp.data.on('data', chunk => process.stdout.write(chunk));
+      resp.data.on('end', resolve);
+      resp.data.on('error', reject);
+    });
+  } catch (err) {
+    console.error('Failed to run puppet:', err.message || err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- allow Aurora to run additional ProgramaticPuppet tasks
- include new API base env var in docs
- extend pipeline job queue for extra steps
- support FixMockups and Finalize in Printify queue
- wire up server endpoints
- add script to call ProgramaticPuppet API

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685f52330d9483238c79e3177631b4b3