### PR TITLE
Add verbose debugging to PrintifyFixMockups

### DIFF
--- a/Aurora/scripts/runPuppet.js
+++ b/Aurora/scripts/runPuppet.js
@@ -6,6 +6,10 @@ const base = process.env.PROGRAMATIC_PUPPET_API_BASE || 'https://localhost:3005'
 const puppet = process.argv[2];
 const productUrl = process.argv[3];
 
+console.debug('[RunPuppet Debug] Base URL =>', base);
+console.debug('[RunPuppet Debug] Puppet =>', puppet);
+if (productUrl) console.debug('[RunPuppet Debug] Product URL =>', productUrl);
+
 if (!puppet) {
   console.error('Usage: runPuppet.js <puppetName> [productUrl]');
   process.exit(1);
@@ -29,6 +33,19 @@ const agent = base.startsWith('https://')
     });
   } catch (err) {
     console.error('Failed to run puppet:', err.message || err);
+    if (err.response) {
+      console.error('[RunPuppet Debug] Response status:', err.response.status);
+      if (err.response.data) {
+        const data =
+          typeof err.response.data === 'string'
+            ? err.response.data
+            : JSON.stringify(err.response.data);
+        console.error('[RunPuppet Debug] Response body:', data);
+      }
+    }
+    if (err.stack) {
+      console.error('[RunPuppet Debug] Stack:', err.stack);
+    }
     process.exit(1);
   }
 })();

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -229,6 +229,7 @@ export default class PrintifyJobQueue {
       }
       if (url) {
         job.productUrl = url;
+        console.debug('[PrintifyJobQueue Debug] Resolved productUrl =>', url);
         if (job.type === 'printifyPrice' || job.type === 'printifyFixMockups' || job.type === 'printifyFinalize') {
           args.push(url);
         } else {
@@ -252,6 +253,7 @@ export default class PrintifyJobQueue {
       args.push(filePath);
     }
     console.log(`[PrintifyJobQueue] Running ${job.type} with script: ${script}`);
+    console.debug('[PrintifyJobQueue Debug] args =>', args.join(' '));
     const jmJob = this.jobManager.createJob(script, args, { cwd, file: job.file });
     job.jobId = jmJob.id;
     this.jobManager.addDoneListener(jmJob, () => {

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2606,11 +2606,17 @@ app.post("/api/printifyFixMockups", async (req, res) => {
     const { file } = req.body || {};
     if (!file) return res.status(400).json({ error: "Missing file" });
 
+    console.debug("[Server Debug] /api/printifyFixMockups called with file =>", file);
+
     let productUrl = db.getProductUrlForImage(`/uploads/${file}`);
     if (!productUrl) {
       const status = db.getImageStatusForUrl(`/uploads/${file}`);
       productUrl = extractPrintifyUrl(status || "");
     }
+    console.debug(
+      "[Server Debug] /api/printifyFixMockups resolved productUrl =>",
+      productUrl
+    );
     if (!productUrl) return res.status(400).json({ error: "Missing Printify URL" });
 
     const scriptPath = path.join(__dirname, "../scripts/runPuppet.js");
@@ -2618,6 +2624,8 @@ app.post("/api/printifyFixMockups", async (req, res) => {
     if (!fs.existsSync(scriptPath)) {
       return res.status(500).json({ error: `Puppet script missing at ${scriptPath}` });
     }
+
+    console.debug("[Server Debug] /api/printifyFixMockups running script =>", scriptPath);
 
     const job = jobManager.createJob(scriptPath, ["PrintifyFixMockups", productUrl], { cwd: scriptCwd, file });
     jobManager.addDoneListener(job, () => {


### PR DESCRIPTION
## Summary
- add debug logging to `runPuppet.js`
- log parameters in `/api/printifyFixMockups`
- log product URLs and arguments within `PrintifyJobQueue`

## Testing
- `npm run lint` in `Aurora`
- `npm test` in `AutoPR`
- `npm test` in `VMRunner` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_685f56c0fc108323a22bdaa3670cb37c