### PR TITLE
Add row borders to pipeline queue table

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -97,7 +97,7 @@
     <button id="enqueueBtn">Add to Queue</button>
     <button id="stopAllBtn" style="margin-left:0.5rem;">Stop All</button>
   </div>
-  <table id="queueTable" style="width:100%;border-collapse:collapse;">
+  <table id="queueTable">
     <thead>
       <tr>
         <th>ID</th>

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -853,6 +853,25 @@ body {
 }
 
 
+/* Pipeline queue table */
+#queueTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+}
+
+#queueTable th,
+#queueTable td {
+  border: 1px solid #444;
+  padding: 4px 6px;
+}
+
+#queueTable th {
+  background: #3a3a3a;
+  text-align: left;
+}
+
+
 
 /* New gear icon for the Markdown area */
 #markdownGearIcon {

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -856,6 +856,25 @@ body {
 }
 
 
+/* Pipeline queue table */
+#queueTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+}
+
+#queueTable th,
+#queueTable td {
+  border: 1px solid #aaa;
+  padding: 4px 6px;
+}
+
+#queueTable th {
+  background: #ddd;
+  text-align: left;
+}
+
+
 
 /* New gear icon for the Markdown area */
 #markdownGearIcon {


### PR DESCRIPTION
## Summary
- style queue table rows with borders in pipeline_queue.html
- remove inline styling from table element

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685f5e47a400832386240e16bd306723