### PR TITLE
Remove queue table borders

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -862,8 +862,16 @@ body {
 
 #queueTable th,
 #queueTable td {
-  border: 1px solid #444;
+  border: none;
   padding: 4px 6px;
+}
+
+#queueTable tbody tr:nth-child(odd) {
+  background-color: #2b2b2b;
+}
+
+#queueTable tbody tr:nth-child(even) {
+  background-color: #242424;
 }
 
 #queueTable th {

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -865,8 +865,16 @@ body {
 
 #queueTable th,
 #queueTable td {
-  border: 1px solid #aaa;
+  border: none;
   padding: 4px 6px;
+}
+
+#queueTable tbody tr:nth-child(odd) {
+  background-color: #f0f0f0;
+}
+
+#queueTable tbody tr:nth-child(even) {
+  background-color: #e6e6e6;
 }
 
 #queueTable th {


### PR DESCRIPTION
## Summary
- make queue table rows alternate colors for readability
- remove cell borders from the queue table

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685f607b01c0832384942de678785455