### PR TITLE
Add eBay URL column for images

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -128,6 +128,7 @@
             <th data-col="source">Source</th>
             <th data-col="status">Status</th>
             <th data-col="productUrl">Printify URL</th>
+            <th data-col="ebayUrl">eBay URL</th>
             <th data-col="portfolio">Portfolio</th>
             <th data-col="size">Size (KB)</th>
             <th data-col="mtime">Last Modified</th>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3418,7 +3418,7 @@ function sortFileData(){
   fileListData.sort((a,b)=>{
     let va=a[fileSortColumn];
     let vb=b[fileSortColumn];
-    if(fileSortColumn==='name' || fileSortColumn==='productUrl'){
+    if(fileSortColumn==='name' || fileSortColumn==='productUrl' || fileSortColumn==='ebayUrl'){
       va = (va||'').toLowerCase();
       vb = (vb||'').toLowerCase();
     }
@@ -3470,6 +3470,16 @@ function renderFileList(){
       tdProductUrl.appendChild(link);
     } else {
       tdProductUrl.textContent = "";
+    }
+    const tdEbayUrl = document.createElement("td");
+    if(f.ebayUrl){
+      const link = document.createElement("a");
+      link.href = f.ebayUrl;
+      link.textContent = f.ebayUrl;
+      link.target = "_blank";
+      tdEbayUrl.appendChild(link);
+    } else {
+      tdEbayUrl.textContent = "";
     }
     const tdPortfolio = document.createElement("td");
     const portCheck = document.createElement("input");
@@ -3528,6 +3538,25 @@ function renderFileList(){
       }
     });
     tdAction.appendChild(urlBtn);
+    const ebayBtn = document.createElement("button");
+    ebayBtn.textContent = "Set eBay";
+    ebayBtn.addEventListener("click", async () => {
+      const current = f.ebayUrl || "";
+      const url = prompt("Enter eBay Listing URL:", current);
+      if(!url) return;
+      try{
+        await fetch('/api/upload/status', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: f.name, ebayUrl: url })
+        });
+        await loadFileList();
+      }catch(err){
+        console.error('Failed to set eBay URL =>', err);
+        alert('Failed to set eBay URL');
+      }
+    });
+    tdAction.appendChild(ebayBtn);
     tr.appendChild(tdIndex);
     tr.appendChild(tdId);
     tr.appendChild(tdThumb);
@@ -3536,6 +3565,7 @@ function renderFileList(){
     tr.appendChild(tdSource);
     tr.appendChild(tdStatus);
     tr.appendChild(tdProductUrl);
+    tr.appendChild(tdEbayUrl);
     tr.appendChild(tdPortfolio);
     tr.appendChild(tdSize);
     tr.appendChild(tdMtime);

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2104,7 +2104,8 @@ app.get("/api/upload/list", (req, res) => {
       const status = db.getImageStatusForUrl(`/uploads/${name}`) || (source === 'Generated' ? 'Generated' : 'Uploaded');
       const portfolio = db.getImagePortfolioForUrl(`/uploads/${name}`) ? 1 : 0;
       const productUrl = db.getProductUrlForImage(`/uploads/${name}`);
-      files.push({ id, uuid, name, size, mtime, title, source, status, portfolio, productUrl });
+      const ebayUrl = db.getEbayUrlForImage(`/uploads/${name}`);
+      files.push({ id, uuid, name, size, mtime, title, source, status, portfolio, productUrl, ebayUrl });
     }
     res.json(files);
   } catch (err) {
@@ -2152,7 +2153,7 @@ app.get("/api/upload/byId", (req, res) => {
 
 app.post("/api/upload/status", (req, res) => {
   try {
-    const { name, status, productUrl } = req.body || {};
+    const { name, status, productUrl, ebayUrl } = req.body || {};
     if(!name){
       return res.status(400).json({ error: "Missing name" });
     }
@@ -2162,6 +2163,9 @@ app.post("/api/upload/status", (req, res) => {
     }
     if(productUrl !== undefined){
       db.setProductUrl(url, productUrl || "");
+    }
+    if(ebayUrl !== undefined){
+      db.setEbayUrl(url, ebayUrl || "");
     }
     res.json({ success: true });
   } catch(err){


### PR DESCRIPTION
## Summary
- extend `chat_pairs` table with `ebay_url`
- expose the new field via `/api/upload/list` and `/api/upload/status`
- support eBay URLs in the DB layer
- update the uploader UI to show and edit eBay links

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685f71d652a883238ff7366e38c6f01a