### PR TITLE
Fix matchAll usage in printify utils

### DIFF
--- a/Aurora/src/printifyUtils.js
+++ b/Aurora/src/printifyUtils.js
@@ -13,7 +13,8 @@ export function extractPrintifyUrl(status = '') {
 
 export function extractUpdatedTitle(log = '') {
   if (!log) return null;
-  const matches = [...log.matchAll(/Updated Title:\s*(.+)/i)];
+  // use a global regex so matchAll retrieves all occurrences
+  const matches = [...log.matchAll(/Updated Title:\s*(.+)/gi)];
   const m = matches[matches.length - 1];
   return m ? m[1].trim() : null;
 }


### PR DESCRIPTION
## Summary
- ensure `extractUpdatedTitle` uses a global regex so `matchAll` works

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685f8833c2388323a4c0ec432996eec6