### PR TITLE
Sort queue dropdown by recency

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -21,7 +21,7 @@
       background-color: #222;
     }
     .img-dropdown .selected img {
-      max-height: 120px;
+      max-height: 240px;
     }
     .img-dropdown .options {
       position: absolute;
@@ -30,7 +30,7 @@
       top: 100%;
       background-color: #222;
       border: 1px solid #444;
-      max-height: 300px;
+      max-height: 600px;
       overflow-y: auto;
       width: 400px;
       z-index: 1000;
@@ -43,7 +43,7 @@
       gap: 0.5rem;
     }
     .img-dropdown .option img {
-      max-height: 120px;
+      max-height: 240px;
     }
     .img-dropdown .option:hover {
       background-color: #333;
@@ -161,6 +161,7 @@
       try{
         const res = await fetch('/api/upload/list?sessionId=' + encodeURIComponent(sessionId));
         const files = await res.json();
+        files.sort((a,b) => b.mtime - a.mtime);
         optionsDiv.innerHTML = '';
         dropdown.dataset.value = '';
         dropdown.dataset.id = '';


### PR DESCRIPTION
## Summary
- show latest uploads first in the queue image selector
- enlarge dropdown preview sizes and its scroll area

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685f8a346ff08323b08276aadecb2828