### PR TITLE
Fix background removal duplication

### DIFF
--- a/Aurora/scripts/upscale.js
+++ b/Aurora/scripts/upscale.js
@@ -62,7 +62,6 @@ async function upscale() {
     child_process.execFileSync(RIBT_SCRIPT, [outputPath], { cwd: ribtCwd });
     if (fs.existsSync(ribtOutput)) {
       fs.copyFileSync(ribtOutput, nobgPath);
-      fs.copyFileSync(ribtOutput, outputPath);
       console.log(`Background removed output saved to: ${nobgPath}`);
     } else {
       console.error('RIBT output not found at', ribtOutput);

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2304,14 +2304,14 @@ app.post("/api/upscale", async (req, res) => {
             // Copy final
             const upscaleName = `${dbId || base}_upscale${ext}`;
             const upscaleDest = path.join(uploadsDir, upscaleName);
-            const ribtCopySrc = ribtOutput;
-            if (fs.existsSync(ribtCopySrc)) {
-              fs.copyFileSync(ribtCopySrc, upscaleDest);
+            const originalUpscaledSrc = job.resultPath;
+            if (fs.existsSync(originalUpscaledSrc)) {
+              fs.copyFileSync(originalUpscaledSrc, upscaleDest);
               job.resultPath = upscaleDest;
               console.debug('[Server Debug] Copied final upscale to =>', upscaleDest);
               db.setUpscaledImage(originalUrl, upscaleDest);
             } else {
-              console.debug('[Server Debug] Expected upscale output not found at', ribtCopySrc);
+              console.debug('[Server Debug] Expected upscale output not found at', originalUpscaledSrc);
             }
           } else {
             console.debug('[Server Debug] RIBT output not found at', ribtOutput);


### PR DESCRIPTION
## Summary
- preserve the original upscaled image when removing backgrounds
- copy the no-background image separately

## Testing
- `npm run lint` in `Aurora`
- `npm test` in `Aurora` *(fails: Missing script)*
- `npm test` in `Sterling` *(fails: Missing script)*
- `npm test` in `PriceScript` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685f8aec34408323913cce57cb86e62f