### PR TITLE
Add remove-all action per DB ID

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -132,8 +132,12 @@
             seen.add(job.dbId);
             const groupTr = document.createElement('tr');
             groupTr.className = 'db-group';
-            groupTr.innerHTML = `<td colspan="9">DB ID: ${job.dbId}</td>`;
+            groupTr.innerHTML = `<td colspan="9">DB ID: ${job.dbId} <button class="removeDbBtn" data-dbid="${job.dbId}" style="margin-left:0.5rem;">Remove All</button></td>`;
             tbody.appendChild(groupTr);
+            groupTr.querySelector('.removeDbBtn').addEventListener('click', async () => {
+              if(!confirm(`Remove all jobs for DB ID ${job.dbId}?`)) return;
+              await removeJobsByDbId(job.dbId);
+            });
           }
 
           const tr = document.createElement('tr');
@@ -343,6 +347,15 @@ async function updateVariantUI(file){
         await loadQueue();
       }catch(e){
         console.error('Failed to remove job', e);
+      }
+    }
+
+    async function removeJobsByDbId(dbId){
+      try{
+        await fetch(`/api/pipelineQueue/db/${encodeURIComponent(dbId)}`, { method: 'DELETE' });
+        await loadQueue();
+      }catch(e){
+        console.error('Failed to remove jobs', e);
       }
     }
 

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -97,6 +97,28 @@ export default class PrintifyJobQueue {
     return true;
   }
 
+  removeByDbId(dbId) {
+    let removed = false;
+    for (let i = this.jobs.length - 1; i >= 0; i--) {
+      const job = this.jobs[i];
+      if (job.dbId === dbId) {
+        if (job.status === 'running' && job.jobId) {
+          this.jobManager.stopJob(job.jobId);
+        }
+        this.jobs.splice(i, 1);
+        if (this.current && this.current.id === job.id) {
+          this.current = null;
+        }
+        removed = true;
+      }
+    }
+    if (removed) {
+      this._saveJobs();
+      this._processNext();
+    }
+    return removed;
+  }
+
   stopAll() {
     for (const job of this.jobs) {
       if (job.status === 'running' && job.jobId) {

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2787,6 +2787,12 @@ app.delete("/api/pipelineQueue/:id", (req, res) => {
   res.json({ removed: true });
 });
 
+app.delete("/api/pipelineQueue/db/:dbId", (req, res) => {
+  const ok = printifyQueue.removeByDbId(req.params.dbId);
+  if (!ok) return res.status(404).json({ error: "Jobs not found" });
+  res.json({ removed: true });
+});
+
 app.post("/api/pipelineQueue/stopAll", (req, res) => {
   printifyQueue.stopAll();
   res.json({ stopped: true });


### PR DESCRIPTION
## Summary
- allow bulk removal of jobs in pipeline queue by DB ID
- add Remove All button to the DB ID header
- expose API to remove jobs by DB ID

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685f95dde2fc8323ad9dd688dc9d497b