### PR TITLE
Remove confirmation prompt

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -135,7 +135,6 @@
             groupTr.innerHTML = `<td colspan="9">DB ID: ${job.dbId} <button class="removeDbBtn" data-dbid="${job.dbId}" style="margin-left:0.5rem;">Remove All</button></td>`;
             tbody.appendChild(groupTr);
             groupTr.querySelector('.removeDbBtn').addEventListener('click', async () => {
-              if(!confirm(`Remove all jobs for DB ID ${job.dbId}?`)) return;
               await removeJobsByDbId(job.dbId);
             });
           }


### PR DESCRIPTION
## Summary
- remove the browser confirmation dialog when clicking "Remove All" in the pipeline queue

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685f98f0adf08323ad09f45e355c5d48