### PR TITLE
Add eBay check daemon

### DIFF
--- a/Aurora/.env.example
+++ b/Aurora/.env.example
@@ -57,3 +57,8 @@ GITHUB_REPO=yourRepo
 
 # Optional IP address allowed to access the web UI
 # WHITELIST_IP=1.2.3.4
+
+# eBay store URL to monitor for new listings
+# EBAY_STORE_URL=https://www.ebay.com/sch/11450/i.html?_dkr=1&iconV2Request=true&_blrs=recall_filtering&_ssn=confused_apparel&_oac=1&_sop=10
+# Optional check interval in ms (defaults to 300000)
+# EBAY_CHECK_INTERVAL_MS=300000

--- a/Aurora/package.json
+++ b/Aurora/package.json
@@ -22,8 +22,8 @@
     "multer": "^1.4.5-lts.1",
     "openai": "^4.7.1",
     "tiktoken": "^1.0.4",
-    "speakeasy": "^2.0.0"
-    ,
+    "speakeasy": "^2.0.0",
+    "cheerio": "^1.0.0-rc.12",
     "pg": "^8.11.3"
   }
 }

--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -77,6 +77,7 @@
         <option value="printifyTitleFix">Printify Title Fix</option>
         <option value="printifyFixMockups">Printify Fix Mockups</option>
         <option value="printifyFinalize">Printify Finalize</option>
+        <option value="ebayCheck">eBay Check</option>
         <option value="all">All</option>
       </select>
     </label>
@@ -210,7 +211,7 @@
             optionsDiv.style.display = 'none';
             updatePreview(f.name);
             const type = document.getElementById('jobType').value;
-            if(type === 'printify' || type === 'printifyPrice' || type === 'printifyTitleFix' || type === 'printifyFixMockups' || type === 'printifyFinalize' || type === 'all'){
+            if(type === 'printify' || type === 'printifyPrice' || type === 'printifyTitleFix' || type === 'printifyFixMockups' || type === 'printifyFinalize' || type === 'ebayCheck' || type === 'all'){
               updateVariantUI(f.name);
             }
           });
@@ -253,7 +254,7 @@
 
     document.getElementById('jobType').addEventListener('change', () => {
       const type = document.getElementById('jobType').value;
-      if(type === 'printify' || type === 'printifyPrice' || type === 'printifyTitleFix' || type === 'printifyFixMockups' || type === 'printifyFinalize' || type === 'all'){
+      if(type === 'printify' || type === 'printifyPrice' || type === 'printifyTitleFix' || type === 'printifyFixMockups' || type === 'printifyFinalize' || type === 'ebayCheck' || type === 'all'){
         updateVariantUI(document.getElementById('imageSelect').dataset.value);
       } else {
         document.getElementById('variantChoice').style.display = 'none';
@@ -320,7 +321,7 @@ async function updateVariantUI(file){
       if(!file) return;
       try{
         if(type === 'all'){
-          const steps = ['upscale','printify','printifyTitleFix','printifyFixMockups','printifyFinalize'];
+          const steps = ['upscale','printify','printifyTitleFix','printifyFixMockups','printifyFinalize','ebayCheck'];
           for(const step of steps){
             await fetch('/api/pipelineQueue', {
               method: 'POST',

--- a/Aurora/scripts/ebayCheck.js
+++ b/Aurora/scripts/ebayCheck.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+import axios from 'axios';
+import dotenv from 'dotenv';
+import path from 'path';
+import cheerio from 'cheerio';
+import TaskDBLocal from '../src/taskDb.js';
+import TaskDBAws from '../src/taskDbAws.js';
+
+dotenv.config();
+
+const useRds = process.env.AWS_DB_URL || process.env.AWS_DB_HOST;
+const TaskDB = useRds ? TaskDBAws : TaskDBLocal;
+const db = new TaskDB();
+
+const storeUrl =
+  process.env.EBAY_STORE_URL ||
+  'https://www.ebay.com/sch/11450/i.html?_dkr=1&iconV2Request=true&_blrs=recall_filtering&_ssn=confused_apparel&_oac=1&_sop=10';
+const interval = parseInt(process.env.EBAY_CHECK_INTERVAL_MS || '300000', 10);
+
+const file = process.argv[2];
+if (!file) {
+  console.error('Usage: ebayCheck.js <file>');
+  process.exit(1);
+}
+
+function getTitle(file) {
+  const url = path.isAbsolute(file) ? file : `/uploads/${file}`;
+  return db.getImageTitleForUrl(url);
+}
+
+async function searchEbay(title) {
+  const { data } = await axios.get(storeUrl);
+  const $ = cheerio.load(data);
+  const items = $('li.s-item');
+  for (const el of items) {
+    const itemTitle = $(el).find('.s-item__title').text().trim();
+    if (itemTitle.toLowerCase() === title.trim().toLowerCase()) {
+      const link = $(el).find('.s-item__link').attr('href');
+      if (link) return link;
+    }
+  }
+  return null;
+}
+
+async function run() {
+  const title = getTitle(file);
+  if (!title) {
+    console.error('No title found for', file);
+    return;
+  }
+  const urlKey = path.isAbsolute(file) ? file : `/uploads/${file}`;
+  while (true) {
+    try {
+      const ebayUrl = await searchEbay(title);
+      if (ebayUrl) {
+        db.setEbayUrl(urlKey, ebayUrl);
+        console.log('EBAY_URL:', ebayUrl);
+        break;
+      }
+    } catch (err) {
+      console.error('eBay search error:', err.message || err);
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+}
+
+run();

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -14,6 +14,7 @@ export default class PrintifyJobQueue {
     this.printifyPriceScript = options.printifyPriceScript || '';
     this.printifyTitleFixScript = options.printifyTitleFixScript || '';
     this.runPuppetScript = options.runPuppetScript || '';
+    this.ebayCheckScript = options.ebayCheckScript || '';
     this.db = options.db || null;
     this.persistencePath = options.persistencePath || null;
 
@@ -215,6 +216,8 @@ export default class PrintifyJobQueue {
         if (nobgFound) filePath = nobgFound;
         else if (normalFound) filePath = normalFound;
       }
+    } else if (job.type === 'ebayCheck') {
+      script = this.ebayCheckScript;
     } else {
       job.status = 'error';
       this.current = null;
@@ -339,10 +342,14 @@ export default class PrintifyJobQueue {
           printifyPrice: 'Printify API Updates',
           printifyTitleFix: 'Printify API Title Fix',
           printifyFixMockups: 'Printify Fix Mockups',
-          printifyFinalize: 'Printify Finalize'
+          printifyFinalize: 'Printify Finalize',
+          ebayCheck: 'eBay Check'
         };
         const status = statusMap[job.type] || job.type;
         this.db.setImageStatus(originalUrl, status);
+        if (job.type === 'printifyFinalize' && this.ebayCheckScript) {
+          this.enqueue(job.file, 'ebayCheck', job.dbId);
+        }
       }
       this.current = null;
       this._saveJobs();

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -638,6 +638,7 @@ const printifyQueue = new PrintifyJobQueue(jobManager, {
     process.env.PRINTIFY_TITLE_FIX_SCRIPT_PATH ||
     path.join(__dirname, "../scripts/printifyTitleFix.js"),
   runPuppetScript: path.join(__dirname, "../scripts/runPuppet.js"),
+  ebayCheckScript: path.join(__dirname, "../scripts/ebayCheck.js"),
   db,
 });
 


### PR DESCRIPTION
## Summary
- add ebayCheck daemon script
- integrate ebayCheck job into job queue and server
- expose ebay config options in `.env.example`
- update pipeline UI for ebayCheck job
- refine ebayCheck to scrape seller store page instead of using API

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_685fa133bde8832392277b6dbf3d9e17