### PR TITLE
Add loading spinner to queue image selector

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -56,6 +56,10 @@
       cursor: pointer;
       padding: 2px 4px;
     }
+    .img-dropdown .loading-more {
+      text-align: center;
+      padding: 4px;
+    }
     .upscaled-label {
       color: cyan;
       margin-left: 0.25rem;
@@ -91,7 +95,9 @@
     <label>Image:
       <div id="imageSelect" class="img-dropdown">
         <div class="selected">-- choose --</div>
-        <div class="options"></div>
+        <div class="options">
+          <div class="loading-more"><span class="loading-spinner"></span></div>
+        </div>
       </div>
     </label>
     <img id="imagePreview" style="display:none;max-height:80px;border:1px solid #444;" />
@@ -181,6 +187,7 @@
     const dropdown = document.getElementById('imageSelect');
     const selectedDiv = dropdown.querySelector('.selected');
     const optionsDiv = dropdown.querySelector('.options');
+    const loadingDiv = optionsDiv.querySelector('.loading-more');
 
     let imgOffset = 0;
     let imgHasMore = true;
@@ -191,13 +198,14 @@
       if(reset){
         imgOffset = 0;
         imgHasMore = true;
-        optionsDiv.innerHTML = '';
+        optionsDiv.querySelectorAll('.option').forEach(o => o.remove());
         dropdown.dataset.value = '';
         dropdown.dataset.id = '';
         selectedDiv.textContent = '-- choose --';
       }
       if(!imgHasMore) return;
       imgLoading = true;
+      loadingDiv.style.display = 'block';
       try{
         const res = await fetch('/api/upload/list?sessionId=' + encodeURIComponent(sessionId) + `&limit=20&offset=${imgOffset}&showHidden=0`);
         const files = await res.json();
@@ -243,6 +251,7 @@
         console.error('Failed to load images', e);
       }
       imgLoading = false;
+      loadingDiv.style.display = 'none';
     }
 
     dropdown.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add a hidden loader element in the image dropdown
- show the loader while fetching more images

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685fa8b01a988323a0f29afceea84e80