### PR TITLE
Default 4096 no-bg variant when missing

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -318,6 +318,9 @@ async function updateVariantUI(file){
       choiceDiv.style.display = '';
       if(nbPath){
         nobgRadio.checked = true;
+      } else if(type === 'all'){
+        nobgRadio.checked = true;
+        normalRadio.checked = false;
       } else if(upPath){
         normalRadio.checked = true;
       } else {


### PR DESCRIPTION
## Summary
- default to the no-background option when no variant exists and it will be generated

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_685faa9a141c8323820cc299e25a4911