### PR TITLE
Add start/finish times to production queue UI

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -121,6 +121,8 @@
         <th>Job ID</th>
         <th>Result Path</th>
         <th>Product URL</th>
+        <th>Start Time</th>
+        <th>Finish Time</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -140,7 +142,7 @@
             seen.add(job.dbId);
             const groupTr = document.createElement('tr');
             groupTr.className = 'db-group';
-            groupTr.innerHTML = `<td colspan="9">DB ID: ${job.dbId} <button class="removeDbBtn" data-dbid="${job.dbId}" style="margin-left:0.5rem;">Remove All</button></td>`;
+            groupTr.innerHTML = `<td colspan="11">DB ID: ${job.dbId} <button class="removeDbBtn" data-dbid="${job.dbId}" style="margin-left:0.5rem;">Remove All</button></td>`;
             tbody.appendChild(groupTr);
             groupTr.querySelector('.removeDbBtn').addEventListener('click', async () => {
               await removeJobsByDbId(job.dbId);
@@ -158,6 +160,8 @@
             if(job.status === 'failed' || job.status === 'error') return '<span class="status-failed">Failed</span>';
             return job.status;
           })();
+          const startHtml = job.startTime ? new Date(job.startTime).toLocaleString() : '';
+          const finishHtml = job.finishTime ? new Date(job.finishTime).toLocaleString() : '';
           tr.innerHTML = `
             <td>${job.id}</td>
             <td>${dbLink}</td>
@@ -167,6 +171,8 @@
             <td>${jobLink}</td>
             <td>${job.resultPath || ''}</td>
             <td>${job.productUrl ? `<a href="${job.productUrl}" target="_blank">${job.productUrl}</a>` : ''}</td>
+            <td>${startHtml}</td>
+            <td>${finishHtml}</td>
             <td><button data-id="${job.id}" class="removeBtn">Remove</button></td>
           `;
           tbody.appendChild(tr);

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -28,6 +28,8 @@ export default class PrintifyJobQueue {
       if (Array.isArray(data.jobs)) {
         this.jobs = data.jobs.map(j => {
           if (j.status === 'running') j.status = 'queued';
+          if (!('startTime' in j)) j.startTime = null;
+          if (!('finishTime' in j)) j.finishTime = null;
           return j;
         });
       }
@@ -59,7 +61,9 @@ export default class PrintifyJobQueue {
       resultPath: null,
       productUrl: null,
       dbId,
-      variant
+      variant,
+      startTime: null,
+      finishTime: null
     };
     this.jobs.push(job);
     this._saveJobs();
@@ -77,7 +81,9 @@ export default class PrintifyJobQueue {
       resultPath: j.resultPath || null,
       productUrl: j.productUrl || null,
       dbId: j.dbId || null,
-      variant: j.variant || null
+      variant: j.variant || null,
+      startTime: j.startTime || null,
+      finishTime: j.finishTime || null
     }));
   }
 
@@ -136,6 +142,8 @@ export default class PrintifyJobQueue {
     if (!job) return;
     this.current = job;
     job.status = 'running';
+    job.startTime = Date.now();
+    job.finishTime = null;
     this._saveJobs();
 
     let filePath = path.isAbsolute(job.file)
@@ -332,6 +340,7 @@ export default class PrintifyJobQueue {
           this.db.setImageTitle(originalUrl, title);
         }
       }
+      job.finishTime = Date.now();
       if (this.db) {
         const statusMap = {
           upscale: 'Upscaled',


### PR DESCRIPTION
## Summary
- track job start and finish times in PrintifyJobQueue
- expose those times in `/api/pipelineQueue`
- display start and finish columns in production queue UI

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685faad93d948323932a85ee764ec16f