### PR TITLE
Add pause/resume control to job queue

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -109,6 +109,8 @@
     </div>
     <button id="enqueueBtn">Add to Queue</button>
     <button id="stopAllBtn" style="margin-left:0.5rem;">Stop All</button>
+    <span id="queueState" style="margin-left:0.5rem;"></span>
+    <button id="togglePauseBtn" style="margin-left:0.5rem;">Pause Jobs</button>
   </div>
   <table id="queueTable">
     <thead>
@@ -128,10 +130,15 @@
   </table>
   <script src="/session.js"></script>
   <script>
+    let queuePaused = false;
     async function loadQueue(){
       try{
         const res = await fetch('/api/pipelineQueue');
-        const queue = await res.json();
+        const data = await res.json();
+        const queue = data.jobs || [];
+        queuePaused = !!data.paused;
+        document.getElementById('queueState').textContent = queuePaused ? 'Jobs Paused' : 'Jobs Enabled';
+        document.getElementById('togglePauseBtn').textContent = queuePaused ? 'Resume Jobs' : 'Pause Jobs';
         const tbody = document.querySelector('#queueTable tbody');
         tbody.innerHTML = '';
         const seen = new Set();
@@ -387,6 +394,16 @@ async function updateVariantUI(file){
         await loadQueue();
       }catch(e){
         console.error('Failed to stop all jobs', e);
+      }
+    });
+
+    document.getElementById('togglePauseBtn').addEventListener('click', async () => {
+      try{
+        const endpoint = queuePaused ? '/api/pipelineQueue/resume' : '/api/pipelineQueue/pause';
+        await fetch(endpoint, { method: 'POST' });
+        await loadQueue();
+      }catch(e){
+        console.error('Failed to toggle queue state', e);
       }
     });
 

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2816,6 +2816,20 @@ app.post("/api/pipelineQueue/stopAll", (req, res) => {
   res.json({ stopped: true });
 });
 
+app.post("/api/pipelineQueue/pause", (req, res) => {
+  printifyQueue.pause();
+  res.json({ paused: true });
+});
+
+app.post("/api/pipelineQueue/resume", (req, res) => {
+  printifyQueue.resume();
+  res.json({ paused: false });
+});
+
+app.get("/api/pipelineQueue/state", (req, res) => {
+  res.json({ paused: printifyQueue.isPaused() });
+});
+
 app.get("/api/upscale/result", (req, res) => {
   try {
     const file = req.query.file;


### PR DESCRIPTION
## Summary
- allow pausing/resuming the pipeline job queue
- persist the paused state and expose via API
- show job queue state on the web page with Pause/Resume button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685fab82963483238d84073d5d424b0c