### PR TITLE
Improve Printify title fix for gender neutrality

### DIFF
--- a/Aurora/scripts/printifyTitleFix.js
+++ b/Aurora/scripts/printifyTitleFix.js
@@ -49,7 +49,8 @@ async function main() {
           content: [
             {
               type: 'text',
-              text: 'Generate an optimized eBay shirt listing title for this design. Only return the title.'
+              text:
+                "Generate an optimized eBay shirt listing title for this design. Use gender-neutral phrasing and do not mention 'Men's' or 'Women's'. Only return the title."
             },
             {
               type: 'image_url',
@@ -70,6 +71,13 @@ async function main() {
 
     // Remove any quotation marks that might wrap or appear in the title
     optimizedTitle = optimizedTitle.replace(/["']/g, '').trim();
+
+    // Strip gendered words like "Men's" or "Women's" to keep the title neutral
+    optimizedTitle = optimizedTitle
+      .replace(/\bmen'?s\b/gi, '')
+      .replace(/\bwomen'?s\b/gi, '')
+      .replace(/\s{2,}/g, ' ')
+      .trim();
 
     // Retry updating the title if Printify temporarily disables editing
     const updateTitle = async () => {


### PR DESCRIPTION
## Summary
- instruct OpenAI to use gender-neutral language when generating Printify titles
- strip "Men's" and "Women's" from generated titles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685fad0978108323b8228c64afddbeab