### PR TITLE
Fix queue dropdown image hiding

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -230,9 +230,9 @@
         imgOffset = 0;
         imgHasMore = true;
         optionsDiv.querySelectorAll('.option').forEach(o => o.remove());
-        dropdown.dataset.value = '';
-        dropdown.dataset.id = '';
-        selectedDiv.textContent = '-- choose --';
+        if(!dropdown.dataset.value){
+          selectedDiv.textContent = '-- choose --';
+        }
       }
       if(!imgHasMore) return;
       imgLoading = true;


### PR DESCRIPTION
## Summary
- prevent clearing selected image when reloading dropdown

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685fb0f9b2e88323a9f82508140ad235