### PR TITLE
Hide name column in Aurora image table

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3449,6 +3449,7 @@ function renderFileList(){
     thumbImg.className = "table-thumb";
     tdThumb.appendChild(thumbImg);
     const tdName = document.createElement("td");
+    tdName.className = "name-col";
     const link = document.createElement("a");
     link.href = `/uploads/${f.name}`;
     link.target = "_blank";

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -852,6 +852,12 @@ body {
   color: cyan;
 }
 
+/* Hide file name column in image table */
+#secureFilesList th[data-col="name"],
+#secureFilesList td.name-col {
+  display: none;
+}
+
 
 /* Pipeline queue table */
 #queueTable {

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -855,6 +855,12 @@ body {
   color: cyan;
 }
 
+/* Hide file name column in image table */
+#secureFilesList th[data-col="name"],
+#secureFilesList td.name-col {
+  display: none;
+}
+
 
 /* Pipeline queue table */
 #queueTable {


### PR DESCRIPTION
## Summary
- add `name-col` cells for image table rows
- hide file name column via styles in both dark and light themes

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685fb1f9bfa483239e3adfd83f637d20