### PR TITLE
Hide hash column

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3438,6 +3438,7 @@ function renderFileList(){
     const tr = document.createElement("tr");
     tr.dataset.fileName = f.name;
     const tdIndex = document.createElement("td");
+    tdIndex.className = "uuid-col";
     tdIndex.textContent = f.uuid ?? "";
     const tdId = document.createElement("td");
     tdId.className = "id-col";

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -844,6 +844,12 @@ body {
   text-align: left;
 }
 
+/* Hide the UUID/hash column */
+#secureFilesList th[data-col="uuid"],
+#secureFilesList td.uuid-col {
+  display: none;
+}
+
 /* Links in the secure uploader table */
 #secureFilesList a {
   color: cyan;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -847,6 +847,12 @@ body {
   text-align: left;
 }
 
+/* Hide the UUID/hash column */
+#secureFilesList th[data-col="uuid"],
+#secureFilesList td.uuid-col {
+  display: none;
+}
+
 /* Links in the secure uploader table */
 #secureFilesList a {
   color: cyan;


### PR DESCRIPTION
## Summary
- hide the UUID/hash column in the Aurora image table

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685fb2a0e88c832389059844888dbb36