### PR TITLE
Fix hide behavior in queue image selector

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -263,7 +263,8 @@
               console.error('Failed to hide image', err);
             }
           });
-          item.addEventListener('click', () => {
+          item.addEventListener('click', ev => {
+            if(ev.target.closest('.hide-btn')) return;
             selectedDiv.innerHTML = `<img src="/uploads/${encodeURIComponent(f.name)}" /> <span>${idx}${label}</span> <button class="hide-btn">Hide</button>`;
             dropdown.dataset.value = f.name;
             dropdown.dataset.id = f.id ?? '';
@@ -273,25 +274,6 @@
             if(type === 'printify' || type === 'printifyPrice' || type === 'printifyTitleFix' || type === 'printifyFixMockups' || type === 'printifyFinalize' || type === 'all'){
               updateVariantUI(f.name);
             }
-            const selHideBtn = selectedDiv.querySelector('.hide-btn');
-            selHideBtn.addEventListener('click', async ev => {
-              ev.stopPropagation();
-              try{
-                await fetch('/api/upload/hidden', {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ name: f.name, hidden: true })
-                });
-                selectedDiv.textContent = '-- choose --';
-                dropdown.dataset.value = '';
-                dropdown.dataset.id = '';
-                updatePreview('');
-                updateVariantUI('');
-                item.remove();
-              }catch(err){
-                console.error('Failed to hide image', err);
-              }
-            });
           });
           optionsDiv.appendChild(item);
         });
@@ -304,8 +286,29 @@
       loadingDiv.style.display = 'none';
     }
 
-    selectedDiv.addEventListener('click', e => {
-      if(e.target.closest('.hide-btn')) return;
+    selectedDiv.addEventListener('click', async e => {
+      if(e.target.closest('.hide-btn')){
+        e.stopPropagation();
+        const name = dropdown.dataset.value;
+        if(!name) return;
+        try{
+          await fetch('/api/upload/hidden', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, hidden: true })
+          });
+          selectedDiv.textContent = '-- choose --';
+          const opt = optionsDiv.querySelector(`.option[data-value="${name}"]`);
+          opt?.remove();
+          dropdown.dataset.value = '';
+          dropdown.dataset.id = '';
+          updatePreview('');
+          updateVariantUI('');
+        }catch(err){
+          console.error('Failed to hide image', err);
+        }
+        return;
+      }
       optionsDiv.style.display = optionsDiv.style.display === 'block' ? 'none' : 'block';
       if(optionsDiv.style.display === 'block' && optionsDiv.querySelectorAll('.option').length === 0){
         loadImages(true);


### PR DESCRIPTION
## Summary
- prevent selecting image from triggering hide in queue dropdown
- centralize hide logic on the selected image button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685fb486de608323a9d1598edfcf83a8