### PR TITLE
Add paginated image loading

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -111,7 +111,7 @@
     </div>
 
     <!-- Uploader view panel (hidden by default) -->
-    <div id="sidebarViewUploader" style="display:none;">
+    <div id="sidebarViewUploader" style="display:none; max-height:60vh; overflow:auto;">
 <!--      <h2>Secure File Uploader</h2>-->
       <form id="secureUploadForm" enctype="multipart/form-data" method="POST">
         <input type="file" id="fileInput"/>


### PR DESCRIPTION
## Summary
- limit initial image list load to 20 items
- add scroll handler to load more images
- set uploader panel to be scrollable

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685fb988170083239509c09a2fcf2583