### PR TITLE
Update queue page to collapse new DB groups

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -133,6 +133,7 @@
   <script src="/session.js"></script>
   <script>
     const collapsedGroups = new Set();
+    const knownDbIds = new Set();
     async function loadQueue(){
       try{
         const res = await fetch('/api/pipelineQueue');
@@ -143,6 +144,10 @@
         queue.forEach(job => {
           if(job.dbId && !seen.has(job.dbId)){
             seen.add(job.dbId);
+            if(!knownDbIds.has(job.dbId)){
+              knownDbIds.add(job.dbId);
+              collapsedGroups.add(job.dbId);
+            }
             const groupTr = document.createElement('tr');
             groupTr.className = 'db-group';
             groupTr.dataset.dbid = job.dbId;


### PR DESCRIPTION
## Summary
- auto collapse new DB ID sections on the pipeline queue page

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685fbc3c0f54832393153ff3f07b6376