### PR TITLE
Update pipeline queue to display image titles

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -138,6 +138,19 @@
   <script>
     const collapsedGroups = new Set();
     const knownDbIds = new Set();
+    const titleCache = {};
+    async function getTitle(file){
+      if(titleCache.hasOwnProperty(file)) return titleCache[file];
+      try{
+        const r = await fetch('/api/upload/title?name=' + encodeURIComponent(file));
+        const d = await r.json();
+        titleCache[file] = d.title || '';
+      }catch(e){
+        console.error('Failed to fetch title', e);
+        titleCache[file] = '';
+      }
+      return titleCache[file];
+    }
     async function loadQueue(){
       try{
         const res = await fetch('/api/pipelineQueue');
@@ -145,7 +158,7 @@
         const tbody = document.querySelector('#queueTable tbody');
         tbody.innerHTML = '';
         const seen = new Set();
-        queue.forEach(job => {
+        for(const job of queue){
           if(job.dbId && !seen.has(job.dbId)){
             seen.add(job.dbId);
             if(!knownDbIds.has(job.dbId)){
@@ -156,7 +169,9 @@
             groupTr.className = 'db-group';
             groupTr.dataset.dbid = job.dbId;
             const collapsed = collapsedGroups.has(job.dbId);
-            groupTr.innerHTML = `<td colspan="11"><span class="toggle">${collapsed ? '[+]' : '[-]'}</span> DB ID: ${job.dbId}<img src="/uploads/${encodeURIComponent(job.file)}" style="max-height:40px;margin-left:0.5rem;vertical-align:middle;" /> <button class="hideImageBtn" data-file="${encodeURIComponent(job.file)}" style="margin-left:0.5rem;">Hide Image</button> <button class="removeDbBtn" data-dbid="${job.dbId}" style="margin-left:0.5rem;">Remove All</button></td>`;
+            const title = await getTitle(job.file);
+            const titlePart = title ? ` - ${title}` : '';
+            groupTr.innerHTML = `<td colspan="11"><span class="toggle">${collapsed ? '[+]' : '[-]'}</span> DB ID: ${job.dbId}${titlePart}<img src="/uploads/${encodeURIComponent(job.file)}" style="max-height:40px;margin-left:0.5rem;vertical-align:middle;" /> <button class="hideImageBtn" data-file="${encodeURIComponent(job.file)}" style="margin-left:0.5rem;">Hide Image</button> <button class="removeDbBtn" data-dbid="${job.dbId}" style="margin-left:0.5rem;">Remove All</button></td>`;
             tbody.appendChild(groupTr);
             groupTr.querySelector('.removeDbBtn').addEventListener('click', async ev => {
               ev.stopPropagation();

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2178,6 +2178,20 @@ app.get("/api/upload/byId", (req, res) => {
   }
 });
 
+app.get("/api/upload/title", (req, res) => {
+  try {
+    const name = req.query.name;
+    if(!name){
+      return res.status(400).json({ error: "Missing name" });
+    }
+    const title = db.getImageTitleForUrl(`/uploads/${name}`);
+    res.json({ title: title || "" });
+  } catch(err){
+    console.error("[Server Debug] /api/upload/title error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 app.post("/api/upload/status", (req, res) => {
   try {
     const { name, status, productUrl, ebayUrl } = req.body || {};


### PR DESCRIPTION
## Summary
- add endpoint for fetching image titles
- display image titles next to DB IDs in the pipeline queue

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685fbe1a80948323b6d7ed533a1934ea