### PR TITLE
Hide queue row IDs

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -878,6 +878,11 @@ body {
   padding: 4px 6px;
 }
 
+#queueTable th:nth-child(1),
+#queueTable td:nth-child(1) {
+  display: none;
+}
+
 #queueTable tbody tr:nth-child(odd) {
   background-color: #2b2b2b;
 }

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -881,6 +881,11 @@ body {
   padding: 4px 6px;
 }
 
+#queueTable th:nth-child(1),
+#queueTable td:nth-child(1) {
+  display: none;
+}
+
 #queueTable tbody tr:nth-child(odd) {
   background-color: #f0f0f0;
 }


### PR DESCRIPTION
## Summary
- hide the ID column in the Design Production Queue table so row IDs don't appear

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685fbe54c29483238e33369800341324