### PR TITLE
Add image list pagination loader

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -138,6 +138,9 @@
         </thead>
         <tbody></tbody>
       </table>
+      <div id="uploaderLoading" class="loading-more" style="display:none;">
+        <span class="loading-spinner"></span>
+      </div>
     </div>
 
     <!-- New File Tree view panel (hidden by default) -->

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3638,6 +3638,8 @@ async function loadFileList(reset = true) {
 async function loadNextFilePage(){
   if(fileListLoading || fileListEnd) return;
   fileListLoading = true;
+  const spin = $("#uploaderLoading");
+  if(spin) spin.style.display = "block";
   try {
     const resp = await fetch(`/api/upload/list?sessionId=${encodeURIComponent(sessionId)}&showHidden=1&limit=${fileListLimit}&offset=${fileListOffset}`);
     const data = await resp.json();
@@ -3651,6 +3653,7 @@ async function loadNextFilePage(){
     console.error("Error fetching file list:", e);
   }
   fileListLoading = false;
+  if(spin) spin.style.display = "none";
 }
 
 $("#secureUploadForm").addEventListener("submit", async e => {

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1002,6 +1002,11 @@ body {
   animation: loading-spin 0.75s linear infinite;
 }
 
+.loading-more {
+  text-align: center;
+  padding: 4px;
+}
+
 @keyframes loading-spin {
   to { transform: rotate(360deg); }
 }

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -1005,6 +1005,11 @@ body {
   animation: loading-spin 0.75s linear infinite;
 }
 
+.loading-more {
+  text-align: center;
+  padding: 4px;
+}
+
 @keyframes loading-spin {
   to { transform: rotate(360deg); }
 }


### PR DESCRIPTION
## Summary
- show a loading spinner when fetching more images in the sidebar
- style `loading-more` element for both light and dark themes
- insert loader markup below the image table

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685fc041de508323b7d2906298a81c11