### PR TITLE
Restore Tasks Sidebar

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -676,7 +676,7 @@
     <label><input type="checkbox" id="nexumTabsMenuCheck"/> Show Nexum Tabs menu</label><br/>
     <label><input type="checkbox" id="fileTreeMenuCheck"/> Show File Tree button</label><br/>
     <label><input type="checkbox" id="aiModelsMenuCheck"/> Show AI Models link</label><br/>
-    <label><input type="checkbox" id="tasksMenuCheck"/> Show Tasks button</label><br/>
+    <label><input type="checkbox" id="tasksMenuCheck" checked/> Show Tasks button</label><br/>
     <label><input type="checkbox" id="jobsMenuCheck"/> Show Jobs button</label><br/>
     <label><input type="checkbox" id="chatTabsMenuCheck"/> Show Chats button</label><br/>
     <label><input type="checkbox" id="viewTabsBarFlagCheck"/> Show Chat/Tasks bar</label><br/>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -126,7 +126,7 @@ let nexumTabsMenuVisible = false;     // show Nexum Tabs menu item
 let imageGeneratorMenuVisible = false; // show Image Generator menu item
 let fileTreeMenuVisible = false;      // show File Tree button
 let aiModelsMenuVisible = false;      // show AI Models link
-let tasksMenuVisible = false;         // show Tasks button
+let tasksMenuVisible = true;          // show Tasks button by default
 let jobsMenuVisible = false;         // show Jobs button
 let chatTabsMenuVisible = true;     // show Chats button
 let showSessionId = false;          // display session ID hash
@@ -4479,6 +4479,7 @@ thinPrintifyIcon?.addEventListener("touchstart", ev => {
   let lastView = await getSetting("last_sidebar_view");
   if(!lastView) lastView = "uploader";
   switch(lastView){
+    case "tasks": showTasksPanel(); break;
     case "uploader": showUploaderPanel(); break;
     case "fileTree": showFileTreePanel(); break;
     case "fileCabinet": showFileCabinetPanel(); break;


### PR DESCRIPTION
## Summary
- default Tasks button enabled in feature flags
- show tasks sidebar when last view was tasks

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68602e8d81308323883fd4f642caab4a