### PR TITLE
Fix pipeline dropdown on non-pointer browsers

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -317,14 +317,27 @@
       }
     };
 
-    selectedDiv.addEventListener('pointerdown', e => {
-      if(e.pointerType === 'touch') e.preventDefault();
-      toggleOptions();
-    });
-
-    document.addEventListener('pointerdown', e => {
-      if(!dropdown.contains(e.target)) optionsDiv.style.display = 'none';
-    });
+    if(window.PointerEvent){
+      selectedDiv.addEventListener('pointerdown', e => {
+        if(e.pointerType === 'touch') e.preventDefault();
+        toggleOptions();
+      });
+      document.addEventListener('pointerdown', e => {
+        if(!dropdown.contains(e.target)) optionsDiv.style.display = 'none';
+      });
+    }else{
+      selectedDiv.addEventListener('click', toggleOptions);
+      selectedDiv.addEventListener('touchstart', e => {
+        e.preventDefault();
+        toggleOptions();
+      });
+      document.addEventListener('click', e => {
+        if(!dropdown.contains(e.target)) optionsDiv.style.display = 'none';
+      });
+      document.addEventListener('touchstart', e => {
+        if(!dropdown.contains(e.target)) optionsDiv.style.display = 'none';
+      });
+    }
 
     optionsDiv.addEventListener('scroll', () => {
       if(optionsDiv.scrollTop + optionsDiv.clientHeight >= optionsDiv.scrollHeight - 5){


### PR DESCRIPTION
## Summary
- add fallback for browsers without PointerEvents

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686061c341cc83239020a77028b0728f