### PR TITLE
Fix dropdown overlay blocking queue button

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -410,6 +410,8 @@ async function updateVariantUI(file){
 }
 
     document.getElementById('enqueueBtn').addEventListener('click', async () => {
+      // Ensure the dropdown is closed so the click isn't intercepted
+      optionsDiv.style.display = 'none';
       const file = document.getElementById('imageSelect').dataset.value;
       const dbId = document.getElementById('imageSelect').dataset.id;
       const type = document.getElementById('jobType').value;


### PR DESCRIPTION
## Summary
- close the image dropdown whenever clicking **Add to Queue** so the overlay can't intercept the click

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68607535d4d48323972e097d82f1657f