### PR TITLE
Fix collapsed pipeline queue rows

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -163,7 +163,6 @@
             seen.add(job.dbId);
             if(!knownDbIds.has(job.dbId)){
               knownDbIds.add(job.dbId);
-              collapsedGroups.add(job.dbId);
             }
             const groupTr = document.createElement('tr');
             groupTr.className = 'db-group';


### PR DESCRIPTION
## Summary
- keep new pipeline queue groups expanded by default

## Testing
- `npm run lint` in Aurora
- `npm test` in AutoPR
- `npm test` in PriceScript (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_b_6860780506f083238065d48d12441662