### PR TITLE
Fix DB groups collapsed by default

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -137,7 +137,6 @@
   <script src="/session.js"></script>
   <script>
     const collapsedGroups = new Set();
-    const knownDbIds = new Set();
     const titleCache = {};
     async function getTitle(file){
       if(titleCache.hasOwnProperty(file)) return titleCache[file];
@@ -161,8 +160,7 @@
         for(const job of queue){
           if(job.dbId && !seen.has(job.dbId)){
             seen.add(job.dbId);
-            if(!knownDbIds.has(job.dbId)){
-              knownDbIds.add(job.dbId);
+            if(!collapsedGroups.has(job.dbId)){
               collapsedGroups.add(job.dbId);
             }
             const groupTr = document.createElement('tr');


### PR DESCRIPTION
## Summary
- keep `collapsedGroups` logic but remove leftover `knownDbIds`
- default collapse each new DB group when loading the queue

## Testing
- `npm run lint` in `Aurora`
- `npm test` in `AutoPR`
- `npm test` in `PriceScript` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68607a83e81083238230713d176318c2