### PR TITLE
Fix pipeline test HTTPS

### DIFF
--- a/Aurora/test/pipelineQueueRoute.test.cjs
+++ b/Aurora/test/pipelineQueueRoute.test.cjs
@@ -3,7 +3,8 @@ const assert = require('assert');
 
 async function runTests() {
   const port = process.env.AURORA_PORT || process.env.PORT || 3000;
-  const baseUrl = `http://localhost:${port}`;
+  const protocol = process.env.AURORA_PROTOCOL || 'http';
+  const baseUrl = `${protocol}://localhost:${port}`;
 
   // Test GET /api/pipelineQueue
   const getRes = await axios.get(`${baseUrl}/api/pipelineQueue`).catch(err => err.response || err);


### PR DESCRIPTION
## Summary
- update pipeline queue test to allow HTTP or HTTPS based on `AURORA_PROTOCOL`

## Testing
- `npm run lint` *(fails: no linter configured)*
- `node test/pipelineQueueRoute.test.cjs` *(fails: cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_686087cad0708323bb17e1a7633caf10