### PR TITLE
Allow localhost when WHITELIST_IP set

### DIFF
--- a/Aurora/.env.example
+++ b/Aurora/.env.example
@@ -55,5 +55,5 @@ GITHUB_REPO=yourRepo
 # AWS_DB_NAME=dbname
 # AWS_DB_PORT=5432
 
-# Optional IP address allowed to access the web UI
+# Optional IP address allowed to access the web UI. Requests from localhost are always allowed
 # WHITELIST_IP=1.2.3.4

--- a/Aurora/README.md
+++ b/Aurora/README.md
@@ -38,7 +38,7 @@ npm start
 | `AWS_DB_PASSWORD` | (Optional) Password for AWS RDS |
 | `AWS_DB_NAME` | (Optional) Database name for AWS RDS |
 | `AWS_DB_PORT` | (Optional) Port for AWS RDS (default: 5432) |
-| `WHITELIST_IP` | (Optional) Only allow UI access from this IP |
+| `WHITELIST_IP` | (Optional) Only allow UI access from this IP. Requests from `localhost` are always permitted |
 
 Run `../setup_certbot.sh <domain> <email>` to quickly generate these files with
 Let's Encrypt. After generation, execute `../setup_ssl_permissions.sh <domain> [user]`

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -577,9 +577,10 @@ app.options("*", cors({
   res.sendStatus(200);
 });
 
-// Restrict access by IP when WHITELIST_IP is set
+// Restrict access by IP when WHITELIST_IP is set. Localhost is always allowed
 const whitelistIp = process.env.whitelist_ip || process.env.WHITELIST_IP;
 if (whitelistIp) {
+  const localIps = new Set(["127.0.0.1", "::1", "::ffff:127.0.0.1"]);
   app.use((req, res, next) => {
     const requestIp =
       (req.headers["x-forwarded-for"] || "")
@@ -592,7 +593,11 @@ if (whitelistIp) {
       return next();
     }
 
-    if (requestIp === whitelistIp || requestIp === `::ffff:${whitelistIp}`) {
+    const allowed =
+      localIps.has(requestIp) ||
+      requestIp === whitelistIp ||
+      requestIp === `::ffff:${whitelistIp}`;
+    if (allowed) {
       return next();
     }
 


### PR DESCRIPTION
## Summary
- allow localhost traffic even when `WHITELIST_IP` is set
- document localhost allowance in README and `.env.example`

## Testing
- `node Aurora/test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_6861b8fefb748323b8ee8a424936605c