### PR TITLE
Update pipeline queue test script

### DIFF
--- a/Aurora/test/pipelineQueueRoute.test.cjs
+++ b/Aurora/test/pipelineQueueRoute.test.cjs
@@ -8,29 +8,45 @@ async function runTests() {
   const baseUrl = `${protocol}://localhost:${port}`;
   const httpsAgent = new https.Agent({ rejectUnauthorized: false });
 
-  // Test GET /api/pipelineQueue
   const opts = { httpsAgent };
-  const getRes = await axios.get(`${baseUrl}/api/pipelineQueue`, opts).catch(err => err.response || err);
+
+  // Always fetch and print the current queue
+  const getRes = await axios
+    .get(`${baseUrl}/api/pipelineQueue`, opts)
+    .catch((err) => err.response || err);
   assert.strictEqual(getRes.status, 200, `Expected 200, got ${getRes.status}`);
   assert.ok(Array.isArray(getRes.data), 'Response should be an array');
   console.log('✓ GET /api/pipelineQueue');
+  console.log('Current queue:\n', JSON.stringify(getRes.data, null, 2));
 
   // Test POST /api/pipelineQueue with missing fields
-  const badPost = await axios.post(`${baseUrl}/api/pipelineQueue`, {}, opts).catch(err => err.response || err);
+  const badPost = await axios
+    .post(`${baseUrl}/api/pipelineQueue`, {}, opts)
+    .catch((err) => err.response || err);
   assert.strictEqual(badPost.status, 400, `Expected 400, got ${badPost.status}`);
   console.log('✓ POST /api/pipelineQueue rejects missing fields');
 
-  // Test successful POST /api/pipelineQueue
-  const postBody = { file: 'test.png', type: 'upscale' };
-  const postRes = await axios.post(`${baseUrl}/api/pipelineQueue`, postBody, opts).catch(err => err.response || err);
-  assert.strictEqual(postRes.status, 200, `Expected 200, got ${postRes.status}`);
-  assert.ok(postRes.data && postRes.data.jobId, 'Response should contain jobId');
-  console.log('✓ POST /api/pipelineQueue creates job');
+  // Only create a job when the --create flag is provided
+  if (process.argv.includes('--create')) {
+    const postBody = { file: 'test.png', type: 'upscale' };
+    const postRes = await axios
+      .post(`${baseUrl}/api/pipelineQueue`, postBody, opts)
+      .catch((err) => err.response || err);
+    assert.strictEqual(postRes.status, 200, `Expected 200, got ${postRes.status}`);
+    assert.ok(postRes.data && postRes.data.jobId, 'Response should contain jobId');
+    console.log('✓ POST /api/pipelineQueue creates job');
 
-  const listRes = await axios.get(`${baseUrl}/api/pipelineQueue`, opts).catch(err => err.response || err);
-  assert.strictEqual(listRes.status, 200, `Expected 200, got ${listRes.status}`);
-  assert.ok(listRes.data.some(j => j.id === postRes.data.jobId), 'Job should appear in queue');
-  console.log('✓ Job appears in queue');
+    const listRes = await axios
+      .get(`${baseUrl}/api/pipelineQueue`, opts)
+      .catch((err) => err.response || err);
+    assert.strictEqual(listRes.status, 200, `Expected 200, got ${listRes.status}`);
+    assert.ok(
+      listRes.data.some((j) => j.id === postRes.data.jobId),
+      'Job should appear in queue'
+    );
+    console.log('✓ Job appears in queue');
+    console.log('Updated queue:\n', JSON.stringify(listRes.data, null, 2));
+  }
 }
 
 runTests().catch(err => {


### PR DESCRIPTION
## Summary
- update queue test script to avoid creating a job unless `--create` is passed
- output entire queue for visibility

## Testing
- `node Aurora/test/pipelineQueueRoute.test.cjs >/tmp/test.log && tail -n 20 /tmp/test.log` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_6861c23c34588323b24d6abd26a28bcb