### PR TITLE
Fix queue page blank due to missing CSS.escape

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -136,6 +136,14 @@
   </table>
   <script src="/session.js"></script>
   <script>
+    if (typeof window.CSS === 'undefined') window.CSS = {};
+    if (typeof window.CSS.escape !== 'function') {
+      window.CSS.escape = function(str) {
+        return String(str).replace(/[^\w-]/g, function(ch) {
+          return '\\' + ch;
+        });
+      };
+    }
     const collapsedGroups = new Set();
     const titleCache = {};
     async function getTitle(file){


### PR DESCRIPTION
## Summary
- patch `pipeline_queue.html` to include a simple CSS.escape polyfill

## Testing
- `node Aurora/test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_6861c61854ec83238d20ecddc4f0eae5