### PR TITLE
Fix blank queue UI by ensuring session ID

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -136,6 +136,35 @@
   </table>
   <script src="/session.js"></script>
   <script>
+    if(!window.sessionId){
+      function getCookie(name){
+        const match = document.cookie.split('; ').find(r => r.startsWith(name + '='));
+        return match ? decodeURIComponent(match.split('=')[1]) : null;
+      }
+      function setCookie(name, value, days=365){
+        const expires = new Date(Date.now() + days*864e5).toUTCString();
+        document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
+      }
+      function generateUUID(){
+        if(window.crypto && typeof window.crypto.randomUUID === 'function'){
+          return window.crypto.randomUUID();
+        }
+        const tpl = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
+        return tpl.replace(/[xy]/g, c => {
+          const r = Math.random()*16|0;
+          const v = c === 'x' ? r : (r&0x3|0x8);
+          return v.toString(16);
+        });
+      }
+      function getSessionId(){
+        let id = getCookie('sessionId') || sessionStorage.getItem('sessionId');
+        if(!id) id = generateUUID();
+        sessionStorage.setItem('sessionId', id);
+        setCookie('sessionId', id);
+        return id;
+      }
+      window.sessionId = getSessionId();
+    }
     const collapsedGroups = new Set();
     const titleCache = {};
     async function getTitle(file){


### PR DESCRIPTION
## Summary
- make `pipeline_queue.html` independent of `session.js`
- generate a fallback session ID if `session.js` fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6861c61854ec83238d20ecddc4f0eae5