### PR TITLE
Add verbose debugging for pipeline queue

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -136,6 +136,7 @@
   </table>
   <script src="./session.js"></script>
   <script>
+    console.debug('[Queue UI] script loaded');
     if (typeof window.CSS === 'undefined') window.CSS = {};
     if (typeof window.CSS.escape !== 'function') {
       window.CSS.escape = function(str) {
@@ -159,9 +160,11 @@
       return titleCache[file];
     }
     async function loadQueue(){
+      console.debug('[Queue UI] loading queue...');
       try{
         const res = await fetch('api/pipelineQueue');
         const queue = await res.json();
+        console.debug('[Queue UI] queue data =>', queue);
         const tbody = document.querySelector('#queueTable tbody');
         tbody.innerHTML = '';
         const seen = new Set();
@@ -271,6 +274,7 @@
     let imgLoading = false;
 
     async function loadImages(reset=false){
+      console.debug('[Queue UI] loadImages reset=' + reset);
       if(imgLoading) return;
       if(reset){
         imgOffset = 0;
@@ -286,6 +290,7 @@
       try{
         const res = await fetch('api/upload/list?sessionId=' + encodeURIComponent(sessionId) + `&limit=20&offset=${imgOffset}&showHidden=0`);
         const files = await res.json();
+        console.debug('[Queue UI] loaded images =>', files);
         files.forEach(f => {
           const item = document.createElement('div');
           item.className = 'option';
@@ -364,6 +369,7 @@
     });
 
 async function updateVariantUI(file){
+  console.debug('[Queue UI] updateVariantUI for', file);
   const choiceDiv = document.getElementById('variantChoice');
   const normalRadio = document.getElementById('choiceQueueNormal');
   const nobgRadio = document.getElementById('choiceQueueNobg');
@@ -429,6 +435,7 @@ async function updateVariantUI(file){
       const variant = variantChoice ? variantChoice.value : null;
       const hideFlag = document.getElementById('hideWhenAdd').checked;
       if(!file) return;
+      console.debug('[Queue UI] enqueue clicked file=' + file + ' type=' + type + ' variant=' + variant);
       try{
         if(type === 'all'){
           const steps = ['upscale','printify','printifyTitleFix','printifyFixMockups','printifyFinalize'];
@@ -445,6 +452,7 @@ async function updateVariantUI(file){
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ file, type, dbId, variant })
           });
+          console.debug('[Queue UI] job enqueued');
         }
         if(hideFlag){
           try{
@@ -497,6 +505,7 @@ async function updateVariantUI(file){
     });
 
     async function removeJob(id){
+      console.debug('[Queue UI] removeJob', id);
       try{
         await fetch(`api/pipelineQueue/${id}`, { method: 'DELETE' });
         await loadQueue();
@@ -506,6 +515,7 @@ async function updateVariantUI(file){
     }
 
     async function removeJobsByDbId(dbId){
+      console.debug('[Queue UI] removeJobsByDbId', dbId);
       try{
         await fetch(`api/pipelineQueue/db/${encodeURIComponent(dbId)}`, { method: 'DELETE' });
         await loadQueue();

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -97,6 +97,7 @@ export default class PrintifyJobQueue {
       finishTime: null
     };
     this.jobs.push(job);
+    console.debug('[PrintifyJobQueue Debug] Enqueued job =>', job);
     this._saveJobs();
     this._processNext();
     return job;
@@ -129,6 +130,7 @@ export default class PrintifyJobQueue {
     if (this.current && this.current.id === id) {
       this.current = null;
     }
+    console.debug('[PrintifyJobQueue Debug] Removed job =>', job);
     this._saveJobs();
     this._processNext();
     return true;
@@ -146,6 +148,7 @@ export default class PrintifyJobQueue {
         if (this.current && this.current.id === job.id) {
           this.current = null;
         }
+        console.debug('[PrintifyJobQueue Debug] Removed job =>', job);
         removed = true;
       }
     }
@@ -162,6 +165,7 @@ export default class PrintifyJobQueue {
         this.jobManager.stopJob(job.jobId);
       }
     }
+    console.debug('[PrintifyJobQueue Debug] stopAll clearing', this.jobs.length, 'jobs');
     this.jobs = [];
     this.current = null;
     this._saveJobs();
@@ -171,6 +175,7 @@ export default class PrintifyJobQueue {
     if (this.current || this.paused) return;
     const job = this.jobs.find(j => j.status === 'queued');
     if (!job) return;
+    console.debug('[PrintifyJobQueue Debug] Starting job =>', job);
     this.current = job;
     job.status = 'running';
     job.startTime = Date.now();

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2820,7 +2820,12 @@ app.post("/api/jobs/:id/stop", (req, res) => {
 // ---------------------------------------------------------------------------
 app.get("/api/pipelineQueue", (req, res) => {
   console.debug("[Server Debug] GET /api/pipelineQueue");
-  res.json(printifyQueue.list());
+  const queue = printifyQueue.list();
+  console.debug(
+    "[Server Debug] Current queue =>",
+    JSON.stringify(queue, null, 2)
+  );
+  res.json(queue);
 });
 
 app.post("/api/pipelineQueue", (req, res) => {
@@ -2830,6 +2835,10 @@ app.post("/api/pipelineQueue", (req, res) => {
     return res.status(400).json({ error: "Missing file or type" });
   }
   const job = printifyQueue.enqueue(file, type, dbId || null, variant || null);
+  console.debug(
+    "[Server Debug] Enqueued job =>",
+    JSON.stringify(job, null, 2)
+  );
   res.json({ jobId: job.id });
 });
 
@@ -2837,6 +2846,7 @@ app.delete("/api/pipelineQueue/:id", (req, res) => {
   console.debug("[Server Debug] DELETE /api/pipelineQueue/:id =>", req.params.id);
   const ok = printifyQueue.remove(req.params.id);
   if (!ok) return res.status(404).json({ error: "Job not found" });
+  console.debug("[Server Debug] Job removed. Queue =>", JSON.stringify(printifyQueue.list(), null, 2));
   res.json({ removed: true });
 });
 
@@ -2847,29 +2857,42 @@ app.delete("/api/pipelineQueue/db/:dbId", (req, res) => {
   );
   const ok = printifyQueue.removeByDbId(req.params.dbId);
   if (!ok) return res.status(404).json({ error: "Jobs not found" });
+  console.debug(
+    "[Server Debug] Jobs removed for DB =>",
+    req.params.dbId,
+    JSON.stringify(printifyQueue.list(), null, 2)
+  );
   res.json({ removed: true });
 });
 
 app.post("/api/pipelineQueue/stopAll", (req, res) => {
   console.debug("[Server Debug] POST /api/pipelineQueue/stopAll");
   printifyQueue.stopAll();
+  console.debug(
+    "[Server Debug] stopAll called. Queue =>",
+    JSON.stringify(printifyQueue.list(), null, 2)
+  );
   res.json({ stopped: true });
 });
 
 app.get("/api/pipelineQueue/state", (req, res) => {
   console.debug("[Server Debug] GET /api/pipelineQueue/state");
-  res.json({ paused: printifyQueue.isPaused() });
+  const paused = printifyQueue.isPaused();
+  console.debug("[Server Debug] Queue paused?", paused);
+  res.json({ paused });
 });
 
 app.post("/api/pipelineQueue/pause", (req, res) => {
   console.debug("[Server Debug] POST /api/pipelineQueue/pause");
   printifyQueue.pause();
+  console.debug("[Server Debug] Queue paused");
   res.json({ paused: true });
 });
 
 app.post("/api/pipelineQueue/resume", (req, res) => {
   console.debug("[Server Debug] POST /api/pipelineQueue/resume");
   printifyQueue.resume();
+  console.debug("[Server Debug] Queue resumed");
   res.json({ paused: false });
 });
 


### PR DESCRIPTION
## Summary
- add detailed debug logging for the pipeline queue API routes
- log queue operations inside `PrintifyJobQueue`
- log queue UI behaviour on `pipeline_queue.html`

## Testing
- `node test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_6861cbafdec08323a38a8fd74f217545