### PR TITLE
Fix dbId missing from queue

### DIFF
--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -29,6 +29,14 @@ export default class PrintifyJobQueue {
       if (Array.isArray(data.jobs)) {
         this.jobs = data.jobs.map(j => {
           if (j.status === 'running') j.status = 'queued';
+          let dbId = j.dbId || null;
+          if (dbId === null && this.db) {
+            try {
+              dbId = this.db.getImageIdForUrl(`/uploads/${j.file}`);
+            } catch (e) {
+              dbId = null;
+            }
+          }
           return {
             id: j.id,
             file: j.file,
@@ -37,7 +45,7 @@ export default class PrintifyJobQueue {
             jobId: j.jobId || null,
             resultPath: j.resultPath || null,
             productUrl: j.productUrl || null,
-            dbId: j.dbId || null,
+            dbId,
             variant: j.variant || null,
             startTime: j.startTime || null,
             finishTime: j.finishTime || null,


### PR DESCRIPTION
## Summary
- compute DB ID for legacy jobs when loading queue

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6861cedb18f883238dabb72be8006231