### PR TITLE
Fix queue display groups

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -171,9 +171,6 @@
         for(const job of queue){
           if(job.dbId && !seen.has(job.dbId)){
             seen.add(job.dbId);
-            if(!collapsedGroups.has(job.dbId)){
-              collapsedGroups.add(job.dbId);
-            }
             const groupTr = document.createElement('tr');
             groupTr.className = 'db-group';
             groupTr.dataset.dbid = job.dbId;


### PR DESCRIPTION
## Summary
- show pipeline queue DB groups expanded by default

## Testing
- `node Aurora/test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_6861da1b2030832381d8b2e6d3d915da