### PR TITLE
Fix pipeline queue DB ID display

### DIFF
--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -112,19 +112,30 @@ export default class PrintifyJobQueue {
   }
 
   list() {
-    return this.jobs.map(j => ({
-      id: j.id,
-      file: j.file,
-      type: j.type,
-      status: j.status,
-      jobId: j.jobId,
-      resultPath: j.resultPath || null,
-      productUrl: j.productUrl || null,
-      dbId: j.dbId || null,
-      variant: j.variant || null,
-      startTime: j.startTime || null,
-      finishTime: j.finishTime || null
-    }));
+    return this.jobs.map(j => {
+      let dbId = j.dbId || null;
+      if (dbId === null && this.db) {
+        try {
+          dbId = this.db.getImageIdForUrl(`/uploads/${j.file}`);
+          if (dbId !== null && dbId !== undefined) j.dbId = dbId;
+        } catch (e) {
+          dbId = null;
+        }
+      }
+      return {
+        id: j.id,
+        file: j.file,
+        type: j.type,
+        status: j.status,
+        jobId: j.jobId,
+        resultPath: j.resultPath || null,
+        productUrl: j.productUrl || null,
+        dbId,
+        variant: j.variant || null,
+        startTime: j.startTime || null,
+        finishTime: j.finishTime || null
+      };
+    });
   }
 
   remove(id) {


### PR DESCRIPTION
## Summary
- ensure `dbId` is always retrieved when listing pipeline queue jobs

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/alfe-ai/package.json')*

------
https://chatgpt.com/codex/tasks/task_b_6861da1b2030832381d8b2e6d3d915da