### PR TITLE
Add location column to pipeline queue

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -122,6 +122,7 @@
         <th>ID</th>
         <th>DB ID</th>
         <th>Type</th>
+        <th>Location</th>
         <th>Variant</th>
         <th>Start</th>
         <th>Finish</th>
@@ -177,7 +178,7 @@
             const collapsed = collapsedGroups.has(job.dbId);
             const title = await getTitle(job.file);
             const titlePart = title ? ` - ${title}` : '';
-            groupTr.innerHTML = `<td colspan="11"><span class="toggle">${collapsed ? '[+]' : '[-]'}</span> DB ID: ${job.dbId}${titlePart}<img src="uploads/${encodeURIComponent(job.file)}" style="max-height:40px;margin-left:0.5rem;vertical-align:middle;" /> <button class="hideImageBtn" data-file="${encodeURIComponent(job.file)}" style="margin-left:0.5rem;">Hide Image</button> <button class="removeDbBtn" data-dbid="${job.dbId}" style="margin-left:0.5rem;">Remove All</button></td>`;
+            groupTr.innerHTML = `<td colspan="12"><span class="toggle">${collapsed ? '[+]' : '[-]'}</span> DB ID: ${job.dbId}${titlePart}<img src="uploads/${encodeURIComponent(job.file)}" style="max-height:40px;margin-left:0.5rem;vertical-align:middle;" /> <button class="hideImageBtn" data-file="${encodeURIComponent(job.file)}" style="margin-left:0.5rem;">Hide Image</button> <button class="removeDbBtn" data-dbid="${job.dbId}" style="margin-left:0.5rem;">Remove All</button></td>`;
             tbody.appendChild(groupTr);
             groupTr.querySelector('.removeDbBtn').addEventListener('click', async ev => {
               ev.stopPropagation();
@@ -241,6 +242,7 @@
             <td>${job.id}</td>
             <td>${dbLink}</td>
             <td>${job.type}</td>
+            <td>${job.location}</td>
             <td>${job.variant || ''}</td>
             <td>${startStr}</td>
             <td>${finishStr}</td>

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -122,10 +122,15 @@ export default class PrintifyJobQueue {
           dbId = null;
         }
       }
+      const location =
+        j.type === 'printifyFixMockups' || j.type === 'printifyFinalize'
+          ? 'ProgramaticPuppet'
+          : 'Local';
       return {
         id: j.id,
         file: j.file,
         type: j.type,
+        location,
         status: j.status,
         jobId: j.jobId,
         resultPath: j.resultPath || null,


### PR DESCRIPTION
## Summary
- update the pipeline queue UI to show where each job will run
- expose job location in the Printify queue API

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6861e1a97fa8832399b284d8f032652e