### PR TITLE
Add thumbnail to queue group headers

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -190,7 +190,7 @@
             headerTr.innerHTML = document.querySelector('#queueTable thead tr').innerHTML;
             const dbIdTh = headerTr.querySelector('th:nth-child(2)');
             if(dbIdTh){
-              dbIdTh.innerHTML = `DB ID: ${job.dbId} <button class="removeDbBtn" data-dbid="${job.dbId}" style="margin-left:0.5rem;">Remove DB</button>`;
+              dbIdTh.innerHTML = `DB ID: ${job.dbId}<img src="uploads/${encodeURIComponent(job.file)}" style="max-height:40px;margin-left:0.5rem;vertical-align:middle;" /> <button class="removeDbBtn" data-dbid="${job.dbId}" style="margin-left:0.5rem;">Remove</button>`;
             }
             if(collapsed) headerTr.style.display = 'none';
             tbody.appendChild(headerTr);


### PR DESCRIPTION
## Summary
- rename `Remove DB` button label to `Remove`
- display the DB ID's thumbnail image in each group header row

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6861eddac5b88323b592671ff163ca22