### PR TITLE
Fix dbId type for queue grouping

### DIFF
--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -92,6 +92,11 @@ export default class PrintifyJobQueue {
 
   enqueue(file, type, dbId = null, variant = null) {
     const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+    let parsedDbId = null;
+    if (dbId !== null && dbId !== undefined && dbId !== '') {
+      const n = Number(dbId);
+      if (!Number.isNaN(n)) parsedDbId = n;
+    }
     const job = {
       id,
       file,
@@ -100,7 +105,7 @@ export default class PrintifyJobQueue {
       jobId: null,
       resultPath: null,
       productUrl: null,
-      dbId,
+      dbId: parsedDbId,
       variant,
       startTime: null,
       finishTime: null
@@ -165,10 +170,15 @@ export default class PrintifyJobQueue {
   }
 
   removeByDbId(dbId) {
+    let target = null;
+    if (dbId !== null && dbId !== undefined && dbId !== '') {
+      const n = Number(dbId);
+      if (!Number.isNaN(n)) target = n;
+    }
     let removed = false;
     for (let i = this.jobs.length - 1; i >= 0; i--) {
       const job = this.jobs[i];
-      if (job.dbId === dbId) {
+      if (job.dbId === target) {
         if (job.status === 'running' && job.jobId) {
           this.jobManager.stopJob(job.jobId);
         }

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2834,7 +2834,12 @@ app.post("/api/pipelineQueue", (req, res) => {
   if (!file || !type) {
     return res.status(400).json({ error: "Missing file or type" });
   }
-  const job = printifyQueue.enqueue(file, type, dbId || null, variant || null);
+  let parsedDbId = null;
+  if (dbId !== undefined && dbId !== null && dbId !== "") {
+    const n = parseInt(dbId, 10);
+    if (!Number.isNaN(n)) parsedDbId = n;
+  }
+  const job = printifyQueue.enqueue(file, type, parsedDbId, variant || null);
   console.debug(
     "[Server Debug] Enqueued job =>",
     JSON.stringify(job, null, 2)
@@ -2855,11 +2860,16 @@ app.delete("/api/pipelineQueue/db/:dbId", (req, res) => {
     "[Server Debug] DELETE /api/pipelineQueue/db/:dbId =>",
     req.params.dbId
   );
-  const ok = printifyQueue.removeByDbId(req.params.dbId);
+  let parsedDbId = null;
+  if (req.params.dbId !== undefined && req.params.dbId !== null && req.params.dbId !== "") {
+    const n = parseInt(req.params.dbId, 10);
+    if (!Number.isNaN(n)) parsedDbId = n;
+  }
+  const ok = printifyQueue.removeByDbId(parsedDbId);
   if (!ok) return res.status(404).json({ error: "Jobs not found" });
   console.debug(
     "[Server Debug] Jobs removed for DB =>",
-    req.params.dbId,
+    parsedDbId,
     JSON.stringify(printifyQueue.list(), null, 2)
   );
   res.json({ removed: true });


### PR DESCRIPTION
## Summary
- normalize `dbId` values when enqueuing pipeline jobs so that jobs are grouped correctly
- parse numeric `dbId` in server routes that enqueue or remove jobs

## Testing
- `node test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_6861f2523398832385cd84c7ede0b617