### PR TITLE
Add persistent job history with log page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ TaskQueue/.env
 printifyQueue.json
  
 mosaic/
+jobsHistory.json

--- a/Aurora/.gitignore
+++ b/Aurora/.gitignore
@@ -23,3 +23,4 @@ backups
 uploads
 markdown_global.txt
 chrome-profile
+jobsHistory.json

--- a/Aurora/public/jobs_log.html
+++ b/Aurora/public/jobs_log.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Jobs Log</title>
+  <link rel="stylesheet" href="/styles.css">
+  <link
+    id="favicon"
+    rel="icon"
+    type="image/svg+xml"
+    href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><polygon points='32,4 4,60 60,60' fill='black' /></svg>"
+  >
+</head>
+<body style="padding:1rem;">
+  <h2>Jobs Log</h2>
+  <ul id="jobsList"></ul>
+  <pre id="terminal" style="background:#000;color:#0f0;padding:0.5rem;margin-top:0.5rem;height:80vh;overflow:auto;font-family:monospace;resize:vertical;"></pre>
+  <dialog id="printifyDialog" style="padding:1rem;"></dialog>
+<script>
+const defaultFavicon = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><polygon points='32,4 4,60 60,60' fill='black' /></svg>";
+const rotatingFavicon = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><polygon points='10,4 58,32 10,60' fill='black' /><path d='M32,4 A28,28 0 0 1 32,60' stroke='black' stroke-width='4' fill='none'><animateTransform attributeName='transform' type='rotate' from='0 32 32' to='360 32 32' dur='1s' repeatCount='indefinite' /></path></svg>";
+let favElement = document.getElementById('favicon');
+if(favElement) favElement.href = defaultFavicon;
+const printifyDialog = document.getElementById('printifyDialog');
+if(printifyDialog){
+  printifyDialog.addEventListener('click', () => printifyDialog.close());
+}
+
+let lastPrintifyMsg = '';
+function checkPrintifyStatus(msg){
+  if(!printifyDialog) return;
+  const match = msg.match(/Product URL:\s*(https?:\/\/\S+)/i);
+  if(match){
+    const url = match[1];
+    if(lastPrintifyMsg !== url){
+      printifyDialog.innerHTML = `Printify Product URL: <a href="${url}" target="_blank">${url}</a>`;
+      printifyDialog.showModal();
+      lastPrintifyMsg = url;
+    }
+    return;
+  }
+  if(/setting printify product url/i.test(msg)){
+    if(lastPrintifyMsg !== 'setting'){
+      printifyDialog.textContent = msg.trim();
+      printifyDialog.showModal();
+      lastPrintifyMsg = 'setting';
+    }
+  }
+}
+async function loadJobs() {
+  const res = await fetch('/api/jobHistory');
+  const jobs = await res.json();
+  const ul = document.getElementById('jobsList');
+  ul.innerHTML = '';
+  jobs.forEach(j => {
+    const li = document.createElement('li');
+    let text = `${j.file || j.command} - ${j.status}`;
+    if(j.resultPath){
+      text += ` -> ${j.resultPath}`;
+    }
+    li.textContent = text;
+    li.style.cursor = 'pointer';
+    li.addEventListener('click', () => openJob(j.id));
+    ul.appendChild(li);
+  });
+}
+let currentJobId = null;
+async function openJob(id) {
+  currentJobId = id;
+  const term = document.getElementById('terminal');
+  const logRes = await fetch(`/api/jobHistory/${id}/log`);
+  term.textContent = await logRes.text();
+}
+
+loadJobs();
+setInterval(loadJobs, 5000);
+
+const params = new URLSearchParams(window.location.search);
+const initialJob = params.get('jobId');
+if(initialJob){
+  openJob(initialJob);
+}
+</script>
+</body>
+</html>

--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -78,7 +78,11 @@
 <body style="padding:1rem;">
 <!--  <h2>Printify Pipeline Queue</h2>-->
 <h2>Design Production Queue</h2>
-  <p><a href="/">← Back</a></p>
+  <p>
+    <a href="/">← Back</a>
+    |
+    <a href="jobs_log.html" target="_blank">Jobs Log</a>
+  </p>
   <div id="addJob" style="margin-bottom:1rem;display:flex;align-items:center;gap:0.5rem;">
     <label>Type:
       <select id="jobType">

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -172,7 +172,8 @@ if (db.getSetting("show_session_id") === undefined) {
 const app = express();
 // Body parser must come before any routes that access req.body
 app.use(bodyParser.json());
-const jobManager = new JobManager();
+const jobHistoryPath = path.join(__dirname, "../jobsHistory.json");
+const jobManager = new JobManager({ historyPath: jobHistoryPath });
 
 // Printify configuration
 // Support both legacy PRINTIFY_TOKEN and the newer PRINTIFY_API_TOKEN env vars
@@ -2778,6 +2779,16 @@ app.post("/api/printify/updateProduct", async (req, res) => {
 
 app.get("/api/jobs", (req, res) => {
   res.json(jobManager.listJobs());
+});
+
+app.get("/api/jobHistory", (req, res) => {
+  res.json(jobManager.listHistory());
+});
+
+app.get("/api/jobHistory/:id/log", (req, res) => {
+  const rec = jobManager.getHistory(req.params.id);
+  if (!rec) return res.status(404).json({ error: "Job not found" });
+  res.type("text/plain").send(rec.log || "");
 });
 
 app.get("/api/jobs/:id/log", (req, res) => {


### PR DESCRIPTION
## Summary
- track all executed jobs and save to `jobsHistory.json`
- expose job history endpoints for server
- add a simple `jobs_log.html` page to view historical jobs
- ignore the new history JSON

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_6861fa441c74832388d1933d043e7b74