### PR TITLE
Fix queue order to show oldest first

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -187,11 +187,11 @@
         }
 
         for(const list of groups.values()){
-          list.sort((a,b) => parseTime(b) - parseTime(a));
+          list.sort((a,b) => parseTime(a) - parseTime(b));
         }
 
         const groupEntries = Array.from(groups.entries()).sort((a,b) => {
-          return parseTime(b[1][0]) - parseTime(a[1][0]);
+          return parseTime(a[1][0]) - parseTime(b[1][0]);
         });
 
         for(const [dbId, jobs] of groupEntries){


### PR DESCRIPTION
## Summary
- show pipeline queue items from oldest to newest

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6861fc3a6db08323ac2be6e1adaf6bf2