### PR TITLE
Fix Printify queue concurrency

### DIFF
--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -220,7 +220,7 @@ export default class PrintifyJobQueue {
       const job = this.jobs.find(
         (j) => j.status === 'queued' && !this._isProgramaticPuppetJob(j)
       );
-      if (job) return this._startJob(job, 'local');
+      if (job) this._startJob(job, 'local');
     }
 
     if (!this.currentPuppet) {
@@ -230,7 +230,7 @@ export default class PrintifyJobQueue {
           this._isProgramaticPuppetJob(j) &&
           !this._hasPendingLocalJobsForDbId(j.dbId)
       );
-      if (job) return this._startJob(job, 'puppet');
+      if (job) this._startJob(job, 'puppet');
     }
 
     return;


### PR DESCRIPTION
## Summary
- update PrintifyJobQueue to start both local and ProgramaticPuppet jobs in the same `_processNext` run

## Testing
- `node -e "console.log('no tests')"`

------
https://chatgpt.com/codex/tasks/task_b_6861fe0595608323ba8972c90613f2ac