### PR TITLE
Improve jobs log display

### DIFF
--- a/Aurora/public/jobs_log.html
+++ b/Aurora/public/jobs_log.html
@@ -13,7 +13,23 @@
 </head>
 <body style="padding:1rem;">
   <h2>Jobs Log</h2>
-  <ul id="jobsList"></ul>
+  <table id="historyTable">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>DB ID</th>
+        <th>Type</th>
+        <th>Location</th>
+        <th>Variant</th>
+        <th>Start</th>
+        <th>Finish</th>
+        <th>Status</th>
+        <th>Result Path</th>
+        <th>Product URL</th>
+      </tr>
+    </thead>
+    <tbody id="jobsList"></tbody>
+  </table>
   <pre id="terminal" style="background:#000;color:#0f0;padding:0.5rem;margin-top:0.5rem;height:80vh;overflow:auto;font-family:monospace;resize:vertical;"></pre>
   <dialog id="printifyDialog" style="padding:1rem;"></dialog>
 <script>
@@ -50,18 +66,27 @@ function checkPrintifyStatus(msg){
 async function loadJobs() {
   const res = await fetch('/api/jobHistory');
   const jobs = await res.json();
-  const ul = document.getElementById('jobsList');
-  ul.innerHTML = '';
+  const tbody = document.getElementById('jobsList');
+  tbody.innerHTML = '';
   jobs.forEach(j => {
-    const li = document.createElement('li');
-    let text = `${j.file || j.command} - ${j.status}`;
-    if(j.resultPath){
-      text += ` -> ${j.resultPath}`;
-    }
-    li.textContent = text;
-    li.style.cursor = 'pointer';
-    li.addEventListener('click', () => openJob(j.id));
-    ul.appendChild(li);
+    const tr = document.createElement('tr');
+    const startStr = j.startTime ? new Date(j.startTime).toLocaleString() : '';
+    const finishStr = j.finishTime ? new Date(j.finishTime).toLocaleString() : '';
+    tr.innerHTML = `
+      <td>${j.id}</td>
+      <td>${j.dbId || ''}</td>
+      <td>${j.type || ''}</td>
+      <td>${j.location || ''}</td>
+      <td>${j.variant || ''}</td>
+      <td>${startStr}</td>
+      <td>${finishStr}</td>
+      <td>${j.status}</td>
+      <td>${j.resultPath || ''}</td>
+      <td>${j.productUrl ? `<a href="${j.productUrl}" target="_blank">${j.productUrl}</a>` : ''}</td>
+    `;
+    tr.style.cursor = 'pointer';
+    tr.addEventListener('click', () => openJob(j.id));
+    tbody.appendChild(tr);
   });
 }
 let currentJobId = null;

--- a/Aurora/src/jobManager.js
+++ b/Aurora/src/jobManager.js
@@ -34,7 +34,7 @@ export default class JobManager {
     }
   }
 
-  createJob(command, args = [], { cwd, file } = {}) {
+  createJob(command, args = [], { cwd, file, extra } = {}) {
     const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
     const job = {
       id,
@@ -42,6 +42,7 @@ export default class JobManager {
       args,
       cwd,
       file,
+      ...(extra || {}),
       resultPath: null,
       productUrl: null,
       status: "running",
@@ -51,6 +52,7 @@ export default class JobManager {
       listeners: [],
       doneListeners: [],
     };
+    job.extra = extra || {};
 
     const child = child_process.spawn(command, args, { cwd });
     job.child = child;
@@ -93,6 +95,7 @@ export default class JobManager {
       resultPath: null,
       productUrl: null,
       log: "",
+      ...(extra || {}),
     };
     job.historyRecord = record;
     this.history.push(record);
@@ -132,6 +135,7 @@ export default class JobManager {
       finishTime: j.finishTime,
       resultPath: j.resultPath,
       productUrl: j.productUrl,
+      ...(j.extra || {}),
     }));
   }
 
@@ -145,6 +149,7 @@ export default class JobManager {
       finishTime: r.finishTime,
       resultPath: r.resultPath,
       productUrl: r.productUrl,
+      ...(r.extra || {}),
     }));
   }
 

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -421,7 +421,13 @@ export default class PrintifyJobQueue {
     }
     console.log(`[PrintifyJobQueue] Running ${job.type} with script: ${script}`);
     console.debug('[PrintifyJobQueue Debug] args =>', args.join(' '));
-    const jmJob = this.jobManager.createJob(script, args, { cwd, file: job.file });
+    const location = slot === 'local' ? 'Local' : 'ProgramaticPuppet';
+    job.location = location;
+    const jmJob = this.jobManager.createJob(script, args, {
+      cwd,
+      file: job.file,
+      extra: { type: job.type, dbId: job.dbId, variant: job.variant, location },
+    });
     job.jobId = jmJob.id;
     job.startTime = jmJob.startTime;
     this.jobManager.addDoneListener(jmJob, () => {


### PR DESCRIPTION
## Summary
- allow extra fields to be stored with each JobManager record
- pipe printify queue job metadata to JobManager
- show a table of detailed records in Jobs Log

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6862015705108323aa24f4e585f69cc6