### PR TITLE
Enable collapsible DB groups in queue UI

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -154,7 +154,10 @@
         });
       };
     }
-    const collapsedGroups = new Set();
+    const collapsedGroups = new Set(JSON.parse(localStorage.getItem('collapsedQueueGroups') || '[]'));
+    const saveCollapsed = () => {
+      localStorage.setItem('collapsedQueueGroups', JSON.stringify([...collapsedGroups]));
+    };
     const titleCache = {};
     async function getTitle(file){
       if(titleCache.hasOwnProperty(file)) return titleCache[file];
@@ -262,6 +265,7 @@
                 collapsedGroups.add(dbId);
                 toggle.textContent = '[+]';
               }
+              saveCollapsed();
               tbody.querySelectorAll(`tr[data-dbid="${dbId}"]`).forEach(r => {
                 if(r !== groupTr) r.style.display = collapsedGroups.has(dbId) ? 'none' : '';
               });
@@ -562,6 +566,8 @@ async function updateVariantUI(file){
       console.debug('[Queue UI] removeJobsByDbId', dbId);
       try{
         await fetch(`api/pipelineQueue/db/${encodeURIComponent(dbId)}`, { method: 'DELETE' });
+        collapsedGroups.delete(String(dbId));
+        saveCollapsed();
         await loadQueue();
       }catch(e){
         console.error('Failed to remove jobs', e);


### PR DESCRIPTION
## Summary
- persist collapsed DB ID groups in local storage
- update click handlers to save the collapsed state
- clear collapsed state when removing a DB ID group

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6862017abeb88323a50ca8335fe5d505