### PR TITLE
Fix DB ID display in Jobs Log

### DIFF
--- a/Aurora/src/jobManager.js
+++ b/Aurora/src/jobManager.js
@@ -96,6 +96,7 @@ export default class JobManager {
       productUrl: null,
       log: "",
       ...(extra || {}),
+      extra: extra || {},
     };
     job.historyRecord = record;
     this.history.push(record);
@@ -140,17 +141,10 @@ export default class JobManager {
   }
 
   listHistory() {
-    return this.history.map((r) => ({
-      id: r.id,
-      file: r.file,
-      command: r.command,
-      status: r.status,
-      startTime: r.startTime,
-      finishTime: r.finishTime,
-      resultPath: r.resultPath,
-      productUrl: r.productUrl,
-      ...(r.extra || {}),
-    }));
+    return this.history.map((r) => {
+      const { args, cwd, log, extra, ...rest } = r;
+      return { ...rest, ...(extra || {}) };
+    });
   }
 
   getHistory(id) {


### PR DESCRIPTION
## Summary
- preserve job `extra` data in history entries
- include any stored extras when listing job history

## Testing
- `node -e "require('./Aurora/src/jobManager.js');"`

------
https://chatgpt.com/codex/tasks/task_b_686203d5eb1c8323a51e68d882a19df9