### PR TITLE
Fix Printify title removal

### DIFF
--- a/Aurora/scripts/printifyTitleFix.js
+++ b/Aurora/scripts/printifyTitleFix.js
@@ -72,12 +72,13 @@ async function main() {
     // Remove any quotation marks that might wrap or appear in the title
     optimizedTitle = optimizedTitle.replace(/["']/g, '').trim();
 
-    // Strip gendered words like "Men's" or "Women's" to keep the title neutral
-    optimizedTitle = optimizedTitle
-      .replace(/\bmen'?s\b/gi, '')
-      .replace(/\bwomen'?s\b/gi, '')
-      .replace(/\s{2,}/g, ' ')
-      .trim();
+  // Strip gendered words like "Men's" or "Women's" and remove "Urban" to keep the title neutral
+  optimizedTitle = optimizedTitle
+    .replace(/\bmen'?s\b/gi, '')
+    .replace(/\bwomen'?s\b/gi, '')
+    .replace(/\burban\b/gi, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
 
     // Retry updating the title if Printify temporarily disables editing
     const updateTitle = async () => {


### PR DESCRIPTION
## Summary
- strip the word "Urban" in the Printify title fix script

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686208164234832396665782b23384c3