### PR TITLE
Fix Printify Title to exclude whimsical

### DIFF
--- a/Aurora/scripts/printifyTitleFix.js
+++ b/Aurora/scripts/printifyTitleFix.js
@@ -77,6 +77,7 @@ async function main() {
     .replace(/\bmen'?s\b/gi, '')
     .replace(/\bwomen'?s\b/gi, '')
     .replace(/\burban\b/gi, '')
+    .replace(/\bwhimsical\b/gi, '')
     .replace(/\s{2,}/g, ' ')
     .trim();
 


### PR DESCRIPTION
## Summary
- clean Printify-generated titles by removing the word `whimsical`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686209849ba08323a5327731b7b9888d