### PR TITLE
Add retry failed jobs button

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -122,6 +122,7 @@
     <button id="enqueueBtn">Add to Queue</button>
     <button id="hideSelectedBtn" style="margin-left:0.5rem;">Hide</button>
     <button id="stopAllBtn" style="margin-left:0.5rem;">Stop All</button>
+    <button id="retryFailedBtn" style="margin-left:0.5rem;">Retry Failed</button>
     <span id="queueState" style="margin-left:0.5rem;">Running</span>
     <button id="pauseBtn" style="margin-left:0.5rem;">Pause</button>
   </div>
@@ -649,6 +650,15 @@ async function updateVariantUI(file){
         await loadQueue();
       }catch(e){
         console.error('Failed to stop all jobs', e);
+      }
+    });
+
+    document.getElementById('retryFailedBtn').addEventListener('click', async () => {
+      try{
+        await fetch('api/pipelineQueue/retryFailed', { method: 'POST' });
+        await loadQueue();
+      }catch(e){
+        console.error('Failed to retry failed jobs', e);
       }
     });
 

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -213,6 +213,25 @@ export default class PrintifyJobQueue {
     this._saveJobs();
   }
 
+  retryFailed() {
+    let count = 0;
+    for (const job of this.jobs) {
+      if (job.status === 'failed' || job.status === 'error') {
+        job.status = 'queued';
+        job.jobId = null;
+        job.startTime = null;
+        job.finishTime = null;
+        job.resultPath = null;
+        count++;
+      }
+    }
+    if (count > 0) {
+      this._saveJobs();
+      this._processNext();
+    }
+    return count;
+  }
+
   _processNext() {
     if (this.paused) return;
 

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2899,6 +2899,18 @@ app.post("/api/pipelineQueue/stopAll", (req, res) => {
   res.json({ stopped: true });
 });
 
+app.post("/api/pipelineQueue/retryFailed", (req, res) => {
+  console.debug("[Server Debug] POST /api/pipelineQueue/retryFailed");
+  const count = printifyQueue.retryFailed();
+  console.debug(
+    "[Server Debug] retryFailed called. Count =>",
+    count,
+    "Queue =>",
+    JSON.stringify(printifyQueue.list(), null, 2)
+  );
+  res.json({ retried: count });
+});
+
 app.get("/api/pipelineQueue/state", (req, res) => {
   console.debug("[Server Debug] GET /api/pipelineQueue/state");
   const paused = printifyQueue.isPaused();


### PR DESCRIPTION
## Summary
- add retryFailed method on Printify queue
- expose API endpoint for retrying failed jobs
- add Retry Failed button to pipeline queue UI

## Testing
- `npm run lint --prefix Aurora`
- `node test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_686212e50b1c8323bdda1c109a092232