### PR TITLE
Fix queue header status when pending jobs exist

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -226,10 +226,10 @@
             let groupStatus = 'queued';
             if(jobs.some(j => j.status === 'failed' || j.status === 'error')){
               groupStatus = 'failed';
-            }else if(finalizeJob && finalizeJob.status === 'finished'){
-              groupStatus = 'finished';
             }else if(jobs.some(j => j.status === 'running')){
               groupStatus = 'running';
+            }else if(finalizeJob && finalizeJob.status === 'finished' && !jobs.some(j => j.status === 'queued')){
+              groupStatus = 'finished';
             }
             const statusHtml = (() => {
               if(groupStatus === 'running') return 'Running <span class="loading-spinner"></span>';


### PR DESCRIPTION
## Summary
- show `queued` status on pipeline queue group headers when unfinished jobs remain

## Testing
- `npm --silent run lint --prefix Aurora`

------
https://chatgpt.com/codex/tasks/task_b_68621a65cd1c83238a1881fd4ff8e078