### PR TITLE
Update Printify title fix retries

### DIFF
--- a/Aurora/scripts/printifyTitleFix.js
+++ b/Aurora/scripts/printifyTitleFix.js
@@ -105,7 +105,7 @@ async function main() {
           err.response?.data?.errors?.reason || err.response?.data?.message;
         const code = err.response?.data?.code;
         if (
-          attempt < 9 &&
+          attempt < 2 &&
           (reason === 'Product is disabled for editing' || code === 8252)
         ) {
           attempt++;


### PR DESCRIPTION
## Summary
- limit `printifyTitleFix.js` retries to two attempts

## Testing
- `npm test` in `AutoPR` package (prints "No tests specified")
- `npm test` in `Aurora` package (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_6862209523348323b86163b8c332755f