### PR TITLE
Add remote job queue API

### DIFF
--- a/Aurora/README.md
+++ b/Aurora/README.md
@@ -54,3 +54,21 @@ so the specified user can access the key and certificate without root.
    - Create new secret key and paste into `.env`
 
 The script prints matching open issues and the current queue size.
+
+### Job Queue Node API
+A small helper class is provided for interacting with the printify pipeline queue from other Node.js processes. This allows running another Aurora server instance on a different machine and enqueueing jobs remotely.
+
+```javascript
+import JobQueueApi from './src/jobQueueApi.js';
+
+const api = new JobQueueApi({ baseURL: 'http://remote-host:3000' });
+
+// Add a job
+await api.enqueue('image.png', 'upscale');
+
+// Check current queue
+const queue = await api.list();
+console.log(queue);
+```
+
+All queue endpoints exposed by `server.js` are available through this API: `enqueue`, `remove`, `removeByDbId`, `stopAll`, `pause`, `resume`, and `state`.

--- a/Aurora/src/jobQueueApi.js
+++ b/Aurora/src/jobQueueApi.js
@@ -1,0 +1,57 @@
+import axios from 'axios';
+import https from 'https';
+
+export default class JobQueueApi {
+  constructor({ baseURL } = {}) {
+    this.baseURL = baseURL || 'http://localhost:3000';
+    this.axios = axios.create({
+      baseURL: this.baseURL,
+      httpsAgent: this.baseURL.startsWith('https://')
+        ? new https.Agent({ rejectUnauthorized: false })
+        : undefined,
+    });
+  }
+
+  async list() {
+    const { data } = await this.axios.get('/api/pipelineQueue');
+    return data;
+  }
+
+  async enqueue(file, type, dbId = null, variant = null) {
+    const { data } = await this.axios.post('/api/pipelineQueue', {
+      file,
+      type,
+      dbId,
+      variant,
+    });
+    return data;
+  }
+
+  async remove(id) {
+    await this.axios.delete(`/api/pipelineQueue/${id}`);
+    return true;
+  }
+
+  async removeByDbId(dbId) {
+    await this.axios.delete(`/api/pipelineQueue/db/${dbId}`);
+    return true;
+  }
+
+  async stopAll() {
+    await this.axios.post('/api/pipelineQueue/stopAll');
+    return true;
+  }
+
+  async pause() {
+    await this.axios.post('/api/pipelineQueue/pause');
+  }
+
+  async resume() {
+    await this.axios.post('/api/pipelineQueue/resume');
+  }
+
+  async state() {
+    const { data } = await this.axios.get('/api/pipelineQueue/state');
+    return data;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `JobQueueApi` helper for interacting with the pipeline queue via HTTP
- document how to use the API for running jobs on another Aurora instance

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6862022423748323b3b4d8353a8ba1d1