### PR TITLE
Collapse new queue groups

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -157,6 +157,7 @@
       };
     }
     const collapsedGroups = new Set(JSON.parse(localStorage.getItem('collapsedQueueGroups') || '[]'));
+    const seenDbIds = new Set();
     const saveCollapsed = () => {
       localStorage.setItem('collapsedQueueGroups', JSON.stringify([...collapsedGroups]));
     };
@@ -205,6 +206,12 @@
 
         for(const [dbId, jobs] of groupEntries){
           if(dbId){
+            const isNewGroup = !seenDbIds.has(dbId);
+            seenDbIds.add(dbId);
+            if(isNewGroup && !collapsedGroups.has(dbId)){
+              collapsedGroups.add(dbId);
+              saveCollapsed();
+            }
             const firstJob = jobs[0];
             const groupTr = document.createElement('tr');
             groupTr.className = 'db-group';


### PR DESCRIPTION
## Summary
- auto-collapse new DB ID groups in `pipeline_queue.html`

## Testing
- `npm run lint` *(fails: (no linter configured))*
- `node Aurora/test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_68623ab4a03883238a6e1c4a0f9b5c05