### PR TITLE
Fix queue header status logic

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -224,10 +224,10 @@
             const finishTime = finalizeJob && finalizeJob.finishTime ? finalizeJob.finishTime : null;
             const productUrl = (finalizeJob && finalizeJob.productUrl) || (jobs.find(j => j.productUrl) || {}).productUrl || '';
             let groupStatus = 'queued';
-            if(jobs.some(j => j.status === 'failed' || j.status === 'error')){
-              groupStatus = 'failed';
-            }else if(jobs.some(j => j.status === 'running')){
+            if(jobs.some(j => j.status === 'running')){
               groupStatus = 'running';
+            }else if(jobs.some(j => j.status === 'failed' || j.status === 'error')){
+              groupStatus = 'failed';
             }else if(finalizeJob && finalizeJob.status === 'finished' && !jobs.some(j => j.status === 'queued')){
               groupStatus = 'finished';
             }


### PR DESCRIPTION
## Summary
- mark group header as running before failed when any child is running

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68623942763c8323acb34a82afbc257a