### PR TITLE
Add sidebar hide on queue

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -522,13 +522,15 @@
           const id = f.id ?? '';
           const btnOrig = document.createElement('button');
           btnOrig.textContent = 'All - Original';
-          btnOrig.addEventListener('click', () => {
-            queueAllVariants(f.name, id, ['normal']);
+          btnOrig.addEventListener('click', async () => {
+            await queueAllVariants(f.name, id, ['normal']);
+            await hideImageUI(f.name, div);
           });
           const btnNobg = document.createElement('button');
           btnNobg.textContent = 'All - No BG';
-          btnNobg.addEventListener('click', () => {
-            queueAllVariants(f.name, id, ['nobg']);
+          btnNobg.addEventListener('click', async () => {
+            await queueAllVariants(f.name, id, ['nobg']);
+            await hideImageUI(f.name, div);
           });
           const btnContainer = document.createElement('div');
           btnContainer.appendChild(btnOrig);
@@ -543,6 +545,29 @@
       }
       sidebarLoading = false;
       document.getElementById('sidebarLoading').style.display = 'none';
+    }
+
+    async function hideImageUI(file, entryDiv){
+      try{
+        await fetch('api/upload/hidden', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: file, hidden: true })
+        });
+        const opt = optionsDiv.querySelector(`.option[data-value="${CSS.escape(file)}"]`);
+        opt?.remove();
+        if(dropdown.dataset.value === file || dropdown.value === file){
+          selectedDiv.textContent = '-- choose --';
+          dropdown.dataset.value = '';
+          dropdown.value = '';
+          dropdown.dataset.id = '';
+          updatePreview('');
+          updateVariantUI('');
+        }
+        entryDiv?.remove();
+      }catch(err){
+        console.error('Failed to hide image', err);
+      }
     }
 
     function hideSidebar(){


### PR DESCRIPTION
## Summary
- hide sidebar images after queuing all variants
- mark images hidden via new `hideImageUI` helper

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68625293abb083238dcd826b46aceafb