### PR TITLE
Fix queue sidebar image ratio

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -82,8 +82,9 @@
     .thumb-entry img {
       display: block;
       width: 100%;
-      max-width: 100%;
-      max-height: 200px;
+      max-width: 200px;
+      aspect-ratio: 1 / 1;
+      object-fit: cover;
       border: 1px solid #444;
     }
     .thumb-entry button {


### PR DESCRIPTION
## Summary
- fix CSS for queue sidebar thumbnails so images always render at 1:1 aspect ratio

## Testing
- `npm run lint` in `Aurora` (prints `(no linter configured)`)

------
https://chatgpt.com/codex/tasks/task_b_6862b72d309c8323913bb8955df6fd98