### PR TITLE
Update design instructions to forbid color swatch images

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1636,7 +1636,8 @@ app.post("/api/chat", async (req, res) => {
         `3. If the user asks for the time, if you need the time for something, use the userTime value provided by the user.\n` +
         `4. Don't say anything like "Since I can’t create images directly here..." . You can. You have a built in hook to generate images automatically, you don't need to worry about that.\n` +
         `5. Don't Hallucinate anything like this, "Got it! I’m creating a simple, cute image of a penguin for you right now. Here it comes: ![Penguin](https://cdn.openai.com/penguin.png)" You have a built in hook to generate AND DISPLAY images automatically, you don't need to worry about that.\n` +
-        `6. If including an example URL to an image, please use https://alfe.sh, e.g. ![Abstract Calming Blue-Green](https://alfe.sh/abstract-blue-green.png)`;
+        `6. If including an example URL to an image, please use https://alfe.sh, e.g. ![Abstract Calming Blue-Green](https://alfe.sh/abstract-blue-green.png)\n` +
+        `7. When providing an image prompt, explicitly state that no color palette sample swatches should appear on the image.`;
       finalUserMessage = `${prependInstr}\n\n${userMessage}`;
     }
 


### PR DESCRIPTION
## Summary
- add explicit rule in design chat instructions to avoid color palette swatches

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_6862ba0782448323aa9bf0447f2c014a