### PR TITLE
Add hide button to queue sidebar

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -539,9 +539,15 @@
             await queueAllVariants(f.name, id, ['nobg']);
             await hideImageUI(f.name, div);
           });
+          const btnHide = document.createElement('button');
+          btnHide.textContent = 'Hide';
+          btnHide.addEventListener('click', async () => {
+            await hideImageUI(f.name, div);
+          });
           const btnContainer = document.createElement('div');
           btnContainer.appendChild(btnOrig);
           btnContainer.appendChild(btnNobg);
+          btnContainer.appendChild(btnHide);
           div.appendChild(btnContainer);
           container.appendChild(div);
         });


### PR DESCRIPTION
## Summary
- allow hiding sidebar images without adding them to the queue

## Testing
- `npm run lint` in `Aurora`
- `node test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_6862d468f314832387a1cdb893fc05d2