### PR TITLE
Enable queue reordering via drag‑drop

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -246,9 +246,11 @@
             const titlePart = title ? ` - ${title}` : '';
             groupTr.innerHTML = `<td colspan="12"><span class="toggle">${collapsed ? '[+]' : '[-]'}</span> DB ID: ${dbId}${titlePart}<img src="uploads/${encodeURIComponent(firstJob.file)}" style="max-height:40px;margin-left:0.5rem;vertical-align:middle;" /> <button class="hideImageBtn" data-file="${encodeURIComponent(firstJob.file)}" style="margin-left:0.5rem;">Hide Image</button> <button class="removeDbBtn" data-dbid="${dbId}" style="margin-left:0.5rem;">Remove All</button></td>`;
             tbody.appendChild(groupTr);
+            groupTr.draggable = true;
             const headerTr = document.createElement('tr');
             headerTr.className = 'group-header';
             headerTr.dataset.dbid = dbId;
+            headerTr.draggable = true;
 
             const startTimes = jobs.map(j => j.startTime).filter(t => t);
             const earliestStart = startTimes.length ? Math.min(...startTimes) : null;
@@ -380,6 +382,8 @@
             <td><button data-id="${job.id}" class="removeBtn">Remove</button></td>
           `;
             tr.dataset.dbid = job.dbId || '';
+            tr.dataset.id = job.id;
+            tr.draggable = true;
             if(job.dbId && collapsedGroups.has(job.dbId)) tr.style.display = 'none';
             tbody.appendChild(tr);
             tr.querySelector('.removeBtn').addEventListener('click', async () => {
@@ -770,6 +774,58 @@ async function updateVariantUI(file){
       retryCountdown = RETRY_INTERVAL;
       updateRetryCountdown();
     });
+
+    const tbodyEl = document.querySelector('#queueTable tbody');
+    let dragRow = null;
+    tbodyEl.addEventListener('dragstart', ev => {
+      const row = ev.target.closest('tr');
+      if(row){
+        dragRow = row;
+        ev.dataTransfer.effectAllowed = 'move';
+      }
+    });
+    tbodyEl.addEventListener('dragover', ev => {
+      if(dragRow) ev.preventDefault();
+    });
+    tbodyEl.addEventListener('drop', ev => {
+      ev.preventDefault();
+      const target = ev.target.closest('tr');
+      if(!dragRow || !target || dragRow === target){ dragRow = null; return; }
+      if(dragRow.classList.contains('db-group') || dragRow.classList.contains('group-header')){
+        const dbId = dragRow.dataset.dbid;
+        const rows = Array.from(tbodyEl.querySelectorAll(`tr[data-dbid="${CSS.escape(dbId)}"]`));
+        const frag = document.createDocumentFragment();
+        rows.forEach(r => frag.appendChild(r));
+        let insertBefore = target;
+        if(!target.classList.contains('db-group') && !target.classList.contains('group-header')){
+          insertBefore = tbodyEl.querySelector(`tr.db-group[data-dbid="${CSS.escape(target.dataset.dbid)}"]`) || target;
+        }
+        tbodyEl.insertBefore(frag, insertBefore);
+      } else {
+        if(target.classList.contains('db-group') || target.classList.contains('group-header')){ dragRow = null; return; }
+        tbodyEl.insertBefore(dragRow, target);
+      }
+      dragRow = null;
+      saveNewOrder();
+    });
+    tbodyEl.addEventListener('dragend', () => { dragRow = null; });
+
+    async function saveNewOrder(){
+      const ids = [];
+      document.querySelectorAll('#queueTable tbody tr').forEach(tr => {
+        if(tr.dataset.id) ids.push(tr.dataset.id);
+      });
+      if(ids.length === 0) return;
+      try{
+        await fetch('api/pipelineQueue/reorder', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ids })
+        });
+      }catch(e){
+        console.error('Failed to reorder queue', e);
+      }
+    }
 
     setInterval(updateRetryCountdown, 1000);
     updateRetryCountdown();

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -232,6 +232,29 @@ export default class PrintifyJobQueue {
     return count;
   }
 
+  reorder(idList) {
+    if (!Array.isArray(idList)) return false;
+    const idSet = new Set();
+    const newJobs = [];
+    for (const id of idList) {
+      const idx = this.jobs.findIndex((j) => j.id === id);
+      if (idx !== -1) {
+        newJobs.push(this.jobs[idx]);
+        idSet.add(id);
+      }
+    }
+    for (const job of this.jobs) {
+      if (!idSet.has(job.id)) newJobs.push(job);
+    }
+    if (newJobs.length === this.jobs.length) {
+      this.jobs = newJobs;
+      this._saveJobs();
+      this._processNext();
+      return true;
+    }
+    return false;
+  }
+
   _processNext() {
     if (this.paused) return;
 

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2911,6 +2911,19 @@ app.post("/api/pipelineQueue/retryFailed", (req, res) => {
   res.json({ retried: count });
 });
 
+app.post("/api/pipelineQueue/reorder", (req, res) => {
+  console.debug("[Server Debug] POST /api/pipelineQueue/reorder =>", req.body);
+  const ids = Array.isArray(req.body?.ids) ? req.body.ids : [];
+  const ok = printifyQueue.reorder(ids);
+  console.debug(
+    "[Server Debug] reorder result =>",
+    ok,
+    JSON.stringify(printifyQueue.list(), null, 2)
+  );
+  if (!ok) return res.status(400).json({ error: "Invalid ids" });
+  res.json({ reordered: true });
+});
+
 app.get("/api/pipelineQueue/state", (req, res) => {
   console.debug("[Server Debug] GET /api/pipelineQueue/state");
   const paused = printifyQueue.isPaused();

--- a/Aurora/test/pipelineQueueRoute.test.cjs
+++ b/Aurora/test/pipelineQueueRoute.test.cjs
@@ -47,6 +47,19 @@ async function runTests() {
     console.log('✓ Job appears in queue');
     console.log('Updated queue:\n', JSON.stringify(listRes.data, null, 2));
   }
+
+  if (process.argv.includes('--reorder')) {
+    const listRes = await axios
+      .get(`${baseUrl}/api/pipelineQueue`, opts)
+      .catch((err) => err.response || err);
+    assert.strictEqual(listRes.status, 200, `Expected 200, got ${listRes.status}`);
+    const ids = listRes.data.map((j) => j.id).reverse();
+    const reorderRes = await axios
+      .post(`${baseUrl}/api/pipelineQueue/reorder`, { ids }, opts)
+      .catch((err) => err.response || err);
+    assert.strictEqual(reorderRes.status, 200, `Expected 200, got ${reorderRes.status}`);
+    console.log('✓ POST /api/pipelineQueue/reorder');
+  }
 }
 
 runTests().catch(err => {


### PR DESCRIPTION
## Summary
- allow dragging rows in the queue UI
- send new order to server
- implement reorder logic on server
- add optional test for reorder endpoint

## Testing
- `npm run lint`
- `node test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_68624360d1548323ae8c943288701621