### PR TITLE
Add remove finished queue option

### DIFF
--- a/Aurora/README.md
+++ b/Aurora/README.md
@@ -71,4 +71,4 @@ const queue = await api.list();
 console.log(queue);
 ```
 
-All queue endpoints exposed by `server.js` are available through this API: `enqueue`, `remove`, `removeByDbId`, `stopAll`, `pause`, `resume`, and `state`.
+All queue endpoints exposed by `server.js` are available through this API: `enqueue`, `remove`, `removeByDbId`, `removeFinished`, `stopAll`, `pause`, `resume`, and `state`.

--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -152,6 +152,7 @@
     <button id="hideSelectedBtn" style="margin-left:0.5rem;">Hide</button>
     <button id="stopAllBtn" style="margin-left:0.5rem;">Stop All</button>
     <button id="retryFailedBtn" style="margin-left:0.5rem;">Retry Failed</button>
+    <button id="removeFinishedBtn" style="margin-left:0.5rem;">Remove All Finished</button>
     <label style="margin-left:0.5rem;">
       <input type="checkbox" id="autoRetryCheckbox" /> Auto Retry Failed
     </label>
@@ -801,6 +802,16 @@ async function updateVariantUI(file){
         await loadQueue();
       }catch(e){
         console.error('Failed to retry failed jobs', e);
+      }
+    });
+
+    document.getElementById('removeFinishedBtn').addEventListener('click', async () => {
+      if(!confirm('Remove all finished jobs?')) return;
+      try{
+        await fetch('api/pipelineQueue/finished', { method: 'DELETE' });
+        await loadQueue();
+      }catch(e){
+        console.error('Failed to remove finished jobs', e);
       }
     });
 

--- a/Aurora/src/jobQueueApi.js
+++ b/Aurora/src/jobQueueApi.js
@@ -37,6 +37,11 @@ export default class JobQueueApi {
     return true;
   }
 
+  async removeFinished() {
+    await this.axios.delete('/api/pipelineQueue/finished');
+    return true;
+  }
+
   async stopAll() {
     await this.axios.post('/api/pipelineQueue/stopAll');
     return true;

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2890,6 +2890,18 @@ app.delete("/api/pipelineQueue/db/:dbId", (req, res) => {
   res.json({ removed: true });
 });
 
+app.delete("/api/pipelineQueue/finished", (req, res) => {
+  console.debug("[Server Debug] DELETE /api/pipelineQueue/finished");
+  const count = printifyQueue.removeFinished();
+  console.debug(
+    "[Server Debug] removeFinished called. Count =>",
+    count,
+    "Queue =>",
+    JSON.stringify(printifyQueue.list(), null, 2)
+  );
+  res.json({ removed: count });
+});
+
 app.post("/api/pipelineQueue/stopAll", (req, res) => {
   console.debug("[Server Debug] POST /api/pipelineQueue/stopAll");
   printifyQueue.stopAll();


### PR DESCRIPTION
## Summary
- add a button to remove all finished groups from the design production queue UI
- support removing finished groups on the backend and in the JobQueue API
- document the new endpoint

## Testing
- `npm test` in AutoPR (no tests specified)
- `npm test` in VMRunner *(fails: no test specified)*
- `npm run lint` in Aurora
- `npm test` in Sterling *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6862bed6d1248323aeef12eb2fa7bb12