### PR TITLE
Fix finished-job removal

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -267,7 +267,8 @@
 
             const startTimes = jobs.map(j => j.startTime).filter(t => t);
             const earliestStart = startTimes.length ? Math.min(...startTimes) : null;
-            const finalizeJob = jobs.find(j => j.type === 'printifyFinalize');
+            const finalizeJobs = jobs.filter(j => j.type === 'printifyFinalize');
+            const finalizeJob = finalizeJobs[finalizeJobs.length - 1];
             const finishTime = finalizeJob && finalizeJob.finishTime ? finalizeJob.finishTime : null;
             const productUrl = (finalizeJob && finalizeJob.productUrl) || (jobs.find(j => j.productUrl) || {}).productUrl || '';
             let groupStatus = 'queued';

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -209,7 +209,8 @@ export default class PrintifyJobQueue {
     let count = 0;
     for (const [dbId, list] of groups.entries()) {
       if (dbId === null || dbId === undefined) continue;
-      const finalizeJob = list.find(j => j.type === 'printifyFinalize');
+      const finalizeJobs = list.filter(j => j.type === 'printifyFinalize');
+      const finalizeJob = finalizeJobs[finalizeJobs.length - 1];
       if (
         finalizeJob &&
         finalizeJob.status === 'finished' &&


### PR DESCRIPTION
## Summary
- correctly select the latest finalize job when checking for finished groups
- update queue UI logic to use the last finalize job

## Testing
- `npm test` in AutoPR (no tests specified)
- `npm test` in VMRunner *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6862e2ed1dec8323a63bec05302c5c1b