### PR TITLE
Add Load More button to queue

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -179,6 +179,9 @@
     </thead>
     <tbody></tbody>
   </table>
+  <div style="text-align:center;margin-top:1rem;">
+    <button id="loadMoreBtn" style="display:none;">Load More</button>
+  </div>
   <script src="./session.js"></script>
   <script>
     console.debug('[Queue UI] script loaded');
@@ -209,6 +212,13 @@
       }
     }
 
+    const loadMoreBtn = document.getElementById('loadMoreBtn');
+    function updateLoadMoreBtn(){
+      if(!loadMoreBtn) return;
+      loadMoreBtn.style.display = queueHasMore ? 'block' : 'none';
+      loadMoreBtn.disabled = queueLoading;
+    }
+
     let queueOffset = 0;
     let queueHasMore = true;
     let queueLoading = false;
@@ -223,9 +233,11 @@
         queueHasMore = true;
         seenDbIds.clear();
         document.querySelector('#queueTable tbody').innerHTML = '';
+        updateLoadMoreBtn();
       }
       if(!queueHasMore) return;
       queueLoading = true;
+      updateLoadMoreBtn();
       await prefetchTitles();
       try{
         const res = await fetch(`api/pipelineQueue?limit=20&offset=${queueOffset}`);
@@ -423,6 +435,7 @@
         console.error('Failed to load queue', e);
       }
       queueLoading = false;
+      updateLoadMoreBtn();
     }
     const dropdown = document.getElementById('imageSelect');
     const selectedDiv = dropdown.querySelector('.selected');
@@ -922,10 +935,15 @@ async function updateVariantUI(file){
       }
     }
 
+    loadMoreBtn?.addEventListener('click', () => {
+      loadQueue();
+    });
+
     setInterval(updateRetryCountdown, 1000);
     updateRetryCountdown();
 
     loadQueue(true);
+    updateLoadMoreBtn();
     loadImages(true);
     loadSidebarImages(true);
     document.getElementById('imageSidebar').addEventListener('scroll', () => {


### PR DESCRIPTION
## Summary
- add a `Load More` button below the pipeline queue table
- wire button to fetch the next set of queue entries
- show or hide the button based on available data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6862e8f1c8048323a69d30ed20216bd3