### PR TITLE
Fix queue reorder persistence

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -246,13 +246,7 @@
           groups.get(key).push(job);
         }
 
-        for(const list of groups.values()){
-          list.sort((a,b) => parseTime(a) - parseTime(b));
-        }
-
-        const groupEntries = Array.from(groups.entries()).sort((a,b) => {
-          return parseTime(a[1][0]) - parseTime(b[1][0]);
-        });
+        const groupEntries = Array.from(groups.entries());
 
         for(const [dbId, jobs] of groupEntries){
           if(dbId){

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -152,26 +152,22 @@ export default class PrintifyJobQueue {
   listPaginatedByDbId(limit = 20, offset = 0) {
     const all = this.list();
     const groups = new Map();
-    const parseTime = (j) => {
-      if (j.startTime) return j.startTime;
-      const n = parseInt(j.id, 36);
-      return Number.isNaN(n) ? 0 : n;
-    };
     for (const job of all) {
       const key = job.dbId ?? '';
       if (!groups.has(key)) groups.set(key, []);
       groups.get(key).push(job);
     }
-    for (const list of groups.values()) {
-      list.sort((a, b) => parseTime(a) - parseTime(b));
-    }
-    const entries = Array.from(groups.values()).sort(
-      (a, b) => parseTime(a[0]) - parseTime(b[0])
-    );
+
+    const orderedKeys = Array.from(groups.keys());
     const start = offset > 0 ? offset : 0;
     const end = limit > 0 ? start + limit : undefined;
-    const slice = entries.slice(start, end);
-    return slice.flat();
+    const slice = orderedKeys.slice(start, end);
+
+    const result = [];
+    for (const key of slice) {
+      result.push(...groups.get(key));
+    }
+    return result;
   }
 
   remove(id) {


### PR DESCRIPTION
## Summary
- maintain job order when listing with pagination
- keep UI queue order without sorting

## Testing
- `npm run lint` in `Aurora`
- `node test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_6862e95992088323bf09697e371a3dc6