### PR TITLE
Add load-more button to queue sidebar

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -104,6 +104,7 @@
     <div id="imageSidebar" class="sidebar">
       <div id="thumbnailContainer"></div>
       <div id="sidebarLoading" class="loading-more" style="display:none;"><span class="loading-spinner"></span></div>
+      <button id="sidebarLoadMoreBtn" style="display:none;width:100%;margin-top:0.5rem;">Load More</button>
     </div>
     <div class="chat-panel" style="padding:1rem;">
 <!--  <h2>Printify Pipeline Queue</h2>-->
@@ -525,6 +526,13 @@
     let sidebarOffset = 0;
     let sidebarHasMore = true;
     let sidebarLoading = false;
+    const sidebarLoadMoreBtn = document.getElementById('sidebarLoadMoreBtn');
+
+    function updateSidebarLoadMore(){
+      if(!sidebarLoadMoreBtn) return;
+      sidebarLoadMoreBtn.style.display = sidebarHasMore ? 'block' : 'none';
+      sidebarLoadMoreBtn.disabled = sidebarLoading;
+    }
 
     async function loadSidebarImages(reset=false){
       console.debug('[Queue UI] loadSidebarImages reset=' + reset);
@@ -534,8 +542,12 @@
         sidebarHasMore = true;
         document.getElementById('thumbnailContainer').innerHTML = '';
       }
-      if(!sidebarHasMore) return;
+      if(!sidebarHasMore){
+        updateSidebarLoadMore();
+        return;
+      }
       sidebarLoading = true;
+      updateSidebarLoadMore();
       document.getElementById('sidebarLoading').style.display = 'block';
       try{
         const res = await fetch('api/upload/list?sessionId=' + encodeURIComponent(sessionId) + `&limit=20&offset=${sidebarOffset}&showHidden=0`);
@@ -579,6 +591,7 @@
       }
       sidebarLoading = false;
       document.getElementById('sidebarLoading').style.display = 'none';
+      updateSidebarLoadMore();
     }
 
     async function hideImageUI(file, entryDiv){
@@ -928,6 +941,10 @@ async function updateVariantUI(file){
     loadQueue(true);
     loadImages(true);
     loadSidebarImages(true);
+    updateSidebarLoadMore();
+    if(sidebarLoadMoreBtn){
+      sidebarLoadMoreBtn.addEventListener('click', () => loadSidebarImages());
+    }
     document.getElementById('imageSidebar').addEventListener('scroll', () => {
       const sb = document.getElementById('imageSidebar');
       if(sb.scrollTop + sb.clientHeight >= sb.scrollHeight - 5){


### PR DESCRIPTION
## Summary
- add `Load More` button to queue sidebar
- support clickable button to fetch more images

## Testing
- `node test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_6862e9a952008323b1e6e55cde95f855