### PR TITLE
Add colorIdentify step

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -118,6 +118,7 @@
     <label>Type:
       <select id="jobType">
         <option value="upscale">Upscale</option>
+        <option value="colorIdentify">Color Identify</option>
         <option value="printify">Printify</option>
         <option value="printifyTitleFix">Printify Title Fix</option>
         <option value="printifyFixMockups">Printify Fix Mockups</option>
@@ -524,7 +525,7 @@
     });
 
     async function queueAllVariants(file, dbId, variants){
-      const steps = ['upscale','printify','printifyTitleFix','printifyFixMockups','printifyFinalize'];
+      const steps = ['upscale','colorIdentify','printify','printifyTitleFix','printifyFixMockups','printifyFinalize'];
       for(const variant of variants){
         for(const step of steps){
           await fetch('api/pipelineQueue', {
@@ -726,7 +727,7 @@ async function updateVariantUI(file){
       console.debug('[Queue UI] enqueue clicked file=' + file + ' type=' + type + ' variant=' + variant);
       try{
         if(type === 'all'){
-          const steps = ['upscale','printify','printifyTitleFix','printifyFixMockups','printifyFinalize'];
+          const steps = ['upscale','colorIdentify','printify','printifyTitleFix','printifyFixMockups','printifyFinalize'];
           for(const step of steps){
             await fetch('api/pipelineQueue', {
               method: 'POST',

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -16,6 +16,7 @@ export default class PrintifyJobQueue {
     this.printifyPriceScript = options.printifyPriceScript || '';
     this.printifyTitleFixScript = options.printifyTitleFixScript || '';
     this.runPuppetScript = options.runPuppetScript || '';
+    this.colorIdentifyScript = options.colorIdentifyScript || '';
     this.db = options.db || null;
     this.persistencePath = options.persistencePath || null;
 
@@ -354,7 +355,8 @@ export default class PrintifyJobQueue {
       job.type === 'printifyPrice' ||
       job.type === 'printifyTitleFix' ||
       job.type === 'printifyFixMockups' ||
-      job.type === 'printifyFinalize'
+      job.type === 'printifyFinalize' ||
+      job.type === 'colorIdentify'
     ) {
       script =
         job.type === 'printify'
@@ -363,6 +365,8 @@ export default class PrintifyJobQueue {
           ? this.printifyPriceScript
           : job.type === 'printifyTitleFix'
           ? this.printifyTitleFixScript
+          : job.type === 'colorIdentify'
+          ? this.colorIdentifyScript
           : this.runPuppetScript;
       const ext = path.extname(filePath);
       const base = path.basename(filePath, ext);
@@ -556,6 +560,11 @@ export default class PrintifyJobQueue {
             this.db.setImageTitle(originalUrl, title);
           }
         }
+      } else if (job.type === 'colorIdentify') {
+        const last = jmJob.log.trim().split(/[\r\n]+/).pop().trim();
+        if (last) {
+          job.resultPath = last;
+        }
       }
       if (this.db) {
         const statusMap = {
@@ -564,7 +573,8 @@ export default class PrintifyJobQueue {
           printifyPrice: 'Printify API Updates',
           printifyTitleFix: 'Printify API Title Fix',
           printifyFixMockups: 'Printify Fix Mockups',
-          printifyFinalize: 'Printify Finalize'
+          printifyFinalize: 'Printify Finalize',
+          colorIdentify: 'Color Identify'
         };
         const status = statusMap[job.type] || job.type;
         this.db.setImageStatus(originalUrl, status);

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -691,6 +691,7 @@ const printifyQueue = new PrintifyJobQueue(jobManager, {
   printifyTitleFixScript:
     process.env.PRINTIFY_TITLE_FIX_SCRIPT_PATH ||
     path.join(__dirname, "../scripts/printifyTitleFix.js"),
+  colorIdentifyScript: path.join(__dirname, "../scripts/detectColors.js"),
   runPuppetScript: path.join(__dirname, "../scripts/runPuppet.js"),
   db,
 });


### PR DESCRIPTION
## Summary
- add `colorIdentifyScript` option to queue
- detect colorIdentify jobs in queue and parse color output
- display Color Identify in queue UI and automate with "all" option
- expose detectColors script through server configuration

## Testing
- `npm --prefix Aurora run lint`

------
https://chatgpt.com/codex/tasks/task_b_686330a620f0832382194d79bf11a29c