### PR TITLE
Fix colorIdentify result path extraction

### DIFF
--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -561,7 +561,15 @@ export default class PrintifyJobQueue {
           }
         }
       } else if (job.type === 'colorIdentify') {
-        const last = jmJob.log.trim().split(/[\r\n]+/).pop().trim();
+        const lines = jmJob.log
+          .trim()
+          .split(/[\r\n]+/)
+          .map(l => l.trim())
+          .filter(Boolean);
+        const last = lines
+          .slice()
+          .reverse()
+          .find(l => !/^\[process exited/i.test(l));
         if (last) {
           job.resultPath = last;
         }


### PR DESCRIPTION
## Summary
- parse colorIdentify logs ignoring the exit message

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686336377ae48323bc8cd816f8b68d4e