### PR TITLE
Update titles and favicon

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Alfe AI - AI Image Design and Software Development Platform</title>
+  <title>Alfe - AI Image Design and Software Development Platform</title>
   <link id="themeStylesheet" rel="stylesheet" href="/styles.css" />
   <link
           id="favicon"

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1,6 +1,6 @@
 // sessionId is defined in session.js and available globally
 // sessionId is provided globally by session.js
-const defaultTitle = "Alfe AI - AI Image Design and Software Development Platform";
+const defaultTitle = "Alfe - AI Image Design and Software Development Platform";
 // Disable automatic scrolling of the chat by default. Manual scrolling
 // (e.g. via the scroll down button) can still force scrolling.
 let chatAutoScroll = false;
@@ -175,7 +175,7 @@ let pendingImageDescs = [];
 function updatePageTitle(){
   const active = chatTabs.find(t => t.id === currentTabId);
   if(active && active.name){
-    document.title = `Alfe AI - ${active.name}`;
+    document.title = `Alfe - ${active.name}`;
   } else {
     document.title = defaultTitle;
   }

--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -3,8 +3,9 @@
 <head>
   <meta charset="UTF-8">
 <!--  <title>Printify Pipeline Queue</title>-->
-  <title>Design Production Queue</title>
+  <title>Alfe - Design Production Queue</title>
   <link rel="stylesheet" href="./styles.css">
+  <link id="favicon" rel="icon" type="image/x-icon" href="/alfe_favicon_64x64.ico">
   <style>
     .img-dropdown {
       position: relative;


### PR DESCRIPTION
## Summary
- adjust Aurora titles to use `Alfe -`
- update dynamic title handling in `main.js`
- set Design Production Queue page title to `Alfe - Design Production Queue` and add favicon

## Testing
- `grep -R "Alfe AI -" -n`

------
https://chatgpt.com/codex/tasks/task_b_6863a28738448323a2e2947d92fb117e