### PR TITLE
Remove pride from Printify title fix

### DIFF
--- a/Aurora/scripts/printifyTitleFix.js
+++ b/Aurora/scripts/printifyTitleFix.js
@@ -82,6 +82,7 @@ async function main() {
     .replace(/\bwomen'?s\b/gi, '')
     .replace(/\burban\b/gi, '')
     .replace(/\bwhimsical\b/gi, '')
+    .replace(/\bpride\b/gi, '')
     .replace(/\s{2,}/g, ' ')
     .trim();
 


### PR DESCRIPTION
## Summary
- strip the word `pride` in the Printify title script

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6863b5bff1788323973135e31bb6afd4