### PR TITLE
Remove cocaine from Printify titles

### DIFF
--- a/Aurora/scripts/printifyTitleFix.js
+++ b/Aurora/scripts/printifyTitleFix.js
@@ -84,7 +84,7 @@ async function main() {
     .replace(/\bwhimsical\b/gi, '')
     .replace(/\bpride\b/gi, '')
     .replace(/\bpatriot\b/gi, '')
-    .replace(/\b(?:marijuana|cannabis|lsd|dmt)\b/gi, '')
+    .replace(/\b(?:marijuana|cannabis|lsd|dmt|cocaine)\b/gi, '')
     .replace(/\s{2,}/g, ' ')
     .trim();
 


### PR DESCRIPTION
## Summary
- exclude the word `cocaine` when generating optimized Printify titles

## Testing
- `npm test` in Aurora (fails: Missing script)
- `npm test` in AutoPR (prints "No tests specified")
- `npm test` in PriceScript (fails: Missing script)
- `npm test` in VMRunner (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_b_6863ba2d759483238520af85829d29ab