### PR TITLE
Add queue-to-top option

### DIFF
--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -151,6 +151,9 @@
     <label style="margin-left:0.5rem;">
       <input type="checkbox" id="hideWhenAdd" /> Hide when adding to queue
     </label>
+    <label style="margin-left:0.5rem;">
+      <input type="checkbox" id="queueTopCheckbox" /> Add to top
+    </label>
     <button id="enqueueBtn">Add to Queue</button>
     <button id="hideSelectedBtn" style="margin-left:0.5rem;">Hide</button>
     <button id="stopAllBtn" style="margin-left:0.5rem;">Stop All</button>
@@ -202,6 +205,11 @@
     const saveCollapsed = () => {
       localStorage.setItem('collapsedQueueGroups', JSON.stringify([...collapsedGroups]));
     };
+    const queueTopCheckbox = document.getElementById('queueTopCheckbox');
+    queueTopCheckbox.checked = localStorage.getItem('queueAddTop') === '1';
+    queueTopCheckbox.addEventListener('change', () => {
+      localStorage.setItem('queueAddTop', queueTopCheckbox.checked ? '1' : '0');
+    });
     const titleCache = {};
     let titlesLoaded = false;
     async function prefetchTitles(){
@@ -733,6 +741,7 @@ async function updateVariantUI(file){
       const variantChoice = document.querySelector('input[name="queueVariant"]:checked');
       const variant = variantChoice ? variantChoice.value : null;
       const hideFlag = document.getElementById('hideWhenAdd').checked;
+      const toTop = document.getElementById('queueTopCheckbox').checked;
       if(!file) return;
       console.debug('[Queue UI] enqueue clicked file=' + file + ' type=' + type + ' variant=' + variant);
       try{
@@ -742,14 +751,14 @@ async function updateVariantUI(file){
             await fetch('api/pipelineQueue', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ file, type: step, dbId, variant })
+              body: JSON.stringify({ file, type: step, dbId, variant, toTop })
             });
           }
         } else {
           await fetch('api/pipelineQueue', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ file, type, dbId, variant })
+            body: JSON.stringify({ file, type, dbId, variant, toTop })
           });
           console.debug('[Queue UI] job enqueued');
         }

--- a/Aurora/src/jobQueueApi.js
+++ b/Aurora/src/jobQueueApi.js
@@ -17,12 +17,13 @@ export default class JobQueueApi {
     return data;
   }
 
-  async enqueue(file, type, dbId = null, variant = null) {
+  async enqueue(file, type, dbId = null, variant = null, toTop = false) {
     const { data } = await this.axios.post('/api/pipelineQueue', {
       file,
       type,
       dbId,
       variant,
+      toTop,
     });
     return data;
   }

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -91,7 +91,7 @@ export default class PrintifyJobQueue {
     return this.paused;
   }
 
-  enqueue(file, type, dbId = null, variant = null) {
+  enqueue(file, type, dbId = null, variant = null, toTop = false) {
     const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
     let parsedDbId = null;
     if (dbId !== null && dbId !== undefined && dbId !== '') {
@@ -111,7 +111,7 @@ export default class PrintifyJobQueue {
       startTime: null,
       finishTime: null
     };
-    this.jobs.push(job);
+    if (toTop) this.jobs.unshift(job); else this.jobs.push(job);
     console.debug('[PrintifyJobQueue Debug] Enqueued job =>', job);
     this._saveJobs();
     this._processNext();

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2902,7 +2902,7 @@ app.get("/api/pipelineQueue", (req, res) => {
 
 app.post("/api/pipelineQueue", (req, res) => {
   console.debug("[Server Debug] POST /api/pipelineQueue =>", req.body);
-  const { file, type, dbId, variant } = req.body || {};
+  const { file, type, dbId, variant, toTop } = req.body || {};
   if (!file || !type) {
     return res.status(400).json({ error: "Missing file or type" });
   }
@@ -2911,7 +2911,7 @@ app.post("/api/pipelineQueue", (req, res) => {
     const n = parseInt(dbId, 10);
     if (!Number.isNaN(n)) parsedDbId = n;
   }
-  const job = printifyQueue.enqueue(file, type, parsedDbId, variant || null);
+  const job = printifyQueue.enqueue(file, type, parsedDbId, variant || null, !!toTop);
   console.debug(
     "[Server Debug] Enqueued job =>",
     JSON.stringify(job, null, 2)


### PR DESCRIPTION
## Summary
- add checkbox to queue UI to insert new items at the top
- remember the preference in localStorage
- support `toTop` parameter in API client and server
- allow queue implementation to insert at the start

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686417b013a88323a62d78f90940988b