### PR TITLE
Remove heavy from Printify titles

### DIFF
--- a/Aurora/scripts/printifyTitleFix.js
+++ b/Aurora/scripts/printifyTitleFix.js
@@ -84,6 +84,7 @@ async function main() {
     .replace(/\bwhimsical\b/gi, '')
     .replace(/\bpride\b/gi, '')
     .replace(/\bpatriot\b/gi, '')
+    .replace(/\bheavy\b/gi, '')
     .replace(/\b(?:marijuana|cannabis|lsd|dmt|cocaine)\b/gi, '')
     .replace(/\s{2,}/g, ' ')
     .trim();


### PR DESCRIPTION
## Summary
- strip the word `heavy` from generated Printify titles

## Testing
- `npm run lint -s`

------
https://chatgpt.com/codex/tasks/task_b_68643fd67db8832398a0a26b14441bba