### PR TITLE
Add manual color picker page

### DIFF
--- a/Aurora/public/color_picker.html
+++ b/Aurora/public/color_picker.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Manual Color Picker</title>
+  <link rel="stylesheet" href="/styles.css">
+  <style>
+    .preview-container{display:flex;flex-wrap:wrap;gap:1rem;margin-top:1rem;}
+    .color-preview{width:200px;height:200px;position:relative;border:1px solid #444;display:flex;align-items:center;justify-content:center;}
+    .color-preview img{max-width:100%;max-height:100%;}
+  </style>
+</head>
+<body style="padding:1rem;">
+  <h2>Manual Color Picker</h2>
+  <p>
+    <label><input type="radio" name="variant" value="normal" checked> Default</label>
+    <label id="nobgLabel" style="margin-left:0.5rem;"><input type="radio" name="variant" value="nobg"> No Background</label>
+  </p>
+  <div style="display:flex;gap:0.5rem;flex-wrap:wrap;">
+    <label>Color 1: <input type="color" id="color1" value="#ffffff"></label>
+    <label>Color 2: <input type="color" id="color2" value="#cccccc"></label>
+    <label>Color 3: <input type="color" id="color3" value="#999999"></label>
+  </div>
+  <div id="preview" class="preview-container"></div>
+  <script src="/session.js"></script>
+  <script>
+    const params = new URLSearchParams(location.search);
+    const file = params.get('file');
+    const nobg = params.get('nobg');
+    if(!nobg){
+      document.getElementById('nobgLabel').style.display='none';
+    }
+    const colors = ['#ffffff','#cccccc','#999999'];
+    const previewDiv = document.getElementById('preview');
+
+    function getVariant(){
+      const choice = document.querySelector('input[name="variant"]:checked');
+      return choice ? choice.value : 'normal';
+    }
+
+    function getImageSrc(){
+      const v = getVariant();
+      const p = v==='nobg' && nobg ? nobg : file;
+      return p ? `/${p.replace(/^\/+/, '')}` : '';
+    }
+
+    function render(){
+      previewDiv.innerHTML='';
+      colors.forEach(color=>{
+        const div=document.createElement('div');
+        div.className='color-preview';
+        div.style.backgroundColor=color;
+        if(file){
+          const img=document.createElement('img');
+          img.src=getImageSrc()+`?t=${Date.now()}`;
+          div.appendChild(img);
+        }
+        previewDiv.appendChild(div);
+      });
+    }
+
+    function updateColor(idx,value){
+      colors[idx]=value;
+      render();
+    }
+
+    document.getElementById('color1').addEventListener('input',e=>updateColor(0,e.target.value));
+    document.getElementById('color2').addEventListener('input',e=>updateColor(1,e.target.value));
+    document.getElementById('color3').addEventListener('input',e=>updateColor(2,e.target.value));
+    document.querySelectorAll('input[name="variant"]').forEach(r=>r.addEventListener('change',render));
+
+    render();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `color_picker.html` page for manual color selection

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68659f5f2ef0832398ed544c53ae8e4a