### PR TITLE
Add Kickstarter campaign doc

### DIFF
--- a/Kickstarter.md
+++ b/Kickstarter.md
@@ -1,0 +1,86 @@
+# Alfe AI: Open, Private, and Self-Hostable AI Platform
+
+**Tagline:** Harness AI for image design, development, and project management—all under your control.
+
+## Overview
+Alfe AI combines three core components into a single open-source stack:
+- **Alfe** – the central dashboard integrating image design and code-generation tools.
+- **Aurora** – a task queue and automation server for handling image pipelines and Printify submissions.
+- **Sterling** – a FOSS software development environment with integrated AI chat and GitHub workflows.
+
+Everything is released under the Alfe AI License and available on GitHub for self-hosting or customization. The project ships with convenient deploy scripts and sample environment files to get you up and running quickly.
+
+## The Story
+**Problem**
+- Creative and development teams juggle several SaaS tools, paying high fees and exposing private data.
+- Proprietary AI services often retain or monetize user inputs.
+
+**Solution**
+- A unified open-source platform that lets you host your own AI design, coding, and task management stack.
+- Privacy-first architecture—use the provided scripts to generate HTTPS certificates and keep traffic secure.
+- Modular design: run only the components you need, from the Sterling development server to the Aurora automation queue.
+
+**Why Now**
+- Growing concerns over data privacy are pushing teams toward self-hosted AI solutions.
+- Mature open-source AI models and stable diffusion tools make locally hosted AI practical.
+
+## Key Features
+- **Self-host with HTTPS** – Deploy easily via `deploy_aurelix.sh` and configure certificates using `setup_certbot.sh` as described in the README lines 14–36【F:README.md†L14-L36】.
+- **Task Queue Automation** – Aurora pulls GitHub issues into an in-memory queue, letting you automate tasks using environment variables like `GITHUB_TOKEN`, `OPENAI_API_KEY`, and more【F:Aurora/README.md†L1-L34】.
+- **Job Queue API** – Interact with the printify pipeline from other services using the built-in Node API shown in Aurora’s docs【F:Aurora/README.md†L58-L74】.
+- **FOSS Development Environment** – Sterling provides a full AI-assisted dev server with instructions for generating GitHub SSH keys and running the dev environment locally【F:Sterling/README.md†L1-L75】.
+- **Cross-Platform Tools** – Scripts exist for forwarding ports without root and for running mobile clients in React Native.
+
+## Funding Goal & Budget
+We’re seeking **$60,000** to bring Alfe AI to a polished v1.0 release.
+- **$18K** – Advanced AI model integration and prompt libraries
+- **$15K** – UX/UI polish, template marketplace, and mobile wrappers
+- **$12K** – Self-host installer and Docker orchestration
+- **$8K** – Security audit & privacy compliance testing
+- **$5K** – Documentation, tutorials, demo site hosting
+- **$2K** – Kickstarter fees & supporter swag
+
+## Reward Tiers
+- **$15** – Early Supporter badge and thanks in our README
+- **$35** – 6‑month hosted Basic plan (up to 3 users)
+- **$75** – 1‑year hosted Pro plan (up to 10 users) + sticker pack
+- **$150** – Lifetime Basic self-host license + priority issue support
+- **$300** – Lifetime Pro self-host license + onboarding webinar
+- **$600** – All above + custom feature sprint (5 days dev)
+- **$1,200** – Founders’ Circle: everything above + quarterly strategy call + your logo on our site
+
+## Stretch Goals
+- **$80K** – Mobile-friendly UI and native wrappers for iOS/Android
+- **$100K** – Official integrations: GitHub Apps, Figma plugin, Slack bot
+- **$150K** – Advanced AI add-ons (image-to-code, natural-language analytics)
+
+## Development Timeline
+1. **Month 1–2** – Finalize specs and kick off UI redesign
+2. **Month 3** – AI model fine-tuning; release self-host installer alpha
+3. **Month 4** – Documentation complete; hosted beta for Pro backers
+4. **Month 5** – Security audit and integration tests
+5. **Month 6** – v1.0 launch; deliver digital rewards
+6. **Month 7+** – Stretch-goal development and community contributions
+
+## Marketing & Community
+- Pre-launch newsletter and demos on [confused.art](https://confused.art)
+- Live demos during campaign on YouTube & Product Hunt
+- Referral rewards: backers earn credits for each friend who pledges
+- Monthly community hackathons and plugin contests post-launch
+
+## The Team
+- **Lochner Tech** – Lead developer and project maintainer
+- **UX Designer** – Specializes in developer tools and intuitive UI
+- **Community Manager** – Former open-source project lead focused on privacy advocacy
+
+## Why Back Alfe AI?
+- Own and control your AI tooling end-to-end.
+- Contribute to an open-source ecosystem built with privacy in mind.
+- Help shape the roadmap and get early access to powerful AI features.
+
+## Next Steps
+1. Record a 2–3 minute demo video showing image design, code generation, and task workflows.
+2. Prepare visuals: UI mockups, architecture diagrams, and team photos.
+3. Launch the Kickstarter page with this content and links to our GitHub repos, Terms of Service, Privacy Policy, and Cookies Policy.
+
+Join us in building a secure, open, and fully controllable AI platform for creative and development teams everywhere!


### PR DESCRIPTION
## Summary
- add Kickstarter.md with comprehensive campaign details for Alfe AI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68680b9aeb2c8323811bce776277bec9