### PR TITLE
Add draggable project groups

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -829,11 +829,24 @@ body {
   font-weight: bold;
 }
 
-#projectGroupsContainer .project-group-header {
-  margin: 6px 0 2px;
-  font-size: 0.9rem;
+#projectGroupsContainer button {
+  display: inline-flex;
+  background-color: #333;
+  border: 1px solid #444;
   color: #0ff;
+  padding: 4px 6px;
+  cursor: move;
+  align-items: center;
+  text-align: left;
+  border-radius: 8px;
   font-weight: bold;
+  margin: 6px 0 2px;
+}
+#projectGroupsContainer button.drag-over {
+  border-color: #0ff;
+}
+#verticalTabsContainer .project-indented {
+  margin-left: 10px;
 }
 
 #verticalTabsContainer button.active {

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -831,6 +831,28 @@ body {
   font-weight: bold;
 }
 
+#projectGroupsContainer button {
+  display: inline-flex;
+  background-color: #ccc;
+  border: 1px solid #aaa;
+  color: #111;
+  padding: 4px 6px;
+  cursor: move;
+  align-items: center;
+  text-align: left;
+  border-radius: 8px;
+  font-weight: bold;
+  margin: 6px 0 2px;
+}
+
+#projectGroupsContainer button.drag-over {
+  border-color: #111;
+}
+
+#verticalTabsContainer .project-indented {
+  margin-left: 10px;
+}
+
 #verticalTabsContainer button.active {
   background-color: #ccc;
   border-color: #aaa;


### PR DESCRIPTION
## Summary
- allow reordering project groups in the Aurora chat tab sidebar
- indent tabs when grouped by project
- style project group headers as buttons

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68683000c2048323bf86da6648fab809