### PR TITLE
Add project dropdown in rename modal

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -422,6 +422,9 @@
         <option value="task">Tasks</option>
       </select>
     </label>
+    <label style="display:block;margin-top:8px;">Assign to project:<br/>
+      <select id="renameProjectSelect" style="width:100%;"></select>
+    </label>
     <div class="modal-buttons">
       <button id="renameTabSaveBtn">Save</button>
       <button id="renameTabCancelBtn">Cancel</button>

--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -207,9 +207,13 @@
       <label>New name:<br/>
         <input type="text" id="renameTabInput" style="width:100%;" />
       </label>
+      <label style="margin-top:8px;">Assign to project:<br/>
+        <select id="renameProjectSelect" style="width:100%;"></select>
+      </label>
       <div class="modal-buttons">
         <button id="renameTabSaveBtn">Save</button>
         <button id="renameTabCancelBtn">Cancel</button>
+        <button id="renameAssignProjectBtn">Assign to Project</button>
       </div>
     </div>
   </div>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1791,6 +1791,13 @@ async function openRenameTabModal(tabId){
   $("#renameShowMosaicCheck").checked = mosaicPanelVisible;
   const typeSel = $("#renameTabTypeSelect");
   if(typeSel) typeSel.value = t ? t.tab_type || 'chat' : 'chat';
+  const projSel = $("#renameProjectSelect");
+  if(projSel){
+    const projects = Array.from(new Set(chatTabs.map(c => c.project_name).filter(p => p)));
+    projSel.innerHTML = '<option value="">(none)</option>' +
+      projects.map(p => `<option value="${p}">${p}</option>`).join('');
+    projSel.value = t && t.project_name ? t.project_name : '';
+  }
   const modal = $("#renameTabModal");
   if(!modal){
     renameTab(tabId);
@@ -1835,8 +1842,8 @@ $("#renameTabInput").addEventListener("keydown", evt => {
 $("#renameAssignProjectBtn").addEventListener("click", async () => {
   const modal = $("#renameTabModal");
   const tabId = parseInt(modal.dataset.tabId, 10);
-  let project = prompt("Project name:");
-  if(project === null) return;
+  const projSel = $("#renameProjectSelect");
+  let project = projSel ? projSel.value : "";
   project = project.trim();
   const tab = chatTabs.find(t => t.id === tabId) || {};
   const repo = tab.repo_ssh_url || '';


### PR DESCRIPTION
## Summary
- extend rename modal with project selector
- populate project dropdown in JS
- use dropdown for Assign to Project action

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68683add51248323bfd96daecac4e2e4