### PR TITLE
Add basic Shopify theme

### DIFF
--- a/confused-apparel-theme/assets/theme.css
+++ b/confused-apparel-theme/assets/theme.css
@@ -1,0 +1,32 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.4;
+}
+header, footer {
+  background: #f1f1f1;
+  padding: 1em;
+}
+header nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 1em;
+}
+.product-grid {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1em;
+}
+.product-item {
+  border: 1px solid #ddd;
+  padding: 1em;
+  text-align: center;
+}
+.user-links {
+  float: right;
+}

--- a/confused-apparel-theme/layout/theme.liquid
+++ b/confused-apparel-theme/layout/theme.liquid
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ shop.name }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    {{ content_for_header }}
+    <link rel="stylesheet" href="{{ 'theme.css' | asset_url }}">
+  </head>
+  <body>
+    <header>
+      <h1>Welcome to our store</h1>
+      <h2>{{ shop.name }}</h2>
+      <nav>
+        <ul>
+          <li><a href="{{ routes.root_url }}">Home</a></li>
+          <li><a href="{{ routes.all_products_collection_url }}">Catalog</a></li>
+          <li><a href="/pages/contact">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="user-links">
+        <a href="/account">Log in</a>
+        <a href="/cart">Cart</a>
+      </div>
+    </header>
+
+    <main>
+      {{ content_for_layout }}
+    </main>
+
+    <footer>
+      <form method="post" action="/contact#ContactFooter">
+        <label for="SubscribeEmail">Subscribe to our emails</label>
+        <input type="email" name="contact[email]" id="SubscribeEmail" placeholder="Email">
+        <button type="submit">Subscribe</button>
+      </form>
+      {{ payment_methods }}
+      <p>&copy; {{ 'now' | date: '%Y' }}, {{ shop.name }} Powered by Shopify</p>
+      <a href="/policies/privacy-policy">Privacy policy</a>
+    </footer>
+    {{ content_for_footer }}
+  </body>
+</html>

--- a/confused-apparel-theme/templates/collection.liquid
+++ b/confused-apparel-theme/templates/collection.liquid
@@ -1,0 +1,19 @@
+{% layout 'theme' %}
+<section class="collection-page">
+  <h1>{{ collection.title }}</h1>
+  <ul class="product-grid">
+    {% for product in collection.products %}
+      <li class="product-item">
+        <a href="{{ product.url }}">
+          {% if product.featured_image %}
+            <img src="{{ product.featured_image | image_url: width: 300 }}" alt="{{ product.title }}">
+          {% endif %}
+          <h3>{{ product.title }}</h3>
+        </a>
+        <span class="price">{{ product.price | money }}</span>
+      </li>
+    {% else %}
+      <li>No products found</li>
+    {% endfor %}
+  </ul>
+</section>

--- a/confused-apparel-theme/templates/index.liquid
+++ b/confused-apparel-theme/templates/index.liquid
@@ -1,0 +1,24 @@
+{% layout 'theme' %}
+<section class="collection-grid">
+  <h2>Collection: Aliens, UFOs</h2>
+  <div class="filters">
+    <!-- Filter placeholders -->
+    <span>Filter:</span>
+    <span>Availability</span>
+    <span>Price</span>
+    <span>Sort by:</span>
+  </div>
+  <ul class="product-grid">
+    {% for product in collections.all.products limit: 12 %}
+      <li class="product-item">
+        <a href="{{ product.url }}">
+          {% if product.featured_image %}
+            <img src="{{ product.featured_image | image_url: width: 300 }}" alt="{{ product.title }}">
+          {% endif %}
+          <h3>{{ product.title }}</h3>
+        </a>
+        <span class="price">{{ product.price | money }}</span>
+      </li>
+    {% endfor %}
+  </ul>
+</section>

--- a/confused-apparel-theme/templates/product.liquid
+++ b/confused-apparel-theme/templates/product.liquid
@@ -1,0 +1,16 @@
+{% layout 'theme' %}
+<article class="product-detail">
+  <h1>{{ product.title }}</h1>
+  {% if product.featured_image %}
+    <img src="{{ product.featured_image | image_url: width: 600 }}" alt="{{ product.title }}">
+  {% endif %}
+  <div class="product-description">
+    {{ product.description }}
+  </div>
+  <div class="product-price">
+    {{ product.price | money }}
+  </div>
+  {% form 'product', product %}
+    <button type="submit">Add to cart</button>
+  {% endform %}
+</article>


### PR DESCRIPTION
## Summary
- create new `confused-apparel-theme` with Shopify template files
- implement layout and basic index, collection and product templates
- add minimal CSS styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686859406504832381a4bd961b1fb6e0