### PR TITLE
Extend chat context by project

### DIFF
--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -722,6 +722,23 @@ export default class TaskDB {
         .all(tabId);
   }
 
+  getAllChatPairsByProject(projectName, sessionId = '') {
+    if (sessionId) {
+      return this.db.prepare(`
+        SELECT cp.* FROM chat_pairs cp
+        JOIN chat_tabs ct ON cp.chat_tab_id = ct.id
+        WHERE ct.project_name = ? AND ct.session_id = ?
+        ORDER BY cp.id ASC
+      `).all(projectName, sessionId);
+    }
+    return this.db.prepare(`
+      SELECT cp.* FROM chat_pairs cp
+      JOIN chat_tabs ct ON cp.chat_tab_id = ct.id
+      WHERE ct.project_name = ?
+      ORDER BY cp.id ASC
+    `).all(projectName);
+  }
+
   hasUserMessages(tabId = 1) {
     const row = this.db
         .prepare("SELECT 1 FROM chat_pairs WHERE chat_tab_id=? AND user_text<>'' LIMIT 1")


### PR DESCRIPTION
## Summary
- add DB helper to fetch chat pairs by project
- use project-wide chat history when sending and retrieving chat pairs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68685a569530832390d15e31f5e0d013