### PR TITLE
Update project context with full chat history

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1691,7 +1691,19 @@ app.post("/api/chat", async (req, res) => {
     let systemContext = `System Context:\n${savedInstructions}`;
     let projectContext = '';
     if (tabInfo && tabInfo.project_name) {
+      const projectPairs = db.getChatPairsByProject(tabInfo.project_name);
+      const history = projectPairs
+        .map(p => {
+          const parts = [];
+          if (p.user_text) parts.push(`User: ${p.user_text}`);
+          if (p.ai_text) parts.push(`Assistant: ${p.ai_text}`);
+          return parts.join('\n');
+        })
+        .join('\n');
       projectContext = `Project: ${tabInfo.project_name}`;
+      if (history) {
+        projectContext += `\n${history}`;
+      }
     }
     const fullContext = projectContext ?
       `${systemContext}\n${projectContext}` : systemContext;

--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -722,6 +722,17 @@ export default class TaskDB {
         .all(tabId);
   }
 
+  getChatPairsByProject(projectName) {
+    return this.db
+        .prepare(
+          `SELECT cp.* FROM chat_pairs cp
+           JOIN chat_tabs ct ON cp.chat_tab_id = ct.id
+           WHERE ct.project_name = ?
+           ORDER BY cp.id ASC`
+        )
+        .all(projectName);
+  }
+
   hasUserMessages(tabId = 1) {
     const row = this.db
         .prepare("SELECT 1 FROM chat_pairs WHERE chat_tab_id=? AND user_text<>'' LIMIT 1")


### PR DESCRIPTION
## Summary
- add new `getChatPairsByProject` helper for retrieving pairs across all tabs
- include every chat for a project when building the project context

## Testing
- `npm run lint` within `Aurora`
- `npm test` within `Aurora` *(fails: Missing script)*
- `npm test` within `Sterling` *(fails: Missing script)*
- `npm test` within `AutoPR`

------
https://chatgpt.com/codex/tasks/task_b_68685a569530832390d15e31f5e0d013