### PR TITLE
Implement glitch hero and product snippet

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -4,6 +4,7 @@
   --color-magenta: {{ settings.color_magenta }};
   --color-muted-gray: {{ settings.color_muted_gray }};
   --color-foreground: 255,255,255;
+  --font-heading: {% if settings.use_glitch_font %}'Press Start 2P', cursive{% else %}'Orbitron', sans-serif{% endif %};
 }
 
 body {

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -6,7 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {{ content_for_header }}
     <link rel="preload" href="{{ 'starfield.svg' | asset_url }}" as="image">
-    <link rel="stylesheet" href="{{ 'fonts.css' | asset_url }}">
+    {% if settings.use_glitch_font %}
+      <link rel="stylesheet" href="{{ 'fonts.css' | asset_url }}">
+    {% endif %}
     <link rel="stylesheet" href="{{ 'theme.css' | asset_url }}">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600&display=swap" rel="stylesheet">
     {{ 'confused-dark.css' | asset_url | stylesheet_tag }}


### PR DESCRIPTION
## Summary
- style headings using glitch font when configured

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68687a235d788323978dc026cff827b8