### PR TITLE
Add rounded corners to product thumbnails

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -207,6 +207,12 @@ header nav a {
   opacity: 0;
   transition: opacity 0.3s ease;
 }
+
+/* Slight rounding for product thumbnail images */
+.product-item .primary-image,
+.product-item .secondary-image {
+  border-radius: 4px;
+}
 .badge {
   display: inline-block;
   border: 1px solid var(--color-neon-green);


### PR DESCRIPTION
## Summary
- use `.primary-image` and `.secondary-image` to apply a small 4px `border-radius`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68687c6872908323a41a3382d4a23f37