### PR TITLE
Switch hero text to an SVG logo

### DIFF
--- a/assets/hero-logo.svg
+++ b/assets/hero-logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 120" width="500" height="120">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#39ff14;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#ff2fff;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+  <rect width="500" height="120" fill="transparent"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Orbitron, sans-serif" font-size="48" fill="url(#grad)" stroke="black" stroke-width="2">
+    Stay Confused
+  </text>
+</svg>

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -189,19 +189,12 @@ header nav a {
   color: var(--color-neon-green);
 }
 
-.hero-glitch .glitch {
-  font-size: 2rem;
-  position: relative;
-  color: var(--color-neon-green);
-}
-
-.hero-glitch .glitch::after {
-  content: attr(data-text);
-  position: absolute;
-  left: 2px;
-  top: 0;
-  color: var(--color-magenta);
-  mix-blend-mode: difference;
+.hero-glitch .hero-logo {
+  max-width: 500px;
+  width: 80%;
+  height: auto;
+  margin: 0 auto 1rem;
+  display: block;
 }
 
 .product-item .secondary-image {

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -4,7 +4,8 @@
       "name": "Glitch Hero",
       "settings": {
         "headline": "Stay Confused",
-        "sub": "Aliens \u2022 UFOs \u2022 Cats"
+        "sub": "Aliens \u2022 UFOs \u2022 Cats",
+        "hero_image": "Hero logo"
       }
     }
   }

--- a/sections/hero-glitch.liquid
+++ b/sections/hero-glitch.liquid
@@ -1,7 +1,9 @@
 <div class="hero-glitch" style="background-image:url({{ section.settings.bg_image | image_url }});">
-  <div class="glitch" data-text="{{ section.settings.headline }}">
-    {{ section.settings.headline }}
-  </div>
+  {% if section.settings.hero_image != blank %}
+    <img src="{{ section.settings.hero_image | image_url }}" alt="{{ section.settings.headline }}" class="hero-logo">
+  {% else %}
+    <img src="{{ 'hero-logo.svg' | asset_url }}" alt="{{ section.settings.headline }}" class="hero-logo">
+  {% endif %}
   <p>{{ section.settings.sub }}</p>
 </div>
 
@@ -10,6 +12,7 @@
   "name": "Glitch Hero",
   "settings": [
     { "type": "image_picker", "id": "bg_image", "label": "Background" },
+    { "type": "image_picker", "id": "hero_image", "label": "Hero logo" },
     { "type": "text", "id": "headline", "label": "Headline", "default": "Stay Confused" },
     { "type": "text", "id": "sub", "label": "Sub-text", "default": "Aliens • UFOs • Cats" }
   ]


### PR DESCRIPTION
## Summary
- add a `hero-logo.svg` image and display it in the hero section
- add optional `hero_image` setting for customizing the logo
- adjust hero section markup and styles for the new logo
- update locale strings for the hero section

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_b_68687e3e18cc83238483b8370af07e37