### PR TITLE
Fix product card title truncation

### DIFF
--- a/assets/confused-dark.css
+++ b/assets/confused-dark.css
@@ -37,6 +37,12 @@ a:hover {color: #7dffd1;}
   padding-bottom: 4rem;
 }
 
+@media (min-width: 1024px) {
+  .product-grid {
+    grid-template-columns: repeat(auto-fill,minmax(260px,1fr));
+  }
+}
+
 /* ======  product card ====== */
 .product-card,
 .card-wrapper {        /* theme variations */
@@ -59,15 +65,19 @@ a:hover {color: #7dffd1;}
 }
 /* title */
 .product-card__title,
-.card-information__text {
+.card-information__text,
+.product-item h3 {
   padding: .75rem .9rem 0;
   font-size: .95rem;
-  line-height: 1.25;
-  height: 2.5rem;                  /* two-line clamp */
+  line-height: 1.3;
+  max-height: 3.4rem;               /* ~2.5 lines */
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 2;            /* clamp to two lines */
   -webkit-box-orient: vertical;
   overflow: hidden;
+  text-overflow: ellipsis;          /* show ellipsis when truncated */
+  color: #e7e7e7;                   /* softer than neon */
+  font-weight: 500;
 }
 /* price */
 .price,
@@ -75,6 +85,7 @@ a:hover {color: #7dffd1;}
   color: var(--accent);
   font-weight: 600;
   padding: 0 .9rem 1rem;
+  margin-top: auto;                 /* align to card bottom */
 }
 .price--on-sale .price-item--regular {opacity:.5;}
 /* hide the black “divider bars” if those are theme elements */

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -184,9 +184,13 @@ header nav a {
 .hero-glitch {
   position: relative;
   text-align: center;
-  padding: 4rem 1rem;
+  padding: 4rem 1rem 2rem; /* tighter space below hero */
   background-size: cover;
   color: var(--color-neon-green);
+}
+.hero-glitch p {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
 }
 
 .hero-glitch .hero-logo {

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -6,7 +6,7 @@
         <img class="secondary-image" src="{{ product.images[1] | image_url: width: 300 }}" loading="lazy" alt="">
       {% endif %}
     {% endif %}
-    <h3>{{ product.title }}</h3>
+    <h3 title="{{ product.title }}">{{ product.title }}</h3>
   </a>
   <span class="price">{{ product.price | money }}</span>
   {% if product.tags contains 'cat' %}


### PR DESCRIPTION
## Summary
- style card titles with ellipsis and better color
- widen product cards on desktop
- push price to bottom and keep neon color
- tighten hero block spacing
- show full product title via title attribute

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6868808e8f6c8323b97aa910fe2cd022