### PR TITLE
Fix Shopify rich text styles

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -153,6 +153,14 @@ header nav a {
   overflow: hidden;
 }
 
+/* Ensure product descriptions inherit theme fonts/colors even if pasted
+   rich text includes inline styles */
+.product-description,
+.product-description * {
+  color: var(--color-muted-gray) !important;
+  font-family: inherit !important;
+}
+
 .product-image {
   width: 100%;
   aspect-ratio: 4 / 3;

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -5,3 +5,20 @@ function toggleMenu() {
     menu.classList.toggle('active');
   }
 }
+
+// Strip inline styles from product descriptions that were pasted with rich text
+document.addEventListener('DOMContentLoaded', function() {
+  const desc = document.querySelector('.product-description');
+  if (desc) {
+    desc.querySelectorAll('[style]').forEach(function(el) {
+      el.removeAttribute('style');
+    });
+    desc.querySelectorAll('font').forEach(function(el) {
+      const parent = el.parentNode;
+      while (el.firstChild) {
+        parent.insertBefore(el.firstChild, el);
+      }
+      parent.removeChild(el);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- ensure fonts and color override inline rich text
- strip inline styles and `<font>` tags from product description on load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6868849d55b88323875e15fa3c280360