### PR TITLE
Switch to Luckiest Guy font

### DIFF
--- a/assets/confused-dark.css
+++ b/assets/confused-dark.css
@@ -4,7 +4,7 @@
   --panel: #16181c;          /* cards / nav */
   --text-main: #e5e5e5;    /* body text */
   --accent: #39ffb6;         /* neon beam green */
-  --brand-font: 'Orbitron', sans-serif;
+  --brand-font: 'Luckiest Guy', cursive;
 }
 
 /* ======  global ====== */

--- a/assets/hero-logo.svg
+++ b/assets/hero-logo.svg
@@ -6,7 +6,7 @@
     </linearGradient>
   </defs>
   <rect width="500" height="120" fill="transparent"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Orbitron, sans-serif" font-size="48" fill="url(#grad)" stroke="black" stroke-width="2">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Luckiest Guy, cursive" font-size="48" fill="url(#grad)" stroke="black" stroke-width="2">
     Wear the Weird
   </text>
 </svg>

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -4,7 +4,7 @@
   --color-magenta: {{ settings.color_magenta }};
   --color-muted-gray: {{ settings.color_muted_gray }};
   --color-foreground: 255,255,255;
-  --font-heading: {% if settings.use_glitch_font %}'Press Start 2P', cursive{% else %}'Orbitron', sans-serif{% endif %};
+  --font-heading: {% if settings.use_glitch_font %}'Press Start 2P', cursive{% else %}'Luckiest Guy', cursive{% endif %};
 }
 
 body {

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -10,7 +10,7 @@
       <link rel="stylesheet" href="{{ 'fonts.css' | asset_url }}">
     {% endif %}
     <link rel="stylesheet" href="{{ 'theme.css' | asset_url }}">
-    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Luckiest+Guy&display=swap" rel="stylesheet">
     {{ 'confused-dark.css' | asset_url | stylesheet_tag }}
   </head>
   <body>


### PR DESCRIPTION
## Summary
- swap out Orbitron for the more playful **Luckiest Guy** typeface
- update dark theme variables and hero logo to use the new font

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68688f90f7c88323b66579d145cc7c21