### PR TITLE
Move product purchase options above description

### DIFF
--- a/templates/product.liquid
+++ b/templates/product.liquid
@@ -9,7 +9,6 @@
   <div class="product-info">
     <h1>{{ product.title }}</h1>
     <div class="product-price">{{ product.price | money }}</div>
-    <div class="product-description">{{ product.description }}</div>
 
       {% form 'product', product %}
         {% if product.variants.size > 1 %}
@@ -76,6 +75,7 @@
           });
         </script>
       {% endif %}
-    <p class="ship-note">Ships in 2-5 business days from USA.</p>
+      <p class="ship-note">Ships in 2-5 business days from USA.</p>
+      <div class="product-description">{{ product.description }}</div>
   </div>
 </article>


### PR DESCRIPTION
## Summary
- reorder product page so the Add to cart block and shipping note show above the description

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68688ffe36a48323ad9bb9078879624f