### PR TITLE
Remove privacy text from contact page

### DIFF
--- a/templates/page.contact.liquid
+++ b/templates/page.contact.liquid
@@ -2,5 +2,4 @@
 <section class="page-content contact">
   <h1>Contact Us</h1>
   <p>For help with your order, email <a href="mailto:orders@confused.store">orders@confused.store</a>.</p>
-  <p>Should you have any questions about our privacy practices or this Privacy Policy, or if you would like to exercise any of the rights available to you, please email <a href="mailto:confused@lochner.tech">confused@lochner.tech</a> or contact us at P.O. Box 148, Wisconsin Dells, WI, 53965, US.</p>
 </section>


### PR DESCRIPTION
## Summary
- clean up the contact page by removing the privacy policy paragraph

## Testing
- `npx theme-check` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_686891c42d688323bbe4a930094a44c5