### PR TITLE
Add UFO cart icon link

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -117,6 +117,12 @@ input[type="email"] {
   display: inline-block;
 }
 
+.ufo-cart-link img {
+  display: block;
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
 .text-right {
   text-align: right;
 }

--- a/assets/ufo-cart.svg
+++ b/assets/ufo-cart.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+  <ellipse cx="12" cy="14" rx="8" ry="3" />
+  <path d="M8 11c0-2 2-4 4-4s4 2 4 4" fill="none" stroke="currentColor" stroke-width="2"/>
+  <rect x="6" y="15" width="12" height="3" rx="1.5" />
+  <circle cx="9" cy="20" r="1.5" />
+  <circle cx="15" cy="20" r="1.5" />
+</svg>

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -30,6 +30,11 @@
             <li><a href="{{ routes.root_url }}">Home</a></li>
             <li><a href="{{ routes.all_products_collection_url }}">Catalog</a></li>
             <li><a href="/pages/contact">Contact</a></li>
+            <li>
+              <a href="/cart" aria-label="Cart" class="ufo-cart-link">
+                <img src="{{ 'ufo-cart.svg' | asset_url }}" alt="Cart" width="24" height="24" />
+              </a>
+            </li>
           </ul>
         </nav>
 


### PR DESCRIPTION
## Summary
- create new `ufo-cart.svg` icon
- display UFO cart link in navigation
- style UFO cart icon

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686893f48f348323b01e9cd94ff444d8