### PR TITLE
Remove collection header from index

### DIFF
--- a/templates/index.liquid
+++ b/templates/index.liquid
@@ -1,7 +1,6 @@
 {% layout 'theme' %}
 {% section 'hero-glitch' %}
 <section class="collection-grid">
-  <h2>Collection: Aliens, UFOs</h2>
   <ul class="product-grid">
     {% for product in collections.all.products limit: 12 %}
       {% render 'product-card', product: product %}


### PR DESCRIPTION
## Summary
- hide the "Collection" header on the homepage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68689c3e07ec8323b86df82136340dd1