### PR TITLE
Fix product listing order

### DIFF
--- a/templates/index.liquid
+++ b/templates/index.liquid
@@ -2,7 +2,7 @@
 {% section 'hero-glitch' %}
 <section class="collection-grid">
   <ul class="product-grid">
-    {% for product in collections.all.products limit: 12 %}
+    {% for product in collections.all.products | sort: 'created_at' limit: 12 %}
       {% render 'product-card', product: product %}
     {% endfor %}
   </ul>


### PR DESCRIPTION
## Summary
- sort home page products by `created_at`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68689d502f3083239511f60f515df27f