### PR TITLE
Add margin on mobile dropdown

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -276,7 +276,8 @@ header nav a {
   }
 
   .nav-links.active {
-    max-height: 300px;
+     max-height: 300px;
+     margin-left: 20px;
   }
 
   .mobile-menu-toggle {


### PR DESCRIPTION
## Summary
- style mobile dropdown menu with left margin when expanded

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68689e293460832382d1cd9d0f67b577