### PR TITLE
Fix product order on home page

### DIFF
--- a/confused-apparel-theme/templates/index.liquid
+++ b/confused-apparel-theme/templates/index.liquid
@@ -9,7 +9,7 @@
     <span>Sort by:</span>
   </div>
   <ul class="product-grid">
-    {% for product in collections.all.products limit: 12 %}
+    {% for product in collections.all.products reversed limit: 12 %}
       <li class="product-item">
         <a href="{{ product.url }}">
           {% if product.featured_image %}


### PR DESCRIPTION
## Summary
- show the most recent products first by reversing the collection

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm test` in `Aurora` *(fails: Missing script 'test')*
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_68689fd1bf888323bdaa0835d6139103