### PR TITLE
Fix product order on homepage

### DIFF
--- a/confused-apparel-theme/templates/index.liquid
+++ b/confused-apparel-theme/templates/index.liquid
@@ -3,7 +3,7 @@
 <section class="collection-grid">
   <h2>{{ target_collection.title }}</h2>
   <ul class="product-grid">
-    {% assign sorted_products = target_collection.products | sort: 'created_at' %}
+    {% assign sorted_products = target_collection.products | sort: 'created_at' | reverse %}
     {% for product in sorted_products limit: 12 %}
       <li class="product-item">
         <a href="{{ product.url }}">


### PR DESCRIPTION
## Summary
- show newest products first by reversing the sorted home page collection

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_6868a18fb2508323857e38b51a30b350