### PR TITLE
Add checkout button on product page

### DIFF
--- a/templates/product.liquid
+++ b/templates/product.liquid
@@ -43,6 +43,7 @@
         {% endif %}
 
         <button type="submit">Add to cart</button>
+        <button type="submit" formmethod="post" formaction="/cart/add?return_to=/checkout">Check out</button>
       {% endform %}
       {% if product.variants.size > 1 %}
         <script>


### PR DESCRIPTION
## Summary
- go directly to checkout from product page by adding a new button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6868a316d9d483239e49fba2bb154e54