### PR TITLE
Move cart icon out of dropdown

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -119,11 +119,6 @@ input[type="email"] {
   display: inline-block;
 }
 
-.ufo-cart-link img {
-  display: block;
-  width: 1.5rem;
-  height: 1.5rem;
-}
 
 .text-right {
   text-align: right;

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -29,11 +29,6 @@
             <li><a href="{{ routes.root_url }}">Home</a></li>
             <li><a href="{{ routes.all_products_collection_url }}">Catalog</a></li>
             <li><a href="/pages/contact">Contact</a></li>
-            <li>
-              <a href="/cart" aria-label="Cart" class="ufo-cart-link">
-                <img src="{{ 'ufo-cart.svg' | asset_url }}" alt="Cart" width="24" height="24" />
-              </a>
-            </li>
           </ul>
         </nav>
 


### PR DESCRIPTION
## Summary
- remove cart icon from dropdown nav so it stays next to the hamburger
- drop unused cart icon CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6868a64ed91c832387a29a60c87a6a19