### PR TITLE
Switch cart quantity input to dropdown

### DIFF
--- a/templates/cart.liquid
+++ b/templates/cart.liquid
@@ -27,7 +27,11 @@
                 {% endif %}
               </td>
               <td>
-                <input type="number" name="updates[]" value="{{ item.quantity }}" min="0">
+                <select name="updates[]">
+                  {% for i in (0..4) %}
+                    <option value="{{ i }}" {% if item.quantity == i %}selected{% endif %}>{{ i }}</option>
+                  {% endfor %}
+                </select>
                 <input type="hidden" name="id[]" value="{{ item.key }}">
               </td>
               <td>{{ item.line_price | money }}</td>


### PR DESCRIPTION
## Summary
- update cart quantity input field to a dropdown limited to 0–4

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6868a6b5ad608323a4975084581531e4