### PR TITLE
Add about page, returns policy and social links

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -368,4 +368,13 @@ input[type="number"] {
   border-radius: 4px;
 }
 
+.ebay-reviews {
+  margin-top: 1rem;
+  font-size: 0.9rem;
+}
+
+.ebay-reviews a {
+  color: var(--color-neon-green);
+}
+
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -53,7 +53,9 @@
           {{ payment_methods }}
           <p>&copy; 2024 - 2025, {{ shop.name }}</p>
           <a href="/policies/privacy-policy">Privacy policy</a> |
-          <a href="/pages/contact">Contact</a>
+          <a href="/pages/returns">Return policy</a> |
+          <a href="/pages/contact">Contact</a> |
+          <a href="https://bsky.app/profile/confused-art.bsky.social" target="_blank" rel="noopener">Bluesky</a>
         </div>
       </div>
     </footer>

--- a/snippets/ebay-reviews.liquid
+++ b/snippets/ebay-reviews.liquid
@@ -1,0 +1,3 @@
+<div class="ebay-reviews">
+  <p>Rated 5 stars on <a href="https://www.ebay.com/usr/confused-art" target="_blank" rel="noopener">eBay</a> by hundreds of customers.</p>
+</div>

--- a/templates/index.liquid
+++ b/templates/index.liquid
@@ -7,3 +7,4 @@
     {% endfor %}
   </ul>
 </section>
+{% render 'ebay-reviews' %}

--- a/templates/page.about.liquid
+++ b/templates/page.about.liquid
@@ -1,0 +1,6 @@
+{% layout 'theme' %}
+<section class="page-content about">
+  <h1>About Us</h1>
+  <p>Confused Apparel began as an art project focused on aliens, UFOs and cats. Today we create clothing and prints inspired by that cosmic vibe.</p>
+  <p>Follow our artwork on <a href="https://bsky.app/profile/confused-art.bsky.social" target="_blank" rel="noopener">Bluesky</a> to see what we're up to.</p>
+</section>

--- a/templates/page.returns.liquid
+++ b/templates/page.returns.liquid
@@ -1,0 +1,5 @@
+{% layout 'theme' %}
+<section class="page-content returns">
+  <h1>Return Policy</h1>
+  <p>We want you to love your order. If you're not satisfied, you may return items within 30 days of delivery for a refund or exchange. Contact us first so we can help.</p>
+</section>

--- a/templates/product.liquid
+++ b/templates/product.liquid
@@ -78,5 +78,6 @@
       {% endif %}
       <p class="ship-note">Ships in 2-5 business days from USA.</p>
       <div class="product-description">{{ product.description }}</div>
+      {% render 'ebay-reviews' %}
   </div>
 </article>


### PR DESCRIPTION
## Summary
- add Bluesky link and return policy link in footer
- add new About Us and Return Policy pages
- add snippet showing eBay reviews
- show the reviews on home and product pages
- style reviews section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6868a736771083238456550ad8d2cbe3