### PR TITLE
Add About link to header navigation

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -25,12 +25,13 @@
         </a>
 
         <nav class="main-nav">
-          <ul class="nav-links flex-center gap-md">
-            <li><a href="{{ routes.root_url }}">Home</a></li>
-            <li><a href="{{ routes.all_products_collection_url }}">Catalog</a></li>
-            <li><a href="/pages/contact">Contact</a></li>
-          </ul>
-        </nav>
+            <ul class="nav-links flex-center gap-md">
+              <li><a href="{{ routes.root_url }}">Home</a></li>
+              <li><a href="{{ routes.all_products_collection_url }}">Catalog</a></li>
+              <li><a href="/pages/about">About</a></li>
+              <li><a href="/pages/contact">Contact</a></li>
+            </ul>
+          </nav>
 
         <div class="mobile-menu-toggle" onclick="toggleMenu()">&#9776;</div>
 


### PR DESCRIPTION
## Summary
- add About page link in the site header

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_6868aa1ee9888323b8b570751784dcfc