### PR TITLE
Fix return policy link to existing returns page

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -54,7 +54,7 @@
           {{ payment_methods }}
           <p>&copy; 2024 - 2025, {{ shop.name }}</p>
           <a href="/policies/privacy-policy">Privacy policy</a> |
-          <a href="/policies/refund-policy">Return policy</a> |
+          <a href="/pages/returns">Return policy</a> |
           <a href="/pages/contact">Contact</a> |
           <a href="https://bsky.app/profile/confused-art.bsky.social" target="_blank" rel="noopener">Bluesky</a>
         </div>


### PR DESCRIPTION
## Summary
- update footer to link to `/pages/returns`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_6868abda0cf88323a36a26e9531e3387