### PR TITLE
Add floating cart icon

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -375,5 +375,21 @@ input[type="number"] {
   border-radius: 4px;
 }
 
+.floating-cart {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1000;
+  background: #1b1b1b;
+  border: 1px solid #333;
+  border-radius: 50%;
+  padding: 0.5rem;
+}
+
+.floating-cart .icon-cart {
+  width: 2rem;
+  height: 2rem;
+}
+
 
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -43,6 +43,10 @@
       </div>
     </header>
 
+    <a href="/cart" class="floating-cart icon-link" aria-label="Cart">
+      <span class="icon-cart"></span>
+    </a>
+
     <main class="container">
       {{ content_for_layout }}
     </main>


### PR DESCRIPTION
## Summary
- add new floating cart markup pinned to the top right
- style floating cart icon so it's fixed and larger

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6868ac230a248323803baf53dd6278f2