### PR TITLE
Fix missing cart icon

### DIFF
--- a/confused-apparel-theme/assets/theme.css
+++ b/confused-apparel-theme/assets/theme.css
@@ -116,3 +116,10 @@ header nav a {
 .user-links {
   float: right;
 }
+
+.icon-link svg {
+  width: 24px;
+  height: 24px;
+  fill: currentColor;
+  vertical-align: middle;
+}

--- a/confused-apparel-theme/layout/theme.liquid
+++ b/confused-apparel-theme/layout/theme.liquid
@@ -28,9 +28,27 @@
         </nav>
 
         <div class="user-links flex-center gap-sm">
-          <a class="icon-link" href="/search"><span class="icon-search"></span></a>
-          <a class="icon-link" href="/account"><span class="icon-user"></span></a>
-          <a class="icon-link" href="/cart"><span class="icon-cart"></span></a>
+          <a class="icon-link" href="/search">
+            <span class="icon-search">
+              <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M10 2a8 8 0 106.32 13.906l4.387 4.387a1 1 0 01-1.414 1.414l-4.387-4.387A8 8 0 0010 2z" clip-rule="evenodd"/>
+              </svg>
+            </span>
+          </a>
+          <a class="icon-link" href="/account">
+            <span class="icon-user">
+              <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M12 12a5 5 0 100-10 5 5 0 000 10zm0 2c-3.314 0-6 1.791-6 4v2h12v-2c0-2.209-2.686-4-6-4z" clip-rule="evenodd"/>
+              </svg>
+            </span>
+          </a>
+          <a class="icon-link" href="/cart">
+            <span class="icon-cart">
+              <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" aria-hidden="true">
+                <path d="M2.25 2.25a.75.75 0 000 1.5h1.386l.35 1.591 1.886 8.543A3 3 0 008.832 16.5h8.386a3 3 0 002.94-2.342l1.358-5.432A.75.75 0 0021.786 7.5H6.272l-.349-1.591A1.5 1.5 0 004.449 4.5H2.25zM8.25 20.25a1.5 1.5 0 100-3 1.5 1.5 0 000 3zM17.25 20.25a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/>
+              </svg>
+            </span>
+          </a>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add inline SVG icons for search, account, and cart links
- style icon SVGs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6868ad143e9c8323a5b2d09ca4de748a