### PR TITLE
Fix floating cart icon display

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -386,9 +386,10 @@ input[type="number"] {
   padding: 0.5rem;
 }
 
-.floating-cart .icon-cart {
+.floating-cart-icon {
   width: 2rem;
   height: 2rem;
+  display: block;
 }
 
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -44,7 +44,7 @@
     </header>
 
     <a href="/cart" class="floating-cart icon-link" aria-label="Cart">
-      <span class="icon-cart"></span>
+      <img src="{{ 'ufo-cart.svg' | asset_url }}" alt="Cart icon" class="floating-cart-icon" />
     </a>
 
     <main class="container">


### PR DESCRIPTION
## Summary
- ensure floating cart icon uses an `<img>` element so the SVG displays
- style the new image with `.floating-cart-icon` class

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6868ad3c8f04832397a7a27c83e19540