### PR TITLE
Adjust hamburger menu spacing

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -263,6 +263,7 @@ header nav a {
   font-size: 1.5rem;
   cursor: pointer;
   margin-left: auto;
+  margin-right: 10px;
   color: var(--color-muted-gray);
 }
 
@@ -285,6 +286,7 @@ header nav a {
   .mobile-menu-toggle {
     display: block;
     margin-left: auto;
+    margin-right: 10px;
   }
 
   .user-links {


### PR DESCRIPTION
## Summary
- tweak `.mobile-menu-toggle` spacing to shift the button 10px away from the right edge

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6868ad2fc0d083238002616b12f374d9