### PR TITLE
Fix about and return links

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -28,7 +28,7 @@
             <ul class="nav-links flex-center gap-md">
               <li><a href="{{ routes.root_url }}">Home</a></li>
               <li><a href="{{ routes.all_products_collection_url }}">Catalog</a></li>
-              <li><a href="{{ pages.about.url }}">About</a></li>
+              <li><a href="/pages/about">About</a></li>
               <li><a href="{{ pages.contact.url }}">Contact</a></li>
             </ul>
           </nav>
@@ -58,7 +58,7 @@
           {{ payment_methods }}
           <p>&copy; 2024 - 2025, {{ shop.name }}</p>
           <a href="/policies/privacy-policy">Privacy policy</a> |
-            <a href="/policies/refund-policy">Return policy</a> |
+            <a href="/pages/returns">Return policy</a> |
             <a href="{{ pages.contact.url }}">Contact</a> |
           <a href="https://bsky.app/profile/confused-art.bsky.social" target="_blank" rel="noopener">Bluesky</a>
         </div>


### PR DESCRIPTION
## Summary
- update header 'About' link to use /pages/about
- update footer return policy link to use /pages/returns

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6868afbd26348323a2045eb61362e40e