### PR TITLE
Hide floating cart when menu open

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -390,6 +390,10 @@ input[type="number"] {
   padding: 0.5rem;
 }
 
+.hidden {
+  display: none !important;
+}
+
 .floating-cart-icon {
   width: 2rem;
   height: 2rem;

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -1,8 +1,16 @@
 // Theme scripts
 function toggleMenu() {
   const menu = document.querySelector('.nav-links');
+  const cart = document.querySelector('.floating-cart');
   if (menu) {
     menu.classList.toggle('active');
+    if (cart) {
+      if (menu.classList.contains('active')) {
+        cart.classList.add('hidden');
+      } else {
+        cart.classList.remove('hidden');
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- hide floating cart when the hamburger menu is open

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6868b07064cc8323ac83e73025362ac8