### PR TITLE
Fix hamburger icon placement

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -265,7 +265,8 @@ header nav a {
   margin-left: auto;
   margin-right: 60px;
   color: var(--color-muted-gray);
-  transform: translate(20px, -20px);
+  /* Move hamburger icon up by 10px and right by 10px */
+  transform: translate(30px, -30px);
 }
 
 @media (max-width: 768px) {
@@ -288,7 +289,8 @@ header nav a {
     display: block;
     margin-left: auto;
     margin-right: 60px;
-    transform: translate(20px, -20px);
+    /* Move hamburger icon up by 10px and right by 10px */
+    transform: translate(30px, -30px);
   }
 
   .user-links {


### PR DESCRIPTION
## Summary
- tweak CSS for `.mobile-menu-toggle`
- move hamburger icon 10px up and 10px right on both desktop and mobile styles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6868b03be01c8323a00b591be4607d2f