### PR TITLE
Improve header typography

### DIFF
--- a/assets/confused-dark.css
+++ b/assets/confused-dark.css
@@ -4,7 +4,7 @@
   --panel: #16181c;          /* cards / nav */
   --text-main: #e5e5e5;    /* body text */
   --accent: #39ffb6;         /* neon beam green */
-  --brand-font: 'Luckiest Guy', cursive;
+  --brand-font: 'Bungee', cursive;
 }
 
 /* ======  global ====== */

--- a/assets/fonts.css
+++ b/assets/fonts.css
@@ -1,7 +1,7 @@
 /* Load brand fonts from Google Fonts so they work consistently across browsers */
-@import url('https://fonts.googleapis.com/css2?family=Luckiest+Guy&family=Press+Start+2P&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Bungee&family=Orbitron:wght@400;700&display=swap');
 
 :root {
-  --font-heading: 'Press Start 2P', cursive;
-  --brand-font: 'Luckiest Guy', cursive;
+  --font-heading: 'Orbitron', sans-serif;
+  --brand-font: 'Bungee', cursive;
 }

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -6,7 +6,7 @@
   --color-button-blue: #007bff;
   --color-button-blue-hover: #3399ff;
   --color-foreground: 255,255,255;
-  --font-heading: {% if settings.use_glitch_font %}'Press Start 2P', cursive{% else %}'Luckiest Guy', cursive{% endif %};
+  --font-heading: {% if settings.use_glitch_font %}'Orbitron', sans-serif{% else %}'Bungee', cursive{% endif %};
 }
 
 body {


### PR DESCRIPTION
## Summary
- switch to Orbitron and Bungee fonts for headings
- update theme variables to reference the new fonts

## Testing
- `theme-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868cd4e5e1c8323a1ecd30d7387148d