### PR TITLE
Use Orbitron font for hero logo

### DIFF
--- a/assets/fonts.css
+++ b/assets/fonts.css
@@ -1,7 +1,7 @@
 /* Load brand fonts from Google Fonts so they work consistently across browsers */
-@import url('https://fonts.googleapis.com/css2?family=Luckiest+Guy&family=Press+Start+2P&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Orbitron&display=swap');
 
 :root {
-  --font-heading: 'Press Start 2P', cursive;
-  --brand-font: 'Luckiest Guy', cursive;
+  --font-heading: 'Orbitron', sans-serif;
+  --brand-font: 'Orbitron', sans-serif;
 }

--- a/assets/hero-logo.svg
+++ b/assets/hero-logo.svg
@@ -6,7 +6,7 @@
     </linearGradient>
   </defs>
   <rect width="500" height="120" fill="transparent"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" style="font-family: var(--brand-font);" font-size="48" fill="url(#grad)" stroke="black" stroke-width="2">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" style="font-family: 'Orbitron', sans-serif;" font-size="48" fill="url(#grad)" stroke="black" stroke-width="2">
     Wear the Weird
   </text>
 </svg>

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -6,7 +6,7 @@
   --color-button-blue: #007bff;
   --color-button-blue-hover: #3399ff;
   --color-foreground: 255,255,255;
-  --font-heading: {% if settings.use_glitch_font %}'Press Start 2P', cursive{% else %}'Luckiest Guy', cursive{% endif %};
+  --font-heading: {% if settings.use_glitch_font %}'Orbitron', sans-serif{% else %}'Bungee', cursive{% endif %};
 }
 
 body {

--- a/snippets/hero-logo-svg.liquid
+++ b/snippets/hero-logo-svg.liquid
@@ -6,7 +6,7 @@
     </linearGradient>
   </defs>
   <rect width="500" height="120" fill="transparent"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" style="font-family: var(--brand-font);" font-size="48" fill="url(#grad)" stroke="black" stroke-width="2">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" style="font-family: 'Orbitron', sans-serif;" font-size="48" fill="url(#grad)" stroke="black" stroke-width="2">
     Wear the Weird
   </text>
 </svg>


### PR DESCRIPTION
## Summary
- load Orbitron font as the brand font
- change hero logo SVG font-family to Orbitron
- update heading font variable in theme.css

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68696b10a68883239144d9108316b0f5