### PR TITLE
Fix nav font style

### DIFF
--- a/assets/confused-dark.css
+++ b/assets/confused-dark.css
@@ -28,7 +28,7 @@ a:hover {color: #7dffd1;}
 .site-header, .header-wrapper {background: var(--panel);} 
 .site-header a {
   color: var(--text-main);
-  font-family: var(--font-heading);
+  font-family: var(--font-nav);
 }
 .site-header a:hover {color: var(--accent);}
 


### PR DESCRIPTION
## Summary
- apply `--font-nav` variable to header links in dark theme

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68696ec98bbc8323bee42326ce0f59e5