### PR TITLE
Use Orbitron for hero logo

### DIFF
--- a/assets/confused-dark.css
+++ b/assets/confused-dark.css
@@ -4,7 +4,7 @@
   --panel: #16181c;          /* cards / nav */
   --text-main: #e5e5e5;    /* body text */
   --accent: #39ffb6;         /* neon beam green */
-  --brand-font: 'Luckiest Guy', cursive;
+  --brand-font: 'Orbitron', sans-serif;
 }
 
 /* ======  global ====== */

--- a/assets/fonts.css
+++ b/assets/fonts.css
@@ -1,8 +1,8 @@
 /* Load brand fonts from Google Fonts so they work consistently across browsers */
-@import url('https://fonts.googleapis.com/css2?family=Luckiest+Guy&family=Press+Start+2P&family=Orbitron&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Orbitron&display=swap');
 
 :root {
   --font-heading: 'Press Start 2P', cursive;
-  --brand-font: 'Luckiest Guy', cursive;
+  --brand-font: 'Orbitron', sans-serif;
   --font-nav: 'Orbitron', sans-serif;
 }

--- a/assets/hero-logo.svg
+++ b/assets/hero-logo.svg
@@ -6,7 +6,7 @@
     </linearGradient>
   </defs>
   <rect width="500" height="120" fill="transparent"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" style="font-family: var(--brand-font);" font-size="48" fill="url(#grad)" stroke="black" stroke-width="2">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" style="font-family: 'Orbitron', sans-serif;" font-size="48" fill="url(#grad)" stroke="black" stroke-width="2">
     Wear the Weird
   </text>
 </svg>

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -6,7 +6,7 @@
   --color-button-blue: #007bff;
   --color-button-blue-hover: #3399ff;
   --color-foreground: 255,255,255;
-  --font-heading: {% if settings.use_glitch_font %}'Press Start 2P', cursive{% else %}'Luckiest Guy', cursive{% endif %};
+  --font-heading: {% if settings.use_glitch_font %}'Press Start 2P', cursive{% else %}'Orbitron', sans-serif{% endif %};
 }
 
 body {

--- a/snippets/hero-logo-svg.liquid
+++ b/snippets/hero-logo-svg.liquid
@@ -6,7 +6,7 @@
     </linearGradient>
   </defs>
   <rect width="500" height="120" fill="transparent"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" style="font-family: var(--brand-font);" font-size="48" fill="url(#grad)" stroke="black" stroke-width="2">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" style="font-family: 'Orbitron', sans-serif;" font-size="48" fill="url(#grad)" stroke="black" stroke-width="2">
     Wear the Weird
   </text>
 </svg>


### PR DESCRIPTION
## Summary
- load Orbitron as the brand font
- change hero logo SVGs to use Orbitron
- update heading font variable in theme.css

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68696f70307483238d3f69dbae94aaab