### PR TITLE
Shift open hamburger icon left 10px

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -270,6 +270,10 @@ header nav a {
   transform: translate(30px, -40px);
 }
 
+.mobile-menu-toggle.open {
+  transform: translate(20px, -40px);
+}
+
 @media (max-width: 768px) {
   .nav-links {
     display: flex;
@@ -292,6 +296,10 @@ header nav a {
     margin-right: 60px;
     /* Move hamburger icon up by 40px and right by 30px */
     transform: translate(30px, -40px);
+  }
+
+  .mobile-menu-toggle.open {
+    transform: translate(20px, -40px);
   }
 
   .user-links {

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -2,8 +2,16 @@
 function toggleMenu() {
   const menu = document.querySelector('.nav-links');
   const cart = document.querySelector('.floating-cart');
+  const toggle = document.querySelector('.mobile-menu-toggle');
   if (menu) {
     menu.classList.toggle('active');
+    if (toggle) {
+      if (menu.classList.contains('active')) {
+        toggle.classList.add('open');
+      } else {
+        toggle.classList.remove('open');
+      }
+    }
     if (cart) {
       if (menu.classList.contains('active')) {
         cart.classList.add('hidden');


### PR DESCRIPTION
## Summary
- adjust hamburger icon position when mobile menu is toggled
- add CSS rule for `.mobile-menu-toggle.open` to move icon left

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686978d8070083239db3dc07774398b2