### PR TITLE
Add Bluesky to mobile nav menu

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -30,6 +30,7 @@
               <li><a href="{{ routes.all_products_collection_url }}">Catalog</a></li>
               <li><a href="/pages/about">About</a></li>
               <li><a href="{{ pages.contact.url }}">Contact</a></li>
+              <li><a href="https://bsky.app/profile/confused-art.bsky.social" target="_blank" rel="noopener">Bluesky</a></li>
             </ul>
           </nav>
 


### PR DESCRIPTION
## Summary
- add link to Bluesky in the main navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686982dd19f88323b3dc200e1098a68f