### PR TITLE
Fix About link 404

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -405,6 +405,37 @@ input[type="number"] {
   display: none !important;
 }
 
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1001;
+}
+
+.modal-content {
+  position: relative;
+  background: #1b1b1b;
+  padding: 2rem;
+  border-radius: 0.5rem;
+  max-width: 600px;
+  color: var(--color-muted-gray);
+}
+
+.modal-content .close {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.5rem;
+  font-size: 2rem;
+  cursor: pointer;
+  color: var(--color-muted-gray);
+}
+
 .floating-cart-icon {
   width: 2rem;
   height: 2rem;

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -40,3 +40,18 @@ document.addEventListener('DOMContentLoaded', function() {
     desc.innerHTML = desc.innerHTML.replace(/sust\s*ainable/gi, 'sustainable');
   }
 });
+
+function openAboutModal(event) {
+  if (event) event.preventDefault();
+  const modal = document.getElementById('about-modal');
+  if (modal) {
+    modal.classList.remove('hidden');
+  }
+}
+
+function closeAboutModal() {
+  const modal = document.getElementById('about-modal');
+  if (modal) {
+    modal.classList.add('hidden');
+  }
+}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -28,7 +28,7 @@
             <ul class="nav-links flex-center gap-md">
               <li><a href="{{ routes.root_url }}">Home</a></li>
               <li><a href="{{ routes.all_products_collection_url }}">Catalog</a></li>
-              <li><a href="/pages/about">About</a></li>
+              <li><a href="#" id="about-link" onclick="openAboutModal(event)">About</a></li>
               <li><a href="{{ pages.contact.url }}">Contact</a></li>
               <li><a href="https://bsky.app/profile/confused-art.bsky.social" target="_blank" rel="noopener">Bluesky</a></li>
             </ul>
@@ -70,6 +70,12 @@
         </div>
       </div>
     </footer>
+    <div id="about-modal" class="modal hidden">
+      <div class="modal-content">
+        <span class="close" onclick="closeAboutModal()">&times;</span>
+        <p>Arcane symbols. Forgotten gods. Hidden meanings. Confused Apparel offers esoteric apparel for those walking between worlds. Shirts and gear inspired by ritual, conspiracy, and chaos magic. Wear the sigil. Confuse the system. Stay soft.</p>
+      </div>
+    </div>
     <script src="{{ 'theme.js' | asset_url }}" defer></script>
     {{ content_for_footer }}
   </body>


### PR DESCRIPTION
## Summary
- make About open a modal instead of linking to a page
- style modal in theme CSS
- add JS helpers to open and close the modal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686984d12b94832399bab7e945d76e79