### PR TITLE
Show return policy in modal

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -411,5 +411,39 @@ input[type="number"] {
   display: block;
 }
 
+/* Return policy modal */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+}
+
+.modal-content {
+  background: #1b1b1b;
+  border: 1px solid #333;
+  padding: 2rem;
+  max-width: 600px;
+  color: var(--color-muted-gray);
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
 
 

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -39,4 +39,22 @@ document.addEventListener('DOMContentLoaded', function() {
     // Fix line break "sust\nainable" -> "sustainable"
     desc.innerHTML = desc.innerHTML.replace(/sust\s*ainable/gi, 'sustainable');
   }
+
+  const returnLink = document.getElementById('return-policy-link');
+  const returnModal = document.getElementById('return-modal');
+  const returnClose = document.getElementById('return-modal-close');
+  if (returnLink && returnModal && returnClose) {
+    returnLink.addEventListener('click', function(e) {
+      e.preventDefault();
+      returnModal.classList.remove('hidden');
+    });
+    returnClose.addEventListener('click', function() {
+      returnModal.classList.add('hidden');
+    });
+    returnModal.addEventListener('click', function(e) {
+      if (e.target === returnModal) {
+        returnModal.classList.add('hidden');
+      }
+    });
+  }
 });

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -63,14 +63,22 @@
         <div class="text-right">
           {{ payment_methods }}
           <p>&copy; 2024 - 2025, {{ shop.name }}</p>
-          <a href="/policies/privacy-policy">Privacy policy</a> |
-            <a href="/pages/returns">Return policy</a> |
+            <a href="/policies/privacy-policy">Privacy policy</a> |
+              <a href="#" id="return-policy-link">Return policy</a> |
             <a href="{{ pages.contact.url }}">Contact</a> |
           <a href="https://bsky.app/profile/confused-art.bsky.social" target="_blank" rel="noopener">Bluesky</a>
         </div>
       </div>
-    </footer>
-    <script src="{{ 'theme.js' | asset_url }}" defer></script>
-    {{ content_for_footer }}
-  </body>
-</html>
+      </footer>
+
+      <div id="return-modal" class="modal hidden" role="dialog" aria-modal="true">
+        <div class="modal-content">
+          <button id="return-modal-close" class="modal-close" aria-label="Close">&times;</button>
+          <h2>Return Policy</h2>
+          <p>Returns are accepted within 30 days of purchase for new, unused products in their original condition. Contact us first so we can help.</p>
+        </div>
+      </div>
+      <script src="{{ 'theme.js' | asset_url }}" defer></script>
+      {{ content_for_footer }}
+    </body>
+  </html>

--- a/templates/page.returns.liquid
+++ b/templates/page.returns.liquid
@@ -1,5 +1,5 @@
 {% layout 'theme' %}
 <section class="page-content returns">
   <h1>Return Policy</h1>
-  <p>We want you to love your order. If you're not satisfied, you may return items within 30 days of delivery for a refund or exchange. Contact us first so we can help.</p>
+  <p>Returns are accepted within 30 days of purchase for new, unused products in their original condition. Contact us first so we can help.</p>
 </section>


### PR DESCRIPTION
## Summary
- update 30-day return policy wording
- show return policy in a modal instead of linking to a page
- style the modal with CSS
- trigger modal via JS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686984f7afb8832386968e3ccc39b600