### PR TITLE
Update address to use Confused branding

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -57,7 +57,11 @@
       <div class="container grid-2 gap-lg">
         <div>
           <p>Confused Apparel by <a href="https://lochner.tech" target="_blank" rel="noopener">Lochner Tech</a></p>
-          <p>P.O. Box 148, Wisconsin Dells, WI 53965, US</p>
+          <p>
+            Confused<br>
+            P.O. Box 148<br>
+            Wisconsin Dells, WI 53965
+          </p>
           <p>Products ship from fulfillment centers within a few business days.</p>
         </div>
         <div class="text-right">

--- a/templates/page.contact.liquid
+++ b/templates/page.contact.liquid
@@ -2,5 +2,10 @@
 <section class="page-content contact">
   <h1>Contact Us</h1>
   <p>For help with your order, email <a href="mailto:orders@confused.store">orders@confused.store</a>.</p>
-  <p>Mail correspondence can be sent to Confused Apparel, P.O. Box 148, Wisconsin Dells, WI 53965, US.</p>
+  <p>
+    Mail correspondence can be sent to<br>
+    Confused<br>
+    P.O. Box 148<br>
+    Wisconsin Dells, WI 53965
+  </p>
 </section>


### PR DESCRIPTION
## Summary
- list Confused as the business name in the contact page address
- list Confused as the business name in the footer address

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686986a0c59c8323a0f7fd7cbca49a1d