### PR TITLE
Add return policy modal

### DIFF
--- a/assets/theme.js
+++ b/assets/theme.js
@@ -55,3 +55,18 @@ function closeAboutModal() {
     modal.classList.add('hidden');
   }
 }
+
+function openReturnsModal(event) {
+  if (event) event.preventDefault();
+  const modal = document.getElementById('returns-modal');
+  if (modal) {
+    modal.classList.remove('hidden');
+  }
+}
+
+function closeReturnsModal() {
+  const modal = document.getElementById('returns-modal');
+  if (modal) {
+    modal.classList.add('hidden');
+  }
+}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -64,7 +64,7 @@
           {{ payment_methods }}
           <p>&copy; 2024 - 2025, {{ shop.name }}</p>
           <a href="/policies/privacy-policy">Privacy policy</a> |
-            <a href="/pages/returns">Return policy</a> |
+            <a href="#" onclick="openReturnsModal(event)">Return policy</a> |
             <a href="{{ pages.contact.url }}">Contact</a> |
           <a href="https://bsky.app/profile/confused-art.bsky.social" target="_blank" rel="noopener">Bluesky</a>
         </div>
@@ -74,6 +74,12 @@
       <div class="modal-content">
         <span class="close" onclick="closeAboutModal()">&times;</span>
         <p>Arcane symbols. Forgotten gods. Hidden meanings. Confused Apparel offers esoteric apparel for those walking between worlds. Shirts and gear inspired by ritual, conspiracy, and chaos magic. Wear the sigil. Confuse the system. Stay soft.</p>
+      </div>
+    </div>
+    <div id="returns-modal" class="modal hidden">
+      <div class="modal-content">
+        <span class="close" onclick="closeReturnsModal()">&times;</span>
+        <p>We accept returns of new, unused products in their original condition within 30 days of receipt.</p>
       </div>
     </div>
     <script src="{{ 'theme.js' | asset_url }}" defer></script>

--- a/templates/page.returns.liquid
+++ b/templates/page.returns.liquid
@@ -1,5 +1,5 @@
 {% layout 'theme' %}
 <section class="page-content returns">
   <h1>Return Policy</h1>
-  <p>We want you to love your order. If you're not satisfied, you may return items within 30 days of delivery for a refund or exchange. Contact us first so we can help.</p>
+  <p>We accept returns of new, unused products in their original condition within 30 days of receipt.</p>
 </section>


### PR DESCRIPTION
## Summary
- implement a modal for the return policy link
- update the footer link to show the modal
- add open/close functions for the return policy modal
- update return policy text in `page.returns.liquid`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6869885160dc8323b1eee5a5f5bd20fc