### PR TITLE
Fix shipping note

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -57,7 +57,7 @@
       <div class="container grid-2 gap-lg">
         <div>
           <p>Confused Apparel by <a href="https://lochner.tech" target="_blank" rel="noopener">Lochner Tech</a></p>
-          <p>Products ship from fulfillment centers within a few business days.</p>
+          <p>Products ship from United States fulfillment centers within a few business days.</p>
         </div>
         <div class="text-right">
           {{ payment_methods }}


### PR DESCRIPTION
## Summary
- tweak the shipping footer copy to mention US fulfillment centers

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686989a1e2648323996764ca65ef5156