### PR TITLE
Add About Confused Apparel modal header

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -427,6 +427,11 @@ input[type="number"] {
   color: var(--color-muted-gray);
 }
 
+.modal-title {
+  font-family: var(--brand-font);
+  margin-top: 0;
+}
+
 .modal-content .close {
   position: absolute;
   top: 0.25rem;

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -77,6 +77,7 @@
     <div id="about-modal" class="modal hidden">
       <div class="modal-content">
         <span class="close" onclick="closeAboutModal()">&times;</span>
+        <h2 class="modal-title">About Confused Apparel</h2>
         <p>Arcane symbols. Forgotten gods. Hidden meanings. Confused Apparel offers esoteric apparel for those walking between worlds. Shirts and gear inspired by ritual, conspiracy, and chaos magic. Wear the sigil. Confuse the system. Stay soft.</p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a brand-font heading to the About modal
- style modal-title with the brand font

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68698da6b738832387d0381e39712a3f