### PR TITLE
Add additional footer links

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -65,6 +65,9 @@
           <a href="/policies/privacy-policy">Privacy policy</a> |
             <a href="#" onclick="openReturnsModal(event)">Return policy</a> |
             <a href="{{ pages.contact.url }}">Contact</a> |
+            <a href="{{ routes.root_url }}">Home</a> |
+            <a href="{{ routes.all_products_collection_url }}">Catalog</a> |
+            <a href="#" onclick="openAboutModal(event)">About</a> |
           <a href="https://bsky.app/profile/confused-art.bsky.social" target="_blank" rel="noopener">Bluesky</a>
           <p>
             Confused<br>


### PR DESCRIPTION
## Summary
- add navigation links to footer so Home, Catalog and About are accessible at the bottom of the page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6869916f430c8323bc6ae8491ccc6224