### PR TITLE
Ensure 'sustainable' stays on one line

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -172,6 +172,11 @@ header nav a {
   font-family: inherit !important;
 }
 
+/* Prevent line wrapping for fixed words */
+.no-break {
+  white-space: nowrap;
+}
+
 .product-image {
   width: 100%;
   aspect-ratio: 4 / 3;

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -36,8 +36,8 @@ document.addEventListener('DOMContentLoaded', function() {
       }
       parent.removeChild(el);
     });
-    // Fix line break "sust\nainable" -> "sustainable"
-    desc.innerHTML = desc.innerHTML.replace(/sust\s*ainable/gi, 'sustainable');
+    // Fix line break "sust\nainable" or with HTML tags -> "sustainable"
+    desc.innerHTML = desc.innerHTML.replace(/sust(?:\s|<[^>]*>)*ainable/gi, '<span class="no-break">sustainable</span>');
   }
 });
 


### PR DESCRIPTION
## Summary
- enhance JS regex to catch cases where `sust` and `ainable` are separated by HTML
- wrap the normalized word in a `no-break` span
- add `.no-break` CSS utility to disable wrapping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6869a0c5a82c8323b24d6bfa8f91f3f6