### PR TITLE
Move cart icon next to Bluesky on desktop

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -206,6 +206,10 @@ header nav a {
   float: right;
 }
 
+.user-links .icon-cart {
+  display: none;
+}
+
 .hero-glitch {
   position: relative;
   text-align: center;
@@ -310,8 +314,16 @@ header nav a {
     justify-content: flex-end;
   }
 
+  .nav-cart {
+    display: none;
+  }
+
   .user-links > a:not([href="/cart"]) {
     display: none;
+  }
+
+  .user-links .icon-cart {
+    display: inline-block;
   }
 }
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -31,6 +31,7 @@
               <li><a href="#" id="about-link" onclick="openAboutModal(event)">About</a></li>
               <li><a href="{{ pages.contact.url }}">Contact</a></li>
               <li><a href="https://bsky.app/profile/confused-art.bsky.social" target="_blank" rel="noopener">Bluesky</a></li>
+              <li class="nav-cart"><a class="icon-link" href="/cart"><span class="icon-cart"></span></a></li>
             </ul>
           </nav>
 


### PR DESCRIPTION
## Summary
- add cart link after Bluesky in the main nav
- hide cart icon from user links on desktop
- show nav cart only on desktop via CSS

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6869a05e53ec83239119a2123164a798