### PR TITLE
Position cart icon after Bluesky on desktop

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -315,6 +315,18 @@ header nav a {
   }
 }
 
+@media (max-width: 768px) {
+  .nav-cart {
+    display: none;
+  }
+}
+
+@media (min-width: 769px) {
+  .user-links > a[href="/cart"] {
+    display: none;
+  }
+}
+
 /* --- Cart page styling --- */
 .cart-page {
   background: #1b1b1b;

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -31,6 +31,7 @@
               <li><a href="#" id="about-link" onclick="openAboutModal(event)">About</a></li>
               <li><a href="{{ pages.contact.url }}">Contact</a></li>
               <li><a href="https://bsky.app/profile/confused-art.bsky.social" target="_blank" rel="noopener">Bluesky</a></li>
+              <li class="nav-cart"><a class="icon-link" href="/cart"><span class="icon-cart"></span></a></li>
             </ul>
           </nav>
 


### PR DESCRIPTION
## Summary
- add cart icon entry in navigation menu
- hide old cart icon on desktop and hide nav cart on mobile

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6869a05e53ec83239119a2123164a798