### PR TITLE
Move cart icon to nav on desktop

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -259,6 +259,15 @@ header nav a {
   gap: 1rem;
 }
 
+/* Desktop placement for cart icon */
+.user-links > a.mobile-cart {
+  display: none;
+}
+
+.nav-cart-item {
+  display: inline-block;
+}
+
 .mobile-menu-toggle {
   display: none;
   font-size: 1.5rem;
@@ -312,6 +321,14 @@ header nav a {
 
   .user-links > a:not([href="/cart"]) {
     display: none;
+  }
+
+  .nav-cart-item {
+    display: none;
+  }
+
+  .user-links > a.mobile-cart {
+    display: inline-block;
   }
 }
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -31,15 +31,16 @@
               <li><a href="#" id="about-link" onclick="openAboutModal(event)">About</a></li>
               <li><a href="{{ pages.contact.url }}">Contact</a></li>
               <li><a href="https://bsky.app/profile/confused-art.bsky.social" target="_blank" rel="noopener">Bluesky</a></li>
-            </ul>
-          </nav>
+              <li class="nav-cart-item"><a class="icon-link" href="/cart"><span class="icon-cart"></span></a></li>
+              </ul>
+            </nav>
 
         <div class="mobile-menu-toggle" onclick="toggleMenu()">&#9776;</div>
 
         <div class="user-links flex-center gap-sm">
           <a class="icon-link" href="/search"><span class="icon-search"></span></a>
           <a class="icon-link" href="/account"><span class="icon-user"></span></a>
-          <a class="icon-link" href="/cart"><span class="icon-cart"></span></a>
+          <a class="icon-link mobile-cart" href="/cart"><span class="icon-cart"></span></a>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- place the cart icon in the navigation links
- keep a separate mobile cart icon for small screens
- hide/show the icons with responsive CSS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6869a05e53ec83239119a2123164a798