### PR TITLE
Add ambient graphic banner to hero

### DIFF
--- a/assets/hero-ambient.svg
+++ b/assets/hero-ambient.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="400" viewBox="0 0 1600 400" preserveAspectRatio="none">
+  <defs>
+    <radialGradient id="a" cx="50%" cy="50%" r="70%">
+      <stop offset="0%" stop-color="#ff2fff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ff2fff" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="b" cx="30%" cy="70%" r="60%">
+      <stop offset="0%" stop-color="#39ff14" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#39ff14" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1600" height="400" fill="url(#a)"/>
+  <circle cx="1200" cy="100" r="300" fill="url(#b)"/>
+</svg>

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -213,12 +213,26 @@ header nav a {
   background-size: cover;
   color: var(--color-neon-green);
 }
+.hero-glitch .hero-ambient {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  max-width: 600px;
+  height: auto;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.6;
+}
 .hero-glitch p {
   margin: 0.25rem 0 0;
   font-size: 0.9rem;
 }
 
 .hero-glitch .hero-logo {
+  position: relative;
+  z-index: 1;
   max-width: 500px;
   width: 80%;
   height: auto;

--- a/sections/hero-glitch.liquid
+++ b/sections/hero-glitch.liquid
@@ -1,4 +1,5 @@
 <div class="hero-glitch" style="background-image:url({{ section.settings.bg_image | image_url }});">
+  <img src="{{ 'hero-ambient.svg' | asset_url }}" alt="" class="hero-ambient" aria-hidden="true">
   {% if section.settings.hero_image != blank %}
     <img src="{{ section.settings.hero_image | image_url }}" alt="{{ section.settings.headline }}" class="hero-logo">
   {% else %}


### PR DESCRIPTION
## Summary
- embed an abstract ambient SVG graphic behind hero text
- overlay hero ambient image via CSS with absolute positioning

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6869a2518a948323ba7d87e0785affd9