### PR TITLE
Fix floating cart position on desktop

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -436,6 +436,12 @@ input[type="number"] {
   padding: 0.5rem;
 }
 
+@media (min-width: 769px) {
+  .floating-cart {
+    position: sticky;
+  }
+}
+
 .hidden {
   display: none !important;
 }


### PR DESCRIPTION
## Summary
- set `.floating-cart` to use sticky positioning on desktop screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6869be2dbfc483238f7b39c9d4512a67