### PR TITLE
Fix hero background height on mobile

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -217,6 +217,10 @@ header nav a {
   padding: 2rem 1rem 1rem; /* tighter space above and below */
   background-size: cover;
   color: var(--color-neon-green);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 .hero-glitch .hero-ambient {
   position: absolute;


### PR DESCRIPTION
## Summary
- keep glitch hero full screen on mobile by using min-height and flexbox

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6869c64ab5248323af6947b42857fa4e