### PR TITLE
Adjust mobile header spacing

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -317,12 +317,18 @@ header nav a {
      margin-left: 20px;
   }
 
+  /* Add spacing for logo and hamburger on mobile */
+  .logo {
+    margin-top: 30px;
+  }
+
   .mobile-menu-toggle {
     display: block;
     margin-left: auto;
     margin-right: 60px;
     /* Move hamburger icon up by 40px and right by 30px */
     transform: translate(30px, -40px);
+    margin-top: 30px;
   }
 
   .mobile-menu-toggle.open {


### PR DESCRIPTION
## Summary
- add 30px top margin for the logo and hamburger menu in mobile view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6869c60b0058832383ccd8c0c5efc561