### PR TITLE
Add floating cart item count badge

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -488,5 +488,21 @@ input[type="number"] {
   display: block;
 }
 
+.floating-cart .cart-count {
+  position: absolute;
+  top: -0.25rem;
+  right: -0.25rem;
+  background: #ffd700;
+  color: #1b1b1b;
+  border-radius: 50%;
+  font-size: 0.75rem;
+  font-weight: bold;
+  width: 1.25rem;
+  height: 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -47,6 +47,9 @@
 
     <a href="/cart" class="floating-cart icon-link" aria-label="Cart">
       <img src="{{ 'ufo-cart.svg' | asset_url }}" alt="Cart icon" class="floating-cart-icon" />
+      {% if cart.item_count > 0 %}
+        <span class="cart-count">{{ cart.item_count }}</span>
+      {% endif %}
     </a>
 
     <main class="container">


### PR DESCRIPTION
## Summary
- show cart item count in floating cart
- style count badge with yellow background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6869bfbed9208323bce7089b69934188