### PR TITLE
Shift hamburger icon on open

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -292,10 +292,11 @@ header nav a {
   cursor: pointer;
   margin-left: auto;
   color: var(--color-muted-gray);
+  transition: transform 0.3s ease;
 }
 
 .mobile-menu-toggle.open {
-  /* no positional shift when menu opens */
+  transform: translateX(-30px);
 }
 
 @media (max-width: 768px) {
@@ -328,7 +329,7 @@ header nav a {
   }
 
   .mobile-menu-toggle.open {
-    /* keep icon aligned when menu opens */
+    transform: translateX(-30px);
   }
 
   .user-links {


### PR DESCRIPTION
## Summary
- slide the mobile-menu-toggle 30px left when the menu opens
- transition the transform for a smooth animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6869dcadd07c83239541ccf76d9d2a71