### PR TITLE
Add gpt-image-1 model support

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -3247,12 +3247,12 @@ app.post("/api/image/generate", async (req, res) => {
     const openaiClient = new OpenAI({ apiKey: openAiKey });
 
     let modelName = (model || "dall-e-3").toLowerCase();
-    const allowedModels = ["dall-e-2", "dall-e-3"];
+    const allowedModels = ["dall-e-2", "dall-e-3", "gpt-image-1"];
     if (!allowedModels.includes(modelName)) {
       return res.status(400).json({ error: "Invalid model" });
     }
 
-    if (modelName === "dall-e-3") {
+    if (modelName === "dall-e-3" || modelName === "gpt-image-1") {
       countParsed = 1;
     } else {
       countParsed = Math.min(countParsed, 4);
@@ -3274,7 +3274,7 @@ app.post("/api/image/generate", async (req, res) => {
       });
     } catch (err) {
       if (
-        modelName === "dall-e-3" &&
+        (modelName === "dall-e-3" || modelName === "gpt-image-1") &&
         err?.type === "image_generation_user_error"
       ) {
         try {

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 ### Alfe AI: Software Development and Image Design Platform  
 
 The first version of the Alfe AI Cloud Platform https://alfe.sh <!-- has been released --> (beta-2.30).  
-This initial cloud release includes the image design component of the Alfe AI Platform.  
-The software development component is coming soon, and is available now as a Pre-release on GitHub.  
+This initial cloud release includes the image design component of the Alfe AI Platform.
+It now supports OpenAI's **gpt-image-1** model for image generation via the built-in API.
+The software development component is coming soon, and is available now as a Pre-release on GitHub.
 
 ![image](https://github.com/user-attachments/assets/b7d308f8-e2a6-4098-b707-8f8704a74049)  
 


### PR DESCRIPTION
## Summary
- allow gpt-image-1 in the image generation API
- document gpt-image-1 support in README

## Testing
- `node --check Aurora/src/server.js`

------
https://chatgpt.com/codex/tasks/task_b_686ae23875f48323b3cb4765d410b6f3