### PR TITLE
Default to gpt-image-1 image model

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -3246,7 +3246,7 @@ app.post("/api/image/generate", async (req, res) => {
 
     const openaiClient = new OpenAI({ apiKey: openAiKey });
 
-    let modelName = (model || "dall-e-3").toLowerCase();
+    let modelName = (model || "gpt-image-1").toLowerCase();
     const allowedModels = ["dall-e-2", "dall-e-3", "gpt-image-1"];
     if (!allowedModels.includes(modelName)) {
       return res.status(400).json({ error: "Invalid model" });

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ### Alfe AI: Software Development and Image Design Platform  
 
-The first version of the Alfe AI Cloud Platform https://alfe.sh <!-- has been released --> (beta-2.30).  
+The first version of the Alfe AI Cloud Platform https://alfe.sh <!-- has been released --> (beta-2.30).
 This initial cloud release includes the image design component of the Alfe AI Platform.
-It now supports OpenAI's **gpt-image-1** model for image generation via the built-in API.
+It now defaults to OpenAI's **gpt-image-1** model for image generation via the built-in API.
 The software development component is coming soon, and is available now as a Pre-release on GitHub.
 
 ![image](https://github.com/user-attachments/assets/b7d308f8-e2a6-4098-b707-8f8704a74049)  


### PR DESCRIPTION
## Summary
- default to `gpt-image-1` when generating images via OpenAI API
- document that gpt-image-1 is the default

## Testing
- `node Aurora/test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_686ae46973788323ac6dece29289fc85