### PR TITLE
Handle base64 image responses

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -3298,27 +3298,39 @@ app.post("/api/image/generate", async (req, res) => {
     }
 
     let first = null;
+    let b64 = null;
     if (result && Array.isArray(result.data) && result.data[0]) {
       first = result.data[0].url || result.data[0].image_url || null;
       if (first && typeof first === 'object' && first.url) {
         first = first.url;
       }
+      b64 = result.data[0].b64_json || null;
     }
     console.debug("[Server Debug] OpenAI response url =>", first);
-    if (!first) {
+    if (!first && !b64) {
       return res.status(502).json({ error: "Received empty response from AI service" });
     }
 
     let localUrl = first;
     try {
-      const resp = await axios.get(first, { responseType: "arraybuffer" });
-      const ext = path.extname(new URL(first).pathname) || ".png";
-      const filename = `generated-${Date.now()}-${Math.round(Math.random() * 1e9)}${ext}`;
-      const filePath = path.join(uploadsDir, filename);
-      fs.writeFileSync(filePath, resp.data);
-      await removeColorSwatches(filePath);
-      console.debug("[Server Debug] Saved OpenAI image =>", filePath);
-      localUrl = `/uploads/${filename}`;
+      if (first) {
+        const resp = await axios.get(first, { responseType: "arraybuffer" });
+        const ext = path.extname(new URL(first).pathname) || ".png";
+        const filename = `generated-${Date.now()}-${Math.round(Math.random() * 1e9)}${ext}`;
+        const filePath = path.join(uploadsDir, filename);
+        fs.writeFileSync(filePath, resp.data);
+        await removeColorSwatches(filePath);
+        console.debug("[Server Debug] Saved OpenAI image =>", filePath);
+        localUrl = `/uploads/${filename}`;
+      } else if (b64) {
+        const buffer = Buffer.from(b64, "base64");
+        const filename = `generated-${Date.now()}-${Math.round(Math.random() * 1e9)}.png`;
+        const filePath = path.join(uploadsDir, filename);
+        fs.writeFileSync(filePath, buffer);
+        await removeColorSwatches(filePath);
+        console.debug("[Server Debug] Saved OpenAI b64 image =>", filePath);
+        localUrl = `/uploads/${filename}`;
+      }
     } catch(downloadErr) {
       console.error("[Server Debug] Failed to download generated image:", downloadErr);
     }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 The first version of the Alfe AI Cloud Platform https://alfe.sh <!-- has been released --> (beta-2.30).
 This initial cloud release includes the image design component of the Alfe AI Platform.
 It now defaults to OpenAI's **gpt-image-1** model for image generation via the built-in API.
+If the model returns a base64 string instead of a URL, the server automatically decodes and saves the image.
 The software development component is coming soon, and is available now as a Pre-release on GitHub.
 
 ![image](https://github.com/user-attachments/assets/b7d308f8-e2a6-4098-b707-8f8704a74049)  


### PR DESCRIPTION
## Summary
- save base64 images from gpt-image-1 if no URL is provided
- document the behavior in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686c2bec55ac832388f48ef406b482e0