### PR TITLE
Ensure remove_bg dependencies install automatically

### DIFF
--- a/Aurora/scripts/remove_bg.py
+++ b/Aurora/scripts/remove_bg.py
@@ -2,9 +2,25 @@
 # remove_bg.py - make artwork transparencies for DTG/DTF printing
 import sys
 import pathlib
-from PIL import Image
-from rembg import remove
-from tqdm import tqdm
+import subprocess
+
+try:
+    from PIL import Image
+except ImportError:
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "Pillow"])
+    from PIL import Image
+
+try:
+    from rembg import remove
+except ImportError:
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "rembg"])
+    from rembg import remove
+
+try:
+    from tqdm import tqdm
+except ImportError:
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "tqdm"])
+    from tqdm import tqdm
 
 
 def process_image(src: pathlib.Path, dst: pathlib.Path):


### PR DESCRIPTION
## Summary
- tweak `remove_bg.py` to auto-install Pillow, rembg, and tqdm if missing

## Testing
- `pre-commit` *(fails: not found)*

------
https://chatgpt.com/codex/tasks/task_b_686c3cda1800832394cf30e957dbdc9e