### PR TITLE
Fix remove_bg.sh to install onnxruntime

### DIFF
--- a/Aurora/scripts/remove_bg.sh
+++ b/Aurora/scripts/remove_bg.sh
@@ -17,10 +17,11 @@ source "$VENV_DIR/bin/activate"
 # Install dependencies if missing
 if ! "$VENV_DIR/bin/pip" show pillow >/dev/null 2>&1 || \
    ! "$VENV_DIR/bin/pip" show rembg >/dev/null 2>&1 || \
-   ! "$VENV_DIR/bin/pip" show tqdm >/dev/null 2>&1; then
+   ! "$VENV_DIR/bin/pip" show tqdm >/dev/null 2>&1 || \
+   ! "$VENV_DIR/bin/pip" show onnxruntime >/dev/null 2>&1; then
     echo "Installing dependencies in venv..."
     "$VENV_DIR/bin/pip" install -q --upgrade pip
-    "$VENV_DIR/bin/pip" install -q Pillow rembg tqdm
+    "$VENV_DIR/bin/pip" install -q Pillow rembg tqdm onnxruntime
 fi
 
 # Run remove_bg.py with passed arguments


### PR DESCRIPTION
## Summary
- ensure `onnxruntime` is installed when running `remove_bg.sh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686c4b0fa8148323b8b69d899d06e625