### PR TITLE
Move search toggle next to image button

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -298,6 +298,7 @@
         <!-- Hidden file input for image uploading -->
         <input type="file" id="imageUploadInput" accept="image/*" style="display:none" multiple />
         <button id="chatImageBtn" class="send-btn" title="Upload Image" style="display:none;">🖼</button>
+        <button id="searchToggleBtn" class="send-btn search-toggle-btn" title="Toggle Search">🔍</button>
 
         <textarea id="chatInput" placeholder="Type your message..." style="position:relative; top:20px;"></textarea>
         <button id="chatSendBtn" class="send-btn">
@@ -313,7 +314,6 @@
       <div id="imageProcessingIndicator" style="display:none; color:#f0f; margin:8px 0;">Processing image, please wait...</div>
     </div>
   </main>
-  <button id="searchToggleBtn" class="search-toggle-btn" title="Toggle Search">🔍</button>
 </div>
 
 <div id="colModal" class="modal">

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1314,16 +1314,13 @@ button:disabled {
 
 /* Search toggle button in bottom-left corner */
 #searchToggleBtn {
-  position: fixed;
-  bottom: 8px;
-  left: 8px;
   background: #474747;
   border: 1px solid #666;
   color: #ddd;
   padding: 4px 6px;
   border-radius: 8px;
   cursor: pointer;
-  z-index: 1000;
+  margin-right: 0.5rem;
 }
 #searchToggleBtn.active {
   background: #0062cc;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -1296,16 +1296,13 @@ button:disabled {
 
 /* Search toggle button in bottom-left corner */
 #searchToggleBtn {
-  position: fixed;
-  bottom: 8px;
-  left: 8px;
   background: #ccc;
   border: 1px solid #666;
   color: #111;
   padding: 4px 6px;
   border-radius: 8px;
   cursor: pointer;
-  z-index: 1000;
+  margin-right: 0.5rem;
 }
 #searchToggleBtn.active {
   background: #0062cc;


### PR DESCRIPTION
## Summary
- move search toggle to the chat toolbar near the image button
- update styles so the search toggle uses normal flow

## Testing
- `npm test` *(fails: Missing script)*
- `npx jest` *(fails: 403 Forbidden while downloading package)*

------
https://chatgpt.com/codex/tasks/task_b_686c7485c79c8323b5882f96f842ac93