### PR TITLE
Add AI search model selection

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -550,6 +550,18 @@
         <select id="globalAiModelSelect"></select>
       </label>
     </div>
+    <div style="margin-top:8px;">
+      <label>AI Search Model:
+        <select id="globalAiSearchModelSelect">
+          <option value="openai/gpt-4o-search-preview">openai/gpt-4o-search-preview</option>
+          <option value="openai/gpt-4o-mini-search-preview">openai/gpt-4o-mini-search-preview</option>
+          <option value="openrouter/perplexity/sonar">openrouter/perplexity/sonar</option>
+          <option value="openrouter/perplexity/sonar-pro">openrouter/perplexity/sonar-pro</option>
+          <option value="openrouter/perplexity/sonar-reasoning">openrouter/perplexity/sonar-reasoning</option>
+          <option value="openrouter/perplexity/sonar-reasoning-pro">openrouter/perplexity/sonar-reasoning-pro</option>
+        </select>
+      </label>
+    </div>
     <div class="modal-buttons">
       <button id="globalAiSettingsSaveBtn">Save</button>
       <button id="globalAiSettingsCancelBtn">Cancel</button>

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -136,6 +136,15 @@ if (!currentModel) {
   console.debug("[Server Debug] 'ai_model' found =>", currentModel);
 }
 
+console.debug("[Server Debug] Checking or setting default 'ai_search_model' in DB...");
+const currentSearchModel = db.getSetting("ai_search_model");
+if (!currentSearchModel) {
+  console.debug("[Server Debug] 'ai_search_model' is missing in DB, setting default to 'openrouter/perplexity/sonar'.");
+  db.setSetting("ai_search_model", "openrouter/perplexity/sonar");
+} else {
+  console.debug("[Server Debug] 'ai_search_model' found =>", currentSearchModel);
+}
+
 console.debug("[Server Debug] Checking or setting default 'ai_service' in DB...");
 if (!db.getSetting("ai_service")) {
   db.setSetting("ai_service", "openrouter");


### PR DESCRIPTION
## Summary
- extend server defaults to include `ai_search_model`
- add AI Search Model dropdown to Global AI Settings
- persist selected search model
- load search model into settings cache
- use the selected search model when toggling search

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686c8519e4288323a2acea6857d93cc2