### PR TITLE
Fix search button to use updated global model

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -5604,6 +5604,10 @@ async function saveGlobalAiSettings(){
   const model = document.getElementById("globalAiModelSelect").value;
   const searchModel = document.getElementById("globalAiSearchModelSelect").value;
   await setSettings({ ai_service: svc, ai_model: model, ai_search_model: searchModel });
+  // keep local cache in sync so toggles use latest values immediately
+  settingsCache.ai_service = svc;
+  settingsCache.ai_model = model;
+  settingsCache.ai_search_model = searchModel;
   modelName = model || "unknown";
   document.getElementById("modelHud").textContent = `Model: ${modelName}`;
   hideModal(document.getElementById("globalAiSettingsModal"));


### PR DESCRIPTION
## Summary
- keep the global settings cache in sync after saving

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686c9a6a7644832380656e4a83ad2f98