### PR TITLE
Hide sidebar project cards

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -161,9 +161,8 @@
     <!-- New Chat Tabs view panel -->
     <div id="sidebarViewChatTabs" style="display:none;">
 <!--      <h2>Chat Tabs</h2>-->
-      <div id="projectGroupsContainer" style="display:flex;flex-direction:column;gap:4px;"></div>
+      <div id="projectGroupsContainer" style="display:none;"></div>
       <div id="verticalTabsContainer" style="display:flex;flex-direction:column;gap:4px;"></div>
-      <button id="newProjectGroupBtn">➕ Project Group</button>
       <button id="newSideTabBtn">➕ Tab</button>
       <button id="toggleTopChatTabsBtn" style="display:none;">Hide/Show top chat tabs bar</button>
     </div>


### PR DESCRIPTION
## Summary
- hide project group cards and button in Aurora sidebar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686ca0dc2f188323b4741da9ace1f46e