### PR TITLE
Add collapsible project groups for chat tabs

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -827,6 +827,12 @@ body {
   font-size: 0.9rem;
   color: #aaa;
   font-weight: bold;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+#verticalTabsContainer .project-collapse-arrow {
+  margin-right: 4px;
 }
 
 #projectGroupsContainer button {

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -829,6 +829,12 @@ body {
   font-size: 0.9rem;
   color: #666;
   font-weight: bold;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+#verticalTabsContainer .project-collapse-arrow {
+  margin-right: 4px;
 }
 
 #projectGroupsContainer button {


### PR DESCRIPTION
## Summary
- allow collapsing and expanding project groups on the Aurora chat tabs sidebar

## Testing
- `npm -s run lint --prefix Aurora`

------
https://chatgpt.com/codex/tasks/task_b_686ca89d309c8323bac8f8e9eedcfd31