### PR TITLE
Enable image pasting in Aurora chat

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -5912,6 +5912,27 @@ document.getElementById("imageUploadInput").addEventListener("change", async (ev
   ev.target.value="";
 });
 
+// Allow pasting images directly into the chat input
+chatInputEl.addEventListener("paste", (ev) => {
+  if(!imageUploadEnabled) return;
+  const items = ev.clipboardData && ev.clipboardData.items;
+  if(!items) return;
+  let found = false;
+  for(const item of items){
+    if(item.type && item.type.startsWith("image/")){
+      const file = item.getAsFile();
+      if(file){
+        pendingImages.push(file);
+        found = true;
+      }
+    }
+  }
+  if(found){
+    ev.preventDefault();
+    updateImagePreviewList();
+  }
+});
+
 /*
   Show a small list of “buffered” images that will attach with the next message.
 */


### PR DESCRIPTION
## Summary
- support pasting images from the clipboard into Aurora chat

## Testing
- `npm run lint` *(fails: (no linter configured))*
- `node test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_686ca244912c832389329997584b7eb5