### PR TITLE
Fix project group button

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -161,7 +161,7 @@
     <!-- New Chat Tabs view panel -->
     <div id="sidebarViewChatTabs" style="display:none;">
 <!--      <h2>Chat Tabs</h2>-->
-      <div id="projectGroupsContainer" style="display:none;"></div>
+      <div id="projectGroupsContainer" style="display:none;flex-direction:column;gap:4px;"></div>
       <div id="verticalTabsContainer" style="display:flex;flex-direction:column;gap:4px;"></div>
       <button id="newProjectGroupBtn">➕ Project Group</button>
       <button id="newSideTabBtn">➕ Tab</button>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -376,6 +376,11 @@ function renderProjectGroups(){
   const container = document.getElementById('projectGroupsContainer');
   if(!container) return;
   container.innerHTML = '';
+  container.style.display = projectGroups.length ? 'flex' : 'none';
+  if(projectGroups.length){
+    container.style.flexDirection = 'column';
+    container.style.gap = '4px';
+  }
   projectGroups.forEach((name, idx) => {
     const btn = document.createElement('button');
     btn.className = 'project-group-button';


### PR DESCRIPTION
## Summary
- toggle project group container visibility based on groups
- keep project group container hidden until first group is added

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686d32f65bb883238a6c638b64473379