### PR TITLE
Fix project group display in sidebar

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -68,7 +68,7 @@ document.addEventListener('DOMContentLoaded', () => {
   loadMosaicRepoPath();
   loadProjectGroups();
   loadCollapsedProjectGroups();
-  renderProjectGroups();
+  // Project groups will be rendered within the sidebar tabs
   window.addEventListener('resize', updateChatPanelVisibility);
 });
 
@@ -406,7 +406,7 @@ function renderProjectGroups(){
       projectGroups.splice(idx, 0, moved);
       draggingProjectIndex = null;
       saveProjectGroups();
-      renderProjectGroups();
+      renderSidebarTabs();
     });
     btn.addEventListener('dragend', () => {
       draggingProjectIndex = null;
@@ -421,7 +421,7 @@ function addProjectGroup(){
   if(!name) return;
   projectGroups.push(name.trim());
   saveProjectGroups();
-  renderProjectGroups();
+  renderSidebarTabs();
 }
 
 async function openMosaicEditModal(file){
@@ -2067,6 +2067,11 @@ function renderSidebarTabs(){
   const tabs = chatTabs.filter(t => showArchivedTabs || !t.archived);
   if(groupTabsByProject){
     const groups = new Map();
+    // Include user-defined project groups first so they appear even if empty
+    projectGroups.forEach(name => {
+      if(!groups.has(name)) groups.set(name, []);
+    });
+    // Add projects based on existing chat tabs
     tabs.forEach(t => {
       const key = t.project_name || "";
       if(!groups.has(key)) groups.set(key, []);

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -839,7 +839,7 @@ body {
   display: inline-flex;
   background-color: #333;
   border: 1px solid #444;
-  color: #0ff;
+  color: #aaa;
   padding: 4px 6px;
   cursor: move;
   align-items: center;
@@ -849,7 +849,7 @@ body {
   margin: 6px 0 2px;
 }
 #projectGroupsContainer button.drag-over {
-  border-color: #0ff;
+  border-color: #aaa;
 }
 #verticalTabsContainer .project-indented {
   margin-left: 10px;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -841,7 +841,7 @@ body {
   display: inline-flex;
   background-color: #ccc;
   border: 1px solid #aaa;
-  color: #111;
+  color: #666;
   padding: 4px 6px;
   cursor: move;
   align-items: center;
@@ -852,7 +852,7 @@ body {
 }
 
 #projectGroupsContainer button.drag-over {
-  border-color: #111;
+  border-color: #666;
 }
 
 #verticalTabsContainer .project-indented {


### PR DESCRIPTION
## Summary
- ensure project headers render even without chat tabs
- remove unused blue headers
- show project groups with grey styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686d50229b3c8323bdd631f74138b5fb