### PR TITLE
Fix rename UI to assign project on save

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -446,7 +446,6 @@
     <div class="modal-buttons">
       <button id="renameTabSaveBtn">Save</button>
       <button id="renameTabCancelBtn">Cancel</button>
-      <button id="renameAssignProjectBtn">Assign to Project</button>
     </div>
   </div>
 </div>

--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -213,7 +213,6 @@
       <div class="modal-buttons">
         <button id="renameTabSaveBtn">Save</button>
         <button id="renameTabCancelBtn">Cancel</button>
-        <button id="renameAssignProjectBtn">Assign to Project</button>
       </div>
     </div>
   </div>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1849,7 +1849,9 @@ $("#renameTabSaveBtn").addEventListener("click", async () => {
   await setSetting(mosaicKey(tabId), mosaicPanelVisible);
   if(name) await renameTab(tabId, name);
   const tab = chatTabs.find(t => t.id === tabId) || {};
-  const project = tab.project_name || '';
+  const projSel = $("#renameProjectSelect");
+  let project = projSel ? projSel.value : '';
+  project = project.trim();
   const repo = tab.repo_ssh_url || '';
   await fetch('/api/chat/tabs/config', {
     method:'POST',
@@ -1866,25 +1868,6 @@ $("#renameTabCancelBtn").addEventListener("click", () => hideModal($("#renameTab
 $("#renameTabInput").addEventListener("keydown", evt => {
   if(evt.key === "Enter") $("#renameTabSaveBtn").click();
   else if(evt.key === "Escape") $("#renameTabCancelBtn").click();
-});
-$("#renameAssignProjectBtn").addEventListener("click", async () => {
-  const modal = $("#renameTabModal");
-  const tabId = parseInt(modal.dataset.tabId, 10);
-  const projSel = $("#renameProjectSelect");
-  let project = projSel ? projSel.value : "";
-  project = project.trim();
-  const tab = chatTabs.find(t => t.id === tabId) || {};
-  const repo = tab.repo_ssh_url || '';
-  const type = tab.tab_type || 'chat';
-  await fetch('/api/chat/tabs/config', {
-    method:'POST',
-    headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({tabId, project, repo, type, sessionId})
-  });
-  await loadTabs();
-  renderTabs();
-  renderSidebarTabs();
-  renderArchivedSidebarTabs();
 });
 async function duplicateTab(tabId){
   const t = chatTabs.find(t => t.id===tabId);


### PR DESCRIPTION
## Summary
- allow renaming chats to update assigned project
- remove `Assign to Project` button from rename modal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686d544f85d0832381465abebb7442cc