### PR TITLE
Update tab title truncation limit

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -276,7 +276,7 @@ function addCodeCopyButtons(root){
   });
 }
 
-function truncateTabTitle(title, max=20){
+function truncateTabTitle(title, max=40){
   if(!title) return '';
   return title.length > max ? title.slice(0, max - 2) + '..' : title;
 }


### PR DESCRIPTION
## Summary
- allow longer Aurora chat tab titles

## Testing
- `npm run lint` *(fails: no linter configured)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686d5df2c6008323b2571ebccf96ac79