### PR TITLE
Add quick project chat tab button

### DIFF
--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -59,6 +59,7 @@
         <button id="viewTabTasks" class="view-tab" style="position:relative; left: 40px;">☑️ Tasks</button>
         <button id="viewTabArchive" class="view-tab" style="position:relative; left: 40px;">Archive</button>
         <button id="settingsBtn" title="Settings" style="margin-left:auto;background:none;border:none;color:#ddd;font-size:1.2rem;cursor:pointer;">&#9881;</button>
+        <button id="projectNewTabBtn" title="New Chat Tab" style="background:none;border:none;color:#ddd;font-size:1.2rem;cursor:pointer;margin-left:0.5rem;">➕</button>
         <button id="feedbackBtn" title="Send Feedback" style="background:none;border:none;color:#ddd;font-size:1.2rem;cursor:pointer;margin-left:0.5rem;">📝</button>
       </div>
 <!--      <h1>Nexum Chat</h1>-->
@@ -730,11 +731,11 @@
       if(section) section.style.display = newTabSelectedType === 'code' ? '' : 'none';
     }
 
-    async function createStartTab(type){
-      const repoEl = document.getElementById('startRepoInput');
-      const repo = repoEl ? repoEl.value.trim() : '';
-      showPageLoader(startInAurora ? 'cyan' : null);
-      const body = { name:'New Tab', nexum: startInAurora ? 0 : 1, type, project:'', repo, sessionId };
+      async function createStartTab(type){
+        const repoEl = document.getElementById('startRepoInput');
+        const repo = repoEl ? repoEl.value.trim() : '';
+        showPageLoader(startInAurora ? 'cyan' : null);
+        const body = { name:'New Tab', nexum: startInAurora ? 0 : 1, type, project:'', repo, sessionId };
       try{
         const r = await fetch('/api/chat/tabs/new',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
         if(r.ok){
@@ -848,6 +849,21 @@
           askBtn.style.display = isCode ? '' : 'none';
           codeBtn.style.display = isCode && hasRepo ? '' : 'none';
         }
+      }
+
+      async function quickAddProjectTab(){
+        try{
+          const project = await getSetting('sterling_project') || '';
+          const body = { name:'New Tab', nexum:1, type:'chat', project, repo:'', sessionId };
+          const r = await fetch('/api/chat/tabs/new',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+          if(r.ok){
+            const data = await r.json();
+            await loadTabs();
+            currentTabId = data.id;
+            renderTabs();
+            applyTabView();
+          }
+        }catch(e){ console.error(e); }
       }
 
       const taskPanel = document.getElementById('taskListPanel');
@@ -1135,12 +1151,13 @@
       await fetch('/api/settings', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({key:'nexum_theme_mode', value: currentMode})});
     });
 
-    document.getElementById('settingsBtn').addEventListener('click', () => {
-      document.getElementById('settingsModal').style.display = 'flex';
-    });
-    document.getElementById('closeSettingsBtn').addEventListener('click', () => {
-      document.getElementById('settingsModal').style.display = 'none';
-    });
+      document.getElementById('settingsBtn').addEventListener('click', () => {
+        document.getElementById('settingsModal').style.display = 'flex';
+      });
+      document.getElementById('projectNewTabBtn').addEventListener('click', quickAddProjectTab);
+      document.getElementById('closeSettingsBtn').addEventListener('click', () => {
+        document.getElementById('settingsModal').style.display = 'none';
+      });
     document.getElementById('settingsModal').addEventListener('click', e => {
       if(e.target === e.currentTarget) e.currentTarget.style.display = 'none';
     });

--- a/Aurora/public/nexum.css
+++ b/Aurora/public/nexum.css
@@ -259,7 +259,7 @@ button:hover {
   color: #fff;
 }
 
-#settingsBtn,
+#settingsBtn,#projectNewTabBtn,
 #feedbackBtn {
   background: none;
   border: none;

--- a/Aurora/public/nexum_green.css
+++ b/Aurora/public/nexum_green.css
@@ -259,7 +259,7 @@ button:hover {
   color: #fff;
 }
 
-#settingsBtn,
+#settingsBtn,#projectNewTabBtn,
 #feedbackBtn {
   background: none;
   border: none;

--- a/Aurora/public/nexum_green_light.css
+++ b/Aurora/public/nexum_green_light.css
@@ -260,7 +260,7 @@ button:hover {
   color: #fff;
 }
 
-#settingsBtn,
+#settingsBtn,#projectNewTabBtn,
 #feedbackBtn {
   background: none;
   border: none;

--- a/Aurora/public/nexum_lightblue.css
+++ b/Aurora/public/nexum_lightblue.css
@@ -260,7 +260,7 @@ button:hover {
   color: #fff;
 }
 
-#settingsBtn,
+#settingsBtn,#projectNewTabBtn,
 #feedbackBtn {
   background: none;
   border: none;

--- a/Aurora/public/nexum_lightblue_light.css
+++ b/Aurora/public/nexum_lightblue_light.css
@@ -260,7 +260,7 @@ button:hover {
   color: #fff;
 }
 
-#settingsBtn,
+#settingsBtn,#projectNewTabBtn,
 #feedbackBtn {
   background: none;
   border: none;

--- a/Aurora/public/nexum_orange.css
+++ b/Aurora/public/nexum_orange.css
@@ -260,7 +260,7 @@ button:hover {
   color: #fff;
 }
 
-#settingsBtn,
+#settingsBtn,#projectNewTabBtn,
 #feedbackBtn {
   background: none;
   border: none;

--- a/Aurora/public/nexum_orange_light.css
+++ b/Aurora/public/nexum_orange_light.css
@@ -260,7 +260,7 @@ button:hover {
   color: #fff;
 }
 
-#settingsBtn,
+#settingsBtn,#projectNewTabBtn,
 #feedbackBtn {
   background: none;
   border: none;

--- a/Aurora/public/nexum_pink.css
+++ b/Aurora/public/nexum_pink.css
@@ -260,7 +260,7 @@ button:hover {
   color: #fff;
 }
 
-#settingsBtn,
+#settingsBtn,#projectNewTabBtn,
 #feedbackBtn {
   background: none;
   border: none;

--- a/Aurora/public/nexum_pink_light.css
+++ b/Aurora/public/nexum_pink_light.css
@@ -260,7 +260,7 @@ button:hover {
   color: #fff;
 }
 
-#settingsBtn,
+#settingsBtn,#projectNewTabBtn,
 #feedbackBtn {
   background: none;
   border: none;

--- a/Aurora/public/nexum_purple_light.css
+++ b/Aurora/public/nexum_purple_light.css
@@ -260,7 +260,7 @@ button:hover {
   color: #fff;
 }
 
-#settingsBtn,
+#settingsBtn,#projectNewTabBtn,
 #feedbackBtn {
   background: none;
   border: none;

--- a/Aurora/public/nexum_red.css
+++ b/Aurora/public/nexum_red.css
@@ -260,7 +260,7 @@ button:hover {
   color: #fff;
 }
 
-#settingsBtn,
+#settingsBtn,#projectNewTabBtn,
 #feedbackBtn {
   background: none;
   border: none;

--- a/Aurora/public/nexum_red_light.css
+++ b/Aurora/public/nexum_red_light.css
@@ -260,7 +260,7 @@ button:hover {
   color: #fff;
 }
 
-#settingsBtn,
+#settingsBtn,#projectNewTabBtn,
 #feedbackBtn {
   background: none;
   border: none;

--- a/Aurora/public/nexum_teal.css
+++ b/Aurora/public/nexum_teal.css
@@ -260,7 +260,7 @@ button:hover {
   color: #fff;
 }
 
-#settingsBtn,
+#settingsBtn,#projectNewTabBtn,
 #feedbackBtn {
   background: none;
   border: none;

--- a/Aurora/public/nexum_teal_light.css
+++ b/Aurora/public/nexum_teal_light.css
@@ -260,7 +260,7 @@ button:hover {
   color: #fff;
 }
 
-#settingsBtn,
+#settingsBtn,#projectNewTabBtn,
 #feedbackBtn {
   background: none;
   border: none;


### PR DESCRIPTION
## Summary
- add a new `+` button next to the settings icon in Nexum UI
- implement `quickAddProjectTab` to create a chat tab automatically assigned to the current project
- hook up button event
- style the new button across all themes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686d72e5b08c8323aa90d1c11570ab8c