### PR TITLE
Add + button on project headers

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1881,6 +1881,19 @@ async function openProjectSettingsModal(project){
   setTimeout(() => { input.focus(); input.select(); }, 0);
 }
 
+async function quickAddTabToProject(project){
+  const r = await fetch("/api/chat/tabs/new", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "", nexum: 0, project, type: "chat", sessionId })
+  });
+  if(r.ok){
+    const data = await r.json();
+    await loadTabs();
+    await selectTab(data.id);
+  }
+}
+
 $("#renameTabSaveBtn").addEventListener("click", async () => {
   const modal = $("#renameTabModal");
   const tabId = parseInt(modal.dataset.tabId, 10);
@@ -2125,6 +2138,11 @@ function renderSidebarTabs(){
         gear.className = "project-gear-btn config-btn";
         gear.addEventListener("click", e => { e.stopPropagation(); openProjectSettingsModal(project); });
         header.appendChild(gear);
+        const addBtn = document.createElement("button");
+        addBtn.textContent = "\u2795"; // ➕
+        addBtn.className = "project-add-btn config-btn";
+        addBtn.addEventListener("click", e => { e.stopPropagation(); quickAddTabToProject(project); });
+        header.appendChild(addBtn);
       }
       header.addEventListener("click", () => {
         collapsedProjectGroups[project] = !collapsedProjectGroups[project];

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -848,7 +848,23 @@ body {
   align-items: center;
   justify-content: center;
 }
+#verticalTabsContainer .project-add-btn {
+  background: none;
+  border: none;
+  color: var(--text-color);
+  cursor: pointer;
+  margin-left: 4px;
+  transition: color 0.3s;
+  width: 24px;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 #verticalTabsContainer .project-gear-btn:hover {
+  color: var(--accent-light);
+}
+#verticalTabsContainer .project-add-btn:hover {
   color: var(--accent-light);
 }
 

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -850,7 +850,23 @@ body {
   align-items: center;
   justify-content: center;
 }
+#verticalTabsContainer .project-add-btn {
+  background: none;
+  border: none;
+  color: var(--text-color);
+  cursor: pointer;
+  margin-left: 4px;
+  transition: color 0.3s;
+  width: 24px;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 #verticalTabsContainer .project-gear-btn:hover {
+  color: var(--accent-light);
+}
+#verticalTabsContainer .project-add-btn:hover {
   color: var(--accent-light);
 }
 


### PR DESCRIPTION
## Summary
- allow quick creation of chat tabs inside each project group
- style project add button for both themes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686d7dd4b7b48323a48f12422175ccb0