### PR TITLE
Remove GitHub dependency for tasks

### DIFF
--- a/Aurora/.env.example
+++ b/Aurora/.env.example
@@ -1,11 +1,3 @@
-# Personal access token with at least "repo" scope
-GITHUB_TOKEN=ghp_yourTokenHere
-# Repository owner or organisation
-GITHUB_OWNER=yourOrg
-# Repository name
-GITHUB_REPO=yourRepo
-# Optional label to filter issues (defaults to "task")
-# GITHUB_LABEL=task
 
 # OpenAI API key for AI features (optional)
 # OPENAI_API_KEY=sk-xxxxxxxx

--- a/Aurora/README.md
+++ b/Aurora/README.md
@@ -1,6 +1,6 @@
 # TaskQueue
 
-Small Node.js utility that pulls open GitHub issues (labelled `task` by default) into an in-memory queue.
+Small Node.js utility that stores tasks in a local SQLite database.
 
 ## Quick start
 ```bash
@@ -14,10 +14,6 @@ npm start
 
 | Name             | Purpose                                               |
 | ---------------- | ----------------------------------------------------- |
-| `GITHUB_TOKEN`   | Personal access token (classic) with `repo` scope.    |
-| `GITHUB_OWNER`   | Repository owner or organisation.                     |
-| `GITHUB_REPO`    | Repository name.                                      |
-| `GITHUB_LABEL`   | (Optional) Issue label to filter on. If omitted, **all** open issues are returned. |
 | `OPENAI_API_KEY` | OpenAI API key for AI features ([get here](https://platform.openai.com/api-keys)) |
 | `OPENAI_MODEL`   | (Optional) Model ID for completions (default: deepseek/deepseek-chat)  |
 | `STABILITY_API_KEY` | (Optional) API key for the Stability AI upscaler |
@@ -45,15 +41,10 @@ Let's Encrypt. After generation, execute `../setup_ssl_permissions.sh <domain> [
 so the specified user can access the key and certificate without root.
 
 ### Obtaining API Keys
-1. **GitHub Token**:  
-   - Go to **Settings → Developer settings → Personal access tokens → Tokens (classic)**  
-   - Create token with `repo` scope
-
-2. **OpenAI API Key**:  
-   - Visit [OpenAI API Keys](https://platform.openai.com/api-keys)  
+1. **OpenAI API Key**:
+   - Visit [OpenAI API Keys](https://platform.openai.com/api-keys)
    - Create new secret key and paste into `.env`
 
-The script prints matching open issues and the current queue size.
 
 ### Job Queue Node API
 A small helper class is provided for interacting with the printify pipeline queue from other Node.js processes. This allows running another Aurora server instance on a different machine and enqueueing jobs remotely.

--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -662,6 +662,37 @@ export default class TaskDB {
         .all(sprint);
   }
 
+  createTask(title, project = '', sprint = '') {
+    const maxPrio = this.db.prepare('SELECT MAX(priority_number) AS m FROM issues').get().m || 0;
+    const priority_number = maxPrio + 1;
+    const maxNumber = this.db.prepare('SELECT MAX(number) AS m FROM issues').get().m || 0;
+    const number = maxNumber + 1;
+    const created_at = new Date().toISOString();
+    const stmt = this.db.prepare(`
+      INSERT INTO issues (
+        github_id, repository, number, title, html_url,
+        task_id_slug, priority_number, priority, hidden,
+        project, sprint, fib_points, assignee, created_at, closed, status,
+        dependencies, blocking
+      ) VALUES (
+        NULL, 'local', @number, @title, '#',
+        @task_id_slug, @priority_number, 'Medium', 0,
+        @project, @sprint, NULL, NULL, @created_at, 0, 'Not Started',
+        '', ''
+      )
+    `);
+    const { lastInsertRowid } = stmt.run({
+      number,
+      title,
+      task_id_slug: `local#${number}`,
+      priority_number,
+      project,
+      sprint,
+      created_at
+    });
+    return lastInsertRowid;
+  }
+
   setTitle(id, newTitle) {
     this.db.prepare("UPDATE issues SET title = ? WHERE id = ?").run(newTitle, id);
   }


### PR DESCRIPTION
## Summary
- store tasks directly in the local database
- load tasks from the DB on startup instead of GitHub
- create new tasks in the DB
- update README and example env to reflect local storage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686d8421f98483239e6b187a3e25bb43