### PR TITLE
Change project plus button color

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -856,7 +856,7 @@ body {
 #verticalTabsContainer .project-add-btn {
   background: none;
   border: none;
-  color: var(--text-color);
+  color: #fff;
   cursor: pointer;
   margin-left: 4px;
   transition: color 0.3s;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -858,7 +858,7 @@ body {
 #verticalTabsContainer .project-add-btn {
   background: none;
   border: none;
-  color: var(--text-color);
+  color: #fff;
   cursor: pointer;
   margin-left: 4px;
   transition: color 0.3s;


### PR DESCRIPTION
## Summary
- tweak styles so the `+` button for project tabs is white

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686d88e2d0748323b322b957f46a0bd9