### PR TITLE
Enable chat tab reorder with grabber

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -893,6 +893,14 @@ body {
   margin-left: 10px;
 }
 
+#verticalTabsContainer .sidebar-tab-row.drag-over {
+  border: 1px dashed #aaa;
+}
+
+#verticalTabsContainer .sidebar-tab-row .drag-handle {
+  cursor: move;
+}
+
 #verticalTabsContainer button.active {
   background-color: #555;
   border-color: #aaa;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -897,6 +897,14 @@ body {
   margin-left: 10px;
 }
 
+#verticalTabsContainer .sidebar-tab-row.drag-over {
+  border: 1px dashed #666;
+}
+
+#verticalTabsContainer .sidebar-tab-row .drag-handle {
+  cursor: move;
+}
+
 #verticalTabsContainer button.active {
   background-color: #ccc;
   border-color: #aaa;


### PR DESCRIPTION
## Summary
- add drag handle to chat tabs sidebar
- track tab order per project in local storage
- handle drag events to update order
- style grabber and drag-over state for dark and light themes

## Testing
- `npm run lint`
- `node test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_686d900c8aa08323bef237d53989542f