### PR TITLE
Add markdown styling to Aurora chat

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -264,12 +264,31 @@ function escapeHtml(text){
     .replace(/>/g, "&gt;");
 }
 
+// Apply simple markdown styling while preserving the original syntax
+function applyMarkdownSyntax(text){
+  if(!text) return "";
+  let html = escapeHtml(text);
+  // Headings
+  html = html.replace(/^###### (.*)$/gm, '<span class="md-h6">$&</span>');
+  html = html.replace(/^##### (.*)$/gm, '<span class="md-h5">$&</span>');
+  html = html.replace(/^#### (.*)$/gm,  '<span class="md-h4">$&</span>');
+  html = html.replace(/^### (.*)$/gm,   '<span class="md-h3">$&</span>');
+  html = html.replace(/^## (.*)$/gm,    '<span class="md-h2">$&</span>');
+  html = html.replace(/^# (.*)$/gm,     '<span class="md-h1">$&</span>');
+  // Bold and italic
+  html = html.replace(/\*\*([^*]+)\*\*/g, '<span class="md-bold">**$1**</span>');
+  html = html.replace(/\*([^*]+)\*/g, '<span class="md-italic">*$1*</span>');
+  // Inline code
+  html = html.replace(/`([^`]+)`/g, '<span class="md-inline-code">`$1`</span>');
+  return html.replace(/\n/g, "<br>");
+}
+
 function formatCodeBlocks(text){
   if(!text) return "";
   const parts = text.split(/```/);
   return parts.map((part, idx) => {
     if(idx % 2 === 0){
-      return escapeHtml(part).replace(/\n/g, "<br>");
+      return applyMarkdownSyntax(part);
     }
     return `<pre><code>${escapeHtml(part)}</code></pre>`;
   }).join("");

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1379,4 +1379,25 @@ button:disabled {
   color: #fff;
 }
 
+/* Minimal markdown highlighting */
+.md-h1,.md-h2,.md-h3,.md-h4,.md-h5,.md-h6{
+  display:block;
+  font-weight:bold;
+}
+.md-h1{font-size:1.4rem;}
+.md-h2{font-size:1.3rem;}
+.md-h3{font-size:1.2rem;}
+.md-h4{font-size:1.1rem;}
+.md-h5{font-size:1rem;}
+.md-h6{font-size:0.95rem;}
+
+.md-bold{font-weight:bold;}
+.md-italic{font-style:italic;}
+.md-inline-code{
+  font-family:monospace;
+  background:#333;
+  padding:2px 4px;
+  border-radius:4px;
+}
+
 

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -1361,4 +1361,25 @@ button:disabled {
   color: #fff;
 }
 
+/* Minimal markdown highlighting */
+.md-h1,.md-h2,.md-h3,.md-h4,.md-h5,.md-h6{
+  display:block;
+  font-weight:bold;
+}
+.md-h1{font-size:1.4rem;}
+.md-h2{font-size:1.3rem;}
+.md-h3{font-size:1.2rem;}
+.md-h4{font-size:1.1rem;}
+.md-h5{font-size:1rem;}
+.md-h6{font-size:0.95rem;}
+
+.md-bold{font-weight:bold;}
+.md-italic{font-style:italic;}
+.md-inline-code{
+  font-family:monospace;
+  background:#eee;
+  padding:2px 4px;
+  border-radius:4px;
+}
+
 


### PR DESCRIPTION
## Summary
- style markdown headings/bold/italic/code while preserving syntax
- apply markdown formatting inside code block processing
- support dark/light themes

## Testing
- `npm test --silent` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_b_686d9a584c4483239cc4fdbb5dd2274b