### PR TITLE
Fix sidebar toggle on project header tap

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2163,7 +2163,8 @@ function renderSidebarTabs(){
         addBtn.addEventListener("click", e => { e.stopPropagation(); quickAddTabToProject(project); });
         header.appendChild(addBtn);
       }
-      header.addEventListener("click", () => {
+      header.addEventListener("click", e => {
+        e.stopPropagation();
         collapsedProjectGroups[project] = !collapsedProjectGroups[project];
         saveCollapsedProjectGroups();
         renderSidebarTabs();


### PR DESCRIPTION
## Summary
- stop click propagation when toggling project groups in the sidebar

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686d9292b0648323838ad3dce07d60de