### PR TITLE
Add reasoning model selection

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -593,6 +593,11 @@
         </select>
       </label>
     </div>
+    <div style="margin-top:8px;">
+      <label>AI Reasoning Model:
+        <select id="globalAiReasoningModelSelect"></select>
+      </label>
+    </div>
     <div class="modal-buttons">
       <button id="globalAiSettingsSaveBtn">Save</button>
       <button id="globalAiSettingsCancelBtn">Cancel</button>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -5928,14 +5928,18 @@ async function openGlobalAiSettings(){
   try {
     const service = await getSetting("ai_service");
     const searchModel = await getSetting("ai_search_model");
+    const reasoningModel = await getSetting("ai_reasoning_model");
     const resp = await fetch("/api/ai/models");
     if(resp.ok){
       const data = await resp.json();
       const sel = document.getElementById("globalAiModelSelect");
+      const reasoningSel = document.getElementById("globalAiReasoningModelSelect");
       sel.innerHTML = "";
+      reasoningSel.innerHTML = "";
       const favs = (data.models || []).filter(m => m.favorite);
       if(favs.length === 0){
         sel.appendChild(new Option("(no favorites)", ""));
+        reasoningSel.appendChild(new Option("(no favorites)", ""));
       } else {
         const showPrices = accountInfo && accountInfo.id === 1;
         favs.forEach(m => {
@@ -5943,10 +5947,12 @@ async function openGlobalAiSettings(){
               ? `${m.id} (limit ${m.tokenLimit}, in ${m.inputCost}, out ${m.outputCost})`
               : `${m.id} (limit ${m.tokenLimit})`;
           sel.appendChild(new Option(label, m.id));
+          reasoningSel.appendChild(new Option(label, m.id));
         });
       }
       const curModel = await getSetting("ai_model");
       if(curModel) sel.value = curModel;
+      if(reasoningModel) reasoningSel.value = reasoningModel;
     }
     if(searchModel){
       document.getElementById("globalAiSearchModelSelect").value = searchModel;
@@ -5970,11 +5976,13 @@ async function saveGlobalAiSettings(){
   const svc = document.getElementById("globalAiServiceSelect").value;
   const model = document.getElementById("globalAiModelSelect").value;
   const searchModel = document.getElementById("globalAiSearchModelSelect").value;
-  await setSettings({ ai_service: svc, ai_model: model, ai_search_model: searchModel });
+  const reasoningModel = document.getElementById("globalAiReasoningModelSelect").value;
+  await setSettings({ ai_service: svc, ai_model: model, ai_search_model: searchModel, ai_reasoning_model: reasoningModel });
   // keep local cache in sync so toggles use latest values immediately
   settingsCache.ai_service = svc;
   settingsCache.ai_model = model;
   settingsCache.ai_search_model = searchModel;
+  settingsCache.ai_reasoning_model = reasoningModel;
   modelName = model || "unknown";
   document.getElementById("modelHud").textContent = `Model: ${modelName}`;
   hideModal(document.getElementById("globalAiSettingsModal"));

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -113,6 +113,15 @@ if (!currentSearchModel) {
   console.debug("[Server Debug] 'ai_search_model' found =>", currentSearchModel);
 }
 
+console.debug("[Server Debug] Checking or setting default 'ai_reasoning_model' in DB...");
+const currentReasoningModel = db.getSetting("ai_reasoning_model");
+if (!currentReasoningModel) {
+  console.debug("[Server Debug] 'ai_reasoning_model' is missing in DB, setting default to 'openrouter/perplexity/sonar-reasoning'.");
+  db.setSetting("ai_reasoning_model", "openrouter/perplexity/sonar-reasoning");
+} else {
+  console.debug("[Server Debug] 'ai_reasoning_model' found =>", currentReasoningModel);
+}
+
 console.debug("[Server Debug] Checking or setting default 'ai_service' in DB...");
 if (!db.getSetting("ai_service")) {
   db.setSetting("ai_service", "openrouter");
@@ -158,6 +167,11 @@ if (db.getSetting("remove_color_swatches") === undefined) {
 console.debug("[Server Debug] Checking or setting default 'search_enabled' in DB...");
 if (db.getSetting("search_enabled") === undefined) {
   db.setSetting("search_enabled", false);
+}
+
+console.debug("[Server Debug] Checking or setting default 'reasoning_enabled' in DB...");
+if (db.getSetting("reasoning_enabled") === undefined) {
+  db.setSetting("reasoning_enabled", false);
 }
 
 const app = express();


### PR DESCRIPTION
## Summary
- add AI reasoning model dropdown in Global AI Settings
- populate the dropdown with the same model list as the global model
- save the reasoning model to settings and keep client cache in sync
- ensure server sets defaults for `ai_reasoning_model` and `reasoning_enabled`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686d9eb436e48323a7a0a82589d3ce74