### PR TITLE
Add AlfePM AGI prototype page

### DIFF
--- a/Aurora/public/pm_agi.html
+++ b/Aurora/public/pm_agi.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>AlfePM AGI Prototype</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <h1>AlfePM AGI Prototype</h1>
+  <div style="margin-bottom:1rem;">
+    <h3>Agent Instructions</h3>
+    <textarea id="agentInstructions" rows="8" style="width:100%;"></textarea>
+  </div>
+  <div id="chatPanel" class="chat-panel" style="height:60vh;">
+    <div id="chatMessages" style="overflow-y:auto;height:calc(100% - 3rem);"></div>
+    <form id="chatForm" style="margin-top:0.5rem;display:flex;">
+      <input id="chatInput" type="text" placeholder="Type a message..." style="flex:1;">
+      <button type="submit">Send</button>
+    </form>
+  </div>
+  <script src="/session.js"></script>
+  <script src="/pm_agi.js"></script>
+</body>
+</html>

--- a/Aurora/public/pm_agi.js
+++ b/Aurora/public/pm_agi.js
@@ -1,0 +1,30 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const messagesEl = document.getElementById('chatMessages');
+  const inputEl = document.getElementById('chatInput');
+  const formEl = document.getElementById('chatForm');
+  const instrEl = document.getElementById('agentInstructions');
+
+  // Load default instructions if available
+  fetch('/pm_agi_instructions.txt')
+    .then(res => res.ok ? res.text() : '')
+    .then(text => { instrEl.value = text; })
+    .catch(() => { /* ignore */ });
+
+  function addMessage(author, text) {
+    const div = document.createElement('div');
+    div.className = 'chat-sequence';
+    div.textContent = `${author}: ${text}`;
+    messagesEl.appendChild(div);
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+  }
+
+  addMessage('AlfePM AGI', 'What are you working on?');
+
+  formEl.addEventListener('submit', e => {
+    e.preventDefault();
+    const text = inputEl.value.trim();
+    if(!text) return;
+    addMessage('You', text);
+    inputEl.value = '';
+  });
+});

--- a/Aurora/public/pm_agi_instructions.txt
+++ b/Aurora/public/pm_agi_instructions.txt
@@ -1,0 +1,3 @@
+Agent Instructions (AlfePM AGI):
+1. You are a project management assistant.
+2. Ask the user what they are working on and help them plan tasks.

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -3467,6 +3467,11 @@ app.get("/splash", (req, res) => {
   res.sendFile(path.join(__dirname, "../public/splash.html"));
 });
 
+app.get("/pm_agi", (req, res) => {
+  console.debug("[Server Debug] GET /pm_agi => Serving pm_agi.html");
+  res.sendFile(path.join(__dirname, "../public/pm_agi.html"));
+});
+
 app.delete("/api/chat/pair/:id", (req, res) => {
   console.debug("[Server Debug] DELETE /api/chat/pair =>", req.params.id);
   try {


### PR DESCRIPTION
## Summary
- create `pm_agi.html` prototype chat page
- add simple chat logic in `pm_agi.js`
- provide default instructions file
- expose new route `/pm_agi` in server

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_686da0297618832396bc64e8d9500cf3