### PR TITLE
Add task assignment to chat tab settings

### DIFF
--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -155,6 +155,9 @@
           <option value="task">Project</option>
         </select>
       </label>
+      <label style="margin-top:8px;">Assign Task:<br/>
+        <select id="tabTaskSelect" style="width:100%;"><option value="">(loading...)</option></select>
+      </label>
       <label style="margin-top:8px;">Codex Chat URL:<br/>
         <input type="text" id="codexChatUrlInput" style="width:100%;" />
       </label>
@@ -817,6 +820,14 @@
       document.getElementById('tabProjectInput').value = t.project_name || '';
       document.getElementById('tabRepoInput').value = t.repo_ssh_url || '';
       document.getElementById('tabTypeSelect').value = t.tab_type || 'chat';
+      const taskSel = document.getElementById('tabTaskSelect');
+      if(taskSel){
+        taskSel.innerHTML = '<option value="">(none)</option>';
+        fetch('/api/tasks?includeHidden=1').then(r=>r.json()).then(ts=>{
+          taskSel.innerHTML = '<option value="">(none)</option>' + ts.map(tk=>`<option value="${tk.id}">${tk.title}</option>`).join('');
+          taskSel.value = t.task_id || '';
+        }).catch(()=>{taskSel.innerHTML='<option value="">(error)</option>';});
+      }
       const modal = document.getElementById('tabConfigModal');
       modal.dataset.tabId = tabId;
       modal.style.display = 'flex';
@@ -1175,7 +1186,8 @@
       const project = document.getElementById('tabProjectInput').value;
       const repo = document.getElementById('tabRepoInput').value;
       const type = document.getElementById('tabTypeSelect').value;
-      await fetch('/api/chat/tabs/config', {method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({tabId, project, repo, type})});
+      const taskId = document.getElementById('tabTaskSelect')?.value || '';
+      await fetch('/api/chat/tabs/config', {method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({tabId, project, repo, type, taskId})});
       modal.style.display = 'none';
       await loadTabs();
       renderTabs();

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1957,6 +1957,7 @@ app.post("/api/chat/tabs/new", (req, res) => {
     const repo = req.body.repo || '';
     const type = req.body.type || 'chat';
     const sessionId = req.body.sessionId || '';
+    const taskId = req.body.taskId ? parseInt(req.body.taskId, 10) : null;
 
     const autoNaming = db.getSetting("chat_tab_auto_naming");
     const projectName = db.getSetting("sterling_project") || "";
@@ -1964,7 +1965,7 @@ app.post("/api/chat/tabs/new", (req, res) => {
       name = `${projectName}: ${name}`;
     }
 
-    const { id: tabId, uuid } = db.createChatTab(name, nexum, project, repo, type, sessionId);
+    const { id: tabId, uuid } = db.createChatTab(name, nexum, project, repo, type, sessionId, taskId);
     res.json({ success: true, id: tabId, uuid });
     createInitialTabMessage(tabId, type, sessionId).catch(e =>
       console.error('[Server Debug] Initial message error:', e.message));
@@ -2053,7 +2054,8 @@ app.post("/api/chat/tabs/generate_images", (req, res) => {
 app.post("/api/chat/tabs/config", (req, res) => {
   console.debug("[Server Debug] POST /api/chat/tabs/config =>", req.body);
   try {
-    const { tabId, project = '', repo = '', type = 'chat', sessionId = '' } = req.body;
+    const { tabId, project = '', repo = '', type = 'chat', taskId = null, sessionId = '' } = req.body;
+    const taskIdNum = taskId ? parseInt(taskId, 10) : null;
     if (!tabId) {
       return res.status(400).json({ error: "Missing tabId" });
     }
@@ -2061,7 +2063,7 @@ app.post("/api/chat/tabs/config", (req, res) => {
     if (!tab) {
       return res.status(403).json({ error: 'Forbidden' });
     }
-    db.setChatTabConfig(tabId, project, repo, type);
+    db.setChatTabConfig(tabId, project, repo, type, taskIdNum);
     res.json({ success: true });
   } catch (err) {
     console.error("[TaskQueue] POST /api/chat/tabs/config error:", err);


### PR DESCRIPTION
## Summary
- allow selecting a task for a chat tab
- persist the selected task on the backend

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686d6769e4ec8323868b72518c63a9bb