### PR TITLE
Add PM AGI tab type

### DIFF
--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -153,6 +153,7 @@
           <option value="chat">Chat</option>
           <option value="code">Code</option>
           <option value="design">Design</option>
+          <option value="pm_agi">PM AGI</option>
           <option value="task">Project</option>
         </select>
       </label>
@@ -182,6 +183,10 @@
           <button data-type="design" class="start-type-btn">
             <div class="icon">🎨</div>
             <div>Design</div>
+          </button>
+          <button data-type="pm_agi" class="start-type-btn">
+            <div class="icon">🤖</div>
+            <div>PM AGI</div>
           </button>
         </div>
         <label style="margin-top:8px;">Message:<br/>
@@ -251,6 +256,10 @@
           <button data-type="design" class="start-type-btn">
             <div class="icon">🎨</div>
             <div>Design</div>
+          </button>
+          <button data-type="pm_agi" class="start-type-btn">
+            <div class="icon">🤖</div>
+            <div>PM AGI</div>
           </button>
           <button data-type="task" class="start-type-btn disabled" disabled>
             <div class="icon">📋</div>
@@ -1084,7 +1093,7 @@
       if(chatBtn) chatBtn.style.display = '';
       const advanced = enableStartAdvanced;
       const disableTypes = advanced ? [] : ['code','task'];
-      ['code','design','task'].forEach(t => {
+      ['code','design','task','pm_agi'].forEach(t => {
         const disabled = disableTypes.includes(t);
         const btn = document.querySelector(`#startTypeButtons .start-type-btn[data-type="${t}"]`);
         if(btn){

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -164,7 +164,7 @@ const defaultFavicon = "/alfe_favicon_64x64.ico";
 const rotatingFavicon = "/alfe_favicon_64x64.ico";
 let favElement = null;
 
-const tabTypeIcons = { chat: "💬", design: "🎨", task: "📋" };
+const tabTypeIcons = { chat: "💬", design: "🎨", task: "📋", pm_agi: "🤖" };
 let newTabSelectedType = 'chat';
 
 const $  = (sel, ctx=document) => ctx.querySelector(sel);

--- a/Aurora/public/pm_agi.js
+++ b/Aurora/public/pm_agi.js
@@ -60,12 +60,13 @@ document.addEventListener('DOMContentLoaded', () => {
       const r = await fetch(`/api/chat/tabs?sessionId=${encodeURIComponent(sessionId)}`);
       if(r.ok){
         const tabs = await r.json();
-        if(tabs.length>0){
-          currentTabId = tabs[0].id;
+        const found = tabs.find(t => t.tab_type === 'pm_agi');
+        if(found){
+          currentTabId = found.id;
         }
       }
       if(!currentTabId){
-        const body = { name:'PM AGI', nexum:0, type:'chat', project:'', repo:'', sessionId };
+        const body = { name:'PM AGI', nexum:0, type:'pm_agi', project:'', repo:'', sessionId };
         const r2 = await fetch('/api/chat/tabs/new', {
           method:'POST',
           headers:{'Content-Type':'application/json'},

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -552,6 +552,8 @@ async function generateInitialGreeting(type, client = null) {
   let prompt = 'Write a brief friendly greeting as an AI assistant named Alfe. ';
   if (type === 'design') {
     prompt += 'Invite the user to share what they would like to create.';
+  } else if (type === 'pm_agi') {
+    prompt += 'Ask the user what they are working on and help them plan tasks.';
   } else {
     prompt += 'Invite the user to share what they would like to talk about.';
   }
@@ -575,7 +577,9 @@ async function generateInitialGreeting(type, client = null) {
 
   return type === 'design'
     ? 'Hello! I am Alfe, your AI assistant. What would you like to design today?'
-    : 'Hello! I am Alfe, your AI assistant. What would you like to talk about?';
+    : type === 'pm_agi'
+      ? 'What are you working on?'
+      : 'Hello! I am Alfe, your AI assistant. What would you like to talk about?';
 }
 
 async function createInitialTabMessage(tabId, type, sessionId = '') {


### PR DESCRIPTION
## Summary
- add PM AGI tab type option and buttons in the Aurora UI
- include PM AGI icon mapping in main.js
- ensure pm_agi page creates/uses `pm_agi` chat tab
- customize greeting generation for PM AGI tabs

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686dab36ed0c8323be8754fca0b1e2f8