### PR TITLE
Fix project add button color

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2245,7 +2245,7 @@ function renderSidebarTabs(){
         gear.addEventListener("click", e => { e.stopPropagation(); openProjectSettingsModal(project); });
         header.appendChild(gear);
         const addBtn = document.createElement("button");
-        addBtn.textContent = "\u2795"; // ➕
+        addBtn.textContent = "+";
         addBtn.className = "project-add-btn config-btn";
         addBtn.addEventListener("click", e => { e.stopPropagation(); quickAddTabToProject(project); });
         header.appendChild(addBtn);

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -858,6 +858,8 @@ body {
   border: none;
   color: #fff;
   cursor: pointer;
+  font-weight: bold;
+  font-size: 1rem;
   margin-left: 4px;
   transition: color 0.3s;
   width: 24px;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -860,6 +860,8 @@ body {
   border: none;
   color: #fff;
   cursor: pointer;
+  font-weight: bold;
+  font-size: 1rem;
   margin-left: 4px;
   transition: color 0.3s;
   width: 24px;


### PR DESCRIPTION
## Summary
- ensure project header plus icon uses white text
- style project add button consistently

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686db600dad883238e53c06e8babf63a