### PR TITLE
Fix openAI provider logic

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -196,7 +196,10 @@ function getOpenAiClient() {
   const currentModel = db.getSetting("ai_model") || "";
   const { provider } = parseProviderModel(currentModel);
 
-  if (provider === "openrouter") {
+  if (currentModel.startsWith("openai/o3")) {
+    // Ensure OpenAI's o3 model always uses the OpenAI provider
+    service = "openai";
+  } else if (provider === "openrouter") {
     service = "openrouter";
   }
 


### PR DESCRIPTION
## Summary
- ensure o3 model uses OpenAI provider directly

## Testing
- `npm run lint`
- `node test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_686dd84399008323b0d5250db2d1ab64