### PR TITLE
Add tertiary project context support

### DIFF
--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -216,6 +216,9 @@
       <label style="margin-top:8px;">Assign to project:<br/>
         <select id="renameProjectSelect" style="width:100%;"></select>
       </label>
+      <label style="margin-top:8px;">Tertiary projects:<br/>
+        <input type="text" id="renameExtraProjectsInput" style="width:100%;" placeholder="proj2, proj3" />
+      </label>
       <div class="modal-buttons">
         <button id="renameTabSaveBtn">Save</button>
         <button id="renameTabCancelBtn">Cancel</button>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1943,6 +1943,10 @@ async function openRenameTabModal(tabId){
       allProjects.map(p => `<option value="${p}">${p}</option>`).join('');
     projSel.value = t && t.project_name ? t.project_name : '';
   }
+  const extraInp = $("#renameExtraProjectsInput");
+  if(extraInp){
+    extraInp.value = t && t.extra_projects ? t.extra_projects : '';
+  }
   const modal = $("#renameTabModal");
   if(!modal){
     renameTab(tabId);
@@ -2009,11 +2013,13 @@ $("#renameTabSaveBtn").addEventListener("click", async () => {
   const projSel = $("#renameProjectSelect");
   let project = projSel ? projSel.value : '';
   project = project.trim();
+  const extraInp = $("#renameExtraProjectsInput");
+  let extraProjects = extraInp ? extraInp.value.trim() : '';
   const repo = tab.repo_ssh_url || '';
   await fetch('/api/chat/tabs/config', {
     method:'POST',
     headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({tabId, project, repo, type, sessionId})
+    body: JSON.stringify({tabId, project, repo, extraProjects, type, sessionId})
   });
   await loadTabs();
   renderTabs();


### PR DESCRIPTION
## Summary
- support storing additional projects per chat tab
- surface tertiary projects in rename modal
- include extra project context when building chat history
- allow editing extra projects via settings API

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686defa05dec8323920b8a5cae90ebc9