### PR TITLE
Fix search/reasoning mutual toggle

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3778,6 +3778,10 @@ function updateReasoningButton(){
 }
 
 async function toggleSearch(){
+  if(!searchEnabled && reasoningEnabled){
+    showToast("Disable Reasoning mode first");
+    return;
+  }
   searchEnabled = !searchEnabled;
   await setSetting("search_enabled", searchEnabled);
   if(searchEnabled){
@@ -3798,6 +3802,10 @@ async function toggleSearch(){
 }
 
 async function toggleReasoning(){
+  if(!reasoningEnabled && searchEnabled){
+    showToast("Disable Search mode first");
+    return;
+  }
   reasoningEnabled = !reasoningEnabled;
   await setSetting("reasoning_enabled", reasoningEnabled);
   if(reasoningEnabled){


### PR DESCRIPTION
## Summary
- restrict search/reasoning modes to be mutually exclusive

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686ddb5bcee88323a6997a755e1abca4