### PR TITLE
Fix portfolio hidden filter

### DIFF
--- a/Aurora/public/portfolio.html
+++ b/Aurora/public/portfolio.html
@@ -121,7 +121,7 @@
 
     async function loadPortfolio(){
       try {
-        const resp = await fetch('/api/upload/list');
+        const resp = await fetch('/api/upload/list?showHidden=1');
         const data = await resp.json();
         const grid = document.getElementById('grid');
         grid.innerHTML = '';


### PR DESCRIPTION
## Summary
- show hidden portfolio images by requesting them explicitly

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686d9c730548832389486c87fd4ea291