### PR TITLE
Enable mosaic panel in tasks tab

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -102,7 +102,7 @@ let archivedTabs = [];
 let currentTabId = 1;
 let initialTabUuid = null;
 let currentTabType = 'chat';
-const mosaicAllowedType = 'PM AGI';
+const mosaicAllowedTypes = ['PM AGI', 'task'];
 let chatHideMetadata = false;
 let chatTabAutoNaming = false;
 let showSubbubbleToken = false;
@@ -918,7 +918,7 @@ async function toggleSubroutinePanel(){
 }
 
 function canUseMosaic(){
-  return currentTabType === mosaicAllowedType;
+  return mosaicAllowedTypes.includes(currentTabType);
 }
 
 function updateMosaicPanelVisibility(){


### PR DESCRIPTION
## Summary
- allow the Mosaic panel to be toggled when viewing a **Tasks** tab

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686eb1d39fa483238cf90651ee337ea6