### PR TITLE
Include user input in image analysis

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2874,6 +2874,7 @@ chatSendBtnEl.addEventListener("click", async () => {
         try {
           const formData = new FormData();
           formData.append("imageFile", f);
+          if(userMessage) formData.append("userInput", userMessage);
           let uploadResp = await fetch(`/api/chat/image?tabId=${currentTabId}`, {
             method: "POST",
             body: formData

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2343,6 +2343,7 @@ app.post("/api/chat/image", upload.single("imageFile"), async (req, res) => {
       return res.status(400).json({ error: "No image file received." });
     }
 
+    const userInput = req.body?.userInput || "";
     const filePath = path.join(uploadsDir, req.file.filename);
 
     let desc = "";
@@ -2350,18 +2351,18 @@ app.post("/api/chat/image", upload.single("imageFile"), async (req, res) => {
       const openaiClient = getOpenAiClient();
       const imageData = fs.readFileSync(filePath, { encoding: "base64" });
       const visionModel = "gpt-4o";
+      const contentParts = [];
+      if (userInput) {
+        contentParts.push({ type: "text", text: userInput });
+      }
+      contentParts.push({ type: "text", text: "Describe this image in verbose detail." });
+      contentParts.push({ type: "image_url", image_url: { url: `data:image/png;base64,${imageData}` } });
       const completion = await openaiClient.chat.completions.create({
         model: visionModel,
         messages: [
           {
             role: "user",
-            content: [
-              { type: "text", text: "Describe this image in one sentence." },
-              {
-                type: "image_url",
-                image_url: { url: `data:image/png;base64,${imageData}` }
-              }
-            ]
+            content: contentParts
           }
         ],
         max_tokens: 60,
@@ -2378,7 +2379,7 @@ app.post("/api/chat/image", upload.single("imageFile"), async (req, res) => {
 
     db.logActivity(
       "Image upload",
-      JSON.stringify({ file: req.file.filename, desc })
+      JSON.stringify({ file: req.file.filename, desc, userInput })
     );
     res.json({ success: true, desc, filename: req.file.filename });
   } catch (e) {


### PR DESCRIPTION
## Summary
- allow `/api/chat/image` to accept a `userInput` field
- send `userInput` when uploading images from the chat UI so the vision model can use it
- request verbose image descriptions from the vision model

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_686d8e7854bc832393453a96f367fac8