### PR TITLE
Fix tasks sidebar loading

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -81,7 +81,7 @@
       <p><a href="/activity" target="_blank" hidden>Activity timeline</a></p>
       <p><a href="/test_projects" target="_blank" hidden>API test page</a></p>
 
-      LOADING...<span class="loading-spinner"></span>
+      <div id="tasksLoading">LOADING...<span class="loading-spinner"></span></div>
 
       <details id="toolbarCollapsible" open hidden>
         <summary hidden>Toolbar & Filters</summary>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1536,6 +1536,18 @@ async function loadTasks(){
   allTasks = await fetchTasks();
   renderHeader();
   renderBody();
+  showTasksUi();
+}
+
+function showTasksUi(){
+  const container = document.getElementById('sidebarViewTasks');
+  if(container){
+    container.querySelectorAll('[hidden]').forEach(el => {
+      el.hidden = false;
+    });
+  }
+  const loader = document.getElementById('tasksLoading');
+  if(loader) loader.style.display = 'none';
 }
 
 async function populateFilters(){


### PR DESCRIPTION
## Summary
- wrap the tasks loading indicator in a container
- reveal hidden task elements after tasks load

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686eb485635c83238c2fc3585dc7f3dc