### PR TITLE
Stop auto task creation after each chat

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3234,15 +3234,8 @@ chatSendBtnEl.addEventListener("click", async () => {
       botHead.querySelector("span").textContent = formatTimestamp(new Date().toISOString());
     }
 
-    // POST: Code change request creation after user input
-    await fetch("/api/tasks/new", {
-      method:"POST",
-      headers:{"Content-Type":"application/json"},
-      body: JSON.stringify({
-        title: "[Code Change Request] " + userMessage.slice(0,60),
-        body: partialText
-      })
-    });
+    // Code previously auto-created a task for every chat pair.
+    // This behavior has been disabled to avoid cluttering the task list.
 
     await loadChatHistory(currentTabId, true);
     await loadTabs();


### PR DESCRIPTION
## Summary
- disable automatic task creation after sending a chat message

## Testing
- `npm test` *(fails: Missing script and network access)*

------
https://chatgpt.com/codex/tasks/task_b_686ebef7b2b483239ee852134f475d15