### PR TITLE
Add clickable chat link column in tasks

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -80,6 +80,7 @@ let columnsOrder = [
   { key: "status",       label: "Status"     },
   { key: "number",       label: "#"          },
   { key: "title",        label: "Title"      },
+  { key: "chat_sha",    label: "Chat"       },
   { key: "dependencies", label: "Depends On" },
   { key: "project",      label: "Project"    },
   { key: "created",      label: "Created"    },
@@ -1501,6 +1502,11 @@ function renderBody(){
             case "title":
               td.textContent = t.title;
               td.className="title-cell";
+              break;
+            case "chat_sha":
+              if(t.chat_sha){
+                td.innerHTML = `<a href="/chat/${t.chat_sha}" target="_blank">${t.chat_sha}</a>`;
+              }
               break;
             case "dependencies":
               td.textContent = t.dependencies;

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -751,6 +751,10 @@ app.get("/api/tasks", (req, res) => {
       req.query.includeHidden === "true";
     console.debug("[Server Debug] includeHidden =", includeHidden);
     const tasks = db.listTasks(includeHidden);
+    tasks.forEach(t => {
+      const uuid = db.getChatTabUuidByTaskId(t.id);
+      if (uuid) t.chat_sha = uuid;
+    });
     console.debug("[Server Debug] Found tasks =>", tasks.length);
     res.json(tasks);
   } catch (err) {

--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -970,6 +970,13 @@ export default class TaskDB {
     return this.db.prepare("SELECT * FROM chat_tabs WHERE tab_uuid=?").get(uuid);
   }
 
+  getChatTabUuidByTaskId(taskId) {
+    const row = this.db
+        .prepare("SELECT tab_uuid FROM chat_tabs WHERE task_id=?")
+        .get(taskId);
+    return row ? row.tab_uuid : null;
+  }
+
   duplicateChatTab(tabId, name = null) {
     const tab = this.getChatTab(tabId);
     if (!tab) return null;


### PR DESCRIPTION
## Summary
- expose chat UUID on tasks via DB helper and server
- display chat column and link in tasks table

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686ec4cc63cc8323a6254199dbf8b0f7