### PR TITLE
Fix task ID display

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2472,10 +2472,17 @@ function renderSidebarTabRow(container, tab, indented=false){
     toggleArchiveTab(tab.id, !tab.archived);
   });
 
+  const taskIdSpan = document.createElement("span");
+  taskIdSpan.className = "task-id";
+  if (tab.task_id) {
+    taskIdSpan.textContent = `#${tab.task_id}`;
+  }
+
   wrapper.appendChild(info);
   wrapper.appendChild(renameBtn);
   wrapper.appendChild(forkBtn);
   wrapper.appendChild(archBtn);
+  if (tab.task_id) wrapper.appendChild(taskIdSpan);
   wrapper.addEventListener("dragover", tabDragOver);
   wrapper.addEventListener("dragleave", tabDragLeave);
   wrapper.addEventListener("drop", tabDrop);
@@ -2543,9 +2550,16 @@ function addArchivedRow(container, tab){
     renderArchivedSidebarTabs();
   });
 
+  const taskIdSpan = document.createElement("span");
+  taskIdSpan.className = "task-id";
+  if (tab.task_id) {
+    taskIdSpan.textContent = `#${tab.task_id}`;
+  }
+
   wrapper.appendChild(icon);
   wrapper.appendChild(info);
   wrapper.appendChild(unarchBtn);
+  if (tab.task_id) wrapper.appendChild(taskIdSpan);
   container.appendChild(wrapper);
 }
 

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -909,6 +909,14 @@ body {
   color: #fff;
 }
 
+#verticalTabsContainer .task-id,
+#archivedTabsContainer .task-id {
+  margin-left: auto;
+  color: var(--accent-light);
+  font-size: 0.8rem;
+  padding-left: 4px;
+}
+
 /* Secure uploader file table */
 #secureFilesList {
   width: 100%;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -913,6 +913,14 @@ body {
   color: #fff;
 }
 
+#verticalTabsContainer .task-id,
+#archivedTabsContainer .task-id {
+  margin-left: auto;
+  color: var(--accent-light);
+  font-size: 0.8rem;
+  padding-left: 4px;
+}
+
 /* Secure uploader file table */
 #secureFilesList {
   width: 100%;


### PR DESCRIPTION
## Summary
- show task IDs for each sidebar chat tab
- style task ID elements in sidebar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686ed3321ac88323a59553bb2b13f9c8