### PR TITLE
Add tooltip to Markdown links

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -286,6 +286,9 @@ function applyMarkdownSyntax(text){
   html = html.replace(/\*([^*]+)\*/g, '<span class="md-italic">*$1*</span>');
   // Inline code
   html = html.replace(/`([^`]+)`/g, '<span class="md-inline-code">`$1`</span>');
+  // Links
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g,
+      '<a href="$2" target="_blank" title="$2">$1</a>');
   return html.replace(/\n/g, "<br>");
 }
 


### PR DESCRIPTION
## Summary
- render Markdown links as anchors in Aurora chat UI

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686ed5fd2fa08323a2e9ed17092851c7