### PR TITLE
Move Projects button beneath Chats

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -38,9 +38,9 @@
     <nav class="tree-menu" style="display:none;">
       <ul>
         <li><button id="navChatTabsBtn" class="tree-button" hidden>Chats</button></li>
+        <li><button id="navTasksBtn" class="tree-button active">Projects and Tasks</button></li>
         <li><button id="navUploaderBtn" class="tree-button">Images</button></li>
         <li><button id="navArchiveTabsBtn" class="tree-button">Archived</button></li>
-        <li><button id="navTasksBtn" class="tree-button active">Projects and Tasks</button></li>
         <li><button id="navFileTreeBtn" class="tree-button">File Tree</button></li>
         <li><button id="navFileCabinetBtn" class="tree-button">File Cabinet</button></li>
         <li><button id="navAiModelsBtn" class="tree-button" data-url="/ai_models">AI Models</button></li>
@@ -59,9 +59,9 @@
     <!-- Icon-only menu for collapsed sidebar -->
     <nav class="icon-menu" style="display:none;">
       <button id="navChatTabsIcon" class="icon-btn" title="Chats">💬</button>
+      <button id="navTasksIcon" class="icon-btn" title="Projects and Tasks">✅</button>
       <button id="navUploaderIcon" class="icon-btn" title="Images">🖼️</button>
       <button id="navArchiveTabsIcon" class="icon-btn" title="Archived">&#128452;</button>
-      <button id="navTasksIcon" class="icon-btn" title="Projects and Tasks">✅</button>
       <button id="navFileTreeIcon" class="icon-btn" title="File Tree">📁</button>
       <button id="navFileCabinetIcon" class="icon-btn" title="File Cabinet">🗄️</button>
       <button id="navAiModelsIcon" class="icon-btn" title="AI Models">🤖</button>


### PR DESCRIPTION
## Summary
- reorder sidebar buttons so `Projects and Tasks` is directly under `Chats`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686edd9396188323a968a2560ddf35be