### PR TITLE
Add sidebar footer with social links

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -195,6 +195,10 @@
         <tbody></tbody>
       </table>
     </div>
+    <footer class="sidebar-footer">
+      <a href="https://github.com/alfe-ai" target="_blank">GitHub</a> |
+      <a href="https://bsky.app/profile/alfeai.bsky.social" target="_blank">Bluesky</a>
+    </footer>
   </aside>
 
   <div id="divider" class="divider"></div>

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1252,6 +1252,24 @@ body {
   color: #bfbbbb;
 }
 
+/* Footer at the bottom of the sidebar */
+.sidebar-footer {
+  margin-top: 1rem;
+  font-size: 0.8rem;
+  text-align: center;
+  color: #ccc;
+}
+
+.sidebar-footer a {
+  color: #ddd;
+  text-decoration: none;
+  margin: 0 0.25rem;
+}
+
+.sidebar-footer a:hover {
+  text-decoration: underline;
+}
+
 /* Simple toast notification */
 .toast {
   position: fixed;


### PR DESCRIPTION
## Summary
- add GitHub and Bluesky links in a new sidebar footer
- style the sidebar footer

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686ee0b241408323a0e2c41fcddecccd