### PR TITLE
Fix missing design tab suggestions

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -5214,6 +5214,7 @@ async function loadChatHistory(tabId = 1, reset=false) {
         <span class="loading-spinner"></span>
       </div>
       <div id="imageGenerationIndicator" style="display:none; color:#0ff; margin:8px 0;">Generating image<span class="loading-spinner"></span></div>
+      <div id="startSuggestions" style="display:none;"></div>
     `;
     chatHistoryOffset = 0;
     chatHasMore = true;


### PR DESCRIPTION
## Summary
- ensure `startSuggestions` element persists when loading chat history

## Testing
- `npm run lint`
- `node test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_686eec7b99808323b23924b97521c38f