### PR TITLE
Update page title for task linked chats

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -205,7 +205,11 @@ let pendingImageDescs = [];
 function updatePageTitle(){
   const active = chatTabs.find(t => t.id === currentTabId);
   if(active && active.name){
-    document.title = `Alfe - ${active.name}`;
+    if(active.task_id){
+      document.title = `Alfe - #${active.task_id} ${active.name}`;
+    } else {
+      document.title = `Alfe - ${active.name}`;
+    }
   } else {
     document.title = defaultTitle;
   }


### PR DESCRIPTION
## Summary
- update `updatePageTitle` logic so the browser title shows the task number when present

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686eef585cb483238a05a7fba3a156a0