### PR TITLE
Fix codex-mini model endpoint

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -270,7 +270,7 @@ async function callOpenAiModel(client, model, options = {}) {
     const prompt = Array.isArray(messages)
       ? messages.map(m => `${m.role}: ${m.content}`).join("\n")
       : String(messages || "");
-    return client.responses.create({
+    return client.completions.create({
       model,
       prompt,
       max_tokens,


### PR DESCRIPTION
## Summary
- use `client.completions.create` for the `codex-mini-latest` model

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686ef1b405b88323a11560bc739dc26f