### PR TITLE
Fix codex-mini endpoint

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -264,20 +264,10 @@ function countTokens(encoder, text) {
   return encoder.encode(text || "").length;
 }
 
-async function callOpenAiModel(client, model, options = {}) {
-  const { messages = [], max_tokens, temperature, stream } = options;
-  if (model === "codex-mini-latest") {
-    const prompt = Array.isArray(messages)
-      ? messages.map(m => `${m.role}: ${m.content}`).join("\n")
-      : String(messages || "");
-    return client.completions.create({
-      model,
-      prompt,
-      max_tokens,
-      temperature,
-      stream
-    });
-  }
+async function callOpenAiModel(client, model, opts = {}) {
+  const { messages = [], max_tokens, temperature, stream = false } = opts;
+
+  // All chat-style models—including codex-mini-latest—use the chat endpoint
   return client.chat.completions.create({
     model,
     messages,


### PR DESCRIPTION
## Summary
- remove special handling for `codex-mini-latest`
- always use `chat.completions` for all OpenAI requests

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686ef8ce611c83239c674378e9e0d9a3