### PR TITLE
Enable text file uploads

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -304,9 +304,9 @@
       <div id="waitingCounter"></div>
       <div id="chatQueueContainer" class="chat-queue-container"></div>
       <div class="chat-input-container">
-        <!-- Hidden file input for image uploading -->
-        <input type="file" id="imageUploadInput" accept="image/*" style="display:none" multiple />
-        <button id="chatImageBtn" class="send-btn" title="Upload Image" style="display:none;">🖼</button>
+        <!-- Hidden file input for uploading images or text files -->
+        <input type="file" id="fileUploadInput" accept="image/*,.txt" style="display:none" multiple />
+        <button id="chatFileBtn" class="send-btn" title="Upload File" style="display:none;">🖼</button>
         <button id="searchToggleBtn" class="send-btn search-toggle-btn" title="Toggle Search">🔍</button>
         <button id="reasoningToggleBtn" class="send-btn reasoning-toggle-btn" title="Toggle Reasoning">🧠</button>
 
@@ -320,8 +320,8 @@
         </button>
         <button id="chatGenImageBtn" class="send-btn" title="" hidden></button>
       </div>
-      <div id="imagePreviewArea" style="margin:8px 0;"></div>
-      <div id="imageProcessingIndicator" style="display:none; color:#f0f; margin:8px 0;">Processing image, please wait...</div>
+      <div id="filePreviewArea" style="margin:8px 0;"></div>
+      <div id="fileProcessingIndicator" style="display:none; color:#f0f; margin:8px 0;">Processing file, please wait...</div>
     </div>
   </main>
 </div>

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2444,10 +2444,10 @@ app.post("/api/ebay/bulkUpdate", (req, res) => {
   }
 });
 
-app.post("/api/chat/image", upload.single("imageFile"), async (req, res) => {
+app.post("/api/chat/file", upload.single("file"), async (req, res) => {
   try {
     if (!req.file) {
-      return res.status(400).json({ error: "No image file received." });
+      return res.status(400).json({ error: "No file received." });
     }
 
     const userInput = req.body?.userInput || "";
@@ -2455,42 +2455,46 @@ app.post("/api/chat/image", upload.single("imageFile"), async (req, res) => {
 
     let desc = "";
     try {
-      const openaiClient = getOpenAiClient();
-      const imageData = fs.readFileSync(filePath, { encoding: "base64" });
-      const visionModel = "gpt-4o";
-      const contentParts = [];
-      if (userInput) {
-        contentParts.push({ type: "text", text: userInput });
+      if (req.file.mimetype.startsWith("image/")) {
+        const openaiClient = getOpenAiClient();
+        const imageData = fs.readFileSync(filePath, { encoding: "base64" });
+        const visionModel = "gpt-4o";
+        const contentParts = [];
+        if (userInput) {
+          contentParts.push({ type: "text", text: userInput });
+        }
+        contentParts.push({ type: "text", text: "Describe this image in verbose detail." });
+        contentParts.push({ type: "image_url", image_url: { url: `data:image/png;base64,${imageData}` } });
+        const completion = await openaiClient.chat.completions.create({
+          model: visionModel,
+          messages: [
+            {
+              role: "user",
+              content: contentParts
+            }
+          ],
+          max_tokens: 60,
+          temperature: 0.3
+        });
+        desc = completion.choices?.[0]?.message?.content?.trim();
+      } else if (req.file.mimetype === "text/plain") {
+        desc = fs.readFileSync(filePath, "utf8").slice(0, 500);
       }
-      contentParts.push({ type: "text", text: "Describe this image in verbose detail." });
-      contentParts.push({ type: "image_url", image_url: { url: `data:image/png;base64,${imageData}` } });
-      const completion = await openaiClient.chat.completions.create({
-        model: visionModel,
-        messages: [
-          {
-            role: "user",
-            content: contentParts
-          }
-        ],
-        max_tokens: 60,
-        temperature: 0.3
-      });
-      desc = completion.choices?.[0]?.message?.content?.trim();
       if (!desc) {
         desc = "(Could not generate description.)";
       }
     } catch (e) {
-      console.error("[Server Debug] Error calling OpenAI vision API =>", e);
+      console.error("[Server Debug] Error processing uploaded file =>", e);
       desc = "(Could not generate description.)";
     }
 
     db.logActivity(
-      "Image upload",
+      "File upload",
       JSON.stringify({ file: req.file.filename, desc, userInput })
     );
     res.json({ success: true, desc, filename: req.file.filename });
   } catch (e) {
-    console.error("Error in /api/chat/image:", e);
+    console.error("Error in /api/chat/file:", e);
     res.status(500).json({ error: "Internal server error" });
   }
 });


### PR DESCRIPTION
## Summary
- add text upload support in chat UI
- rename upload UI elements from image to file
- handle generic uploads in the server

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686ef3a8a0cc83239d847508997ad324