### PR TITLE
Update tagline order

### DIFF
--- a/Aurora/public/about.html
+++ b/Aurora/public/about.html
@@ -10,7 +10,7 @@
 </head>
 <body style="padding:1rem;">
   <h2>About Alfe AI</h2>
-  <p>Alfe AI is an open source platform that combines AI-assisted image design, software development, and task management.</p>
+  <p>Alfe AI is an open source platform that combines AI-assisted project management, image design, and software development.</p>
   <p>All source code is available on <a href="https://github.com/alfe-ai/alfe-ai-Aurelix" target="_blank">GitHub</a> for self-hosting or customization. Alfe AI has a privacy-first philosophy, and your data is only used for purposes required by the application. Data is not sold or used for advertising.</p>
   <p>Alfe AI is Developed by <a href="https://lochner.tech" target="_blank">Lochner Tech</a>.</p>
   <p>Alfe AI powers <a href="https://confused.art" target="_blank">confused.art</a>.</p>

--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Alfe - AI Image Design and Software Development Platform</title>
+  <title>Alfe - AI Project Management, Image Design, and Software Development Platform</title>
   <link id="themeStylesheet" rel="stylesheet" href="/styles.css" />
   <link
           id="favicon"

--- a/Aurora/public/changelog.html
+++ b/Aurora/public/changelog.html
@@ -10,7 +10,7 @@
 
   <h3>Alfe AI / 2.30 Beta</h3>
 
-  <h4>Alfe AI: Software Development and Image Design Platform</h4>
+  <h4>Alfe AI: Project Management, Image Design, and Software Development Platform</h4>
 
   <p>The first version of the <a href="https://alfe.sh">Alfe AI Cloud Platform</a> has been released (beta-2.30).</p>
 

--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -242,7 +242,7 @@
     <a href="/about.html" target="_blank" style="position:absolute; top:8px; left:8px; font-size:0.8rem; color:var(--text-color);">About</a>
     <div id="splashAnim">
       <div id="splashTitle">Alfe AI</div>
-      <div id="splashYour">AI Software Development, Image Design, and Project Management</div>
+        <div id="splashYour">AI Project Management, Image Design, and Software Development</div>
     </div>
     <div class="modal-content">
       <h3>Get Started</h3>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1,6 +1,6 @@
 // sessionId is defined in session.js and available globally
 // sessionId is provided globally by session.js
-const defaultTitle = "Alfe - AI Image Design and Software Development Platform";
+const defaultTitle = "Alfe - AI Project Management, Image Design, and Software Development Platform";
 // Disable automatic scrolling of the chat by default. Manual scrolling
 // (e.g. via the scroll down button) can still force scrolling.
 let chatAutoScroll = false;

--- a/Aurora/public/splash.html
+++ b/Aurora/public/splash.html
@@ -44,6 +44,6 @@
 <body>
   <a href="/about.html" style="position:absolute; top:8px; left:8px; font-size:0.8rem; color:#fff;">About</a>
   <div id="title">Alfe AI</div>
-  <div id="your">AI Software Development, Image Design, and Project Management</div>
+  <div id="your">AI Project Management, Image Design, and Software Development</div>
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Alfe AI / 2.30 Beta  
 
-### Alfe AI: Software Development and Image Design Platform  
+### Alfe AI: Project Management, Image Design, and Software Development Platform
 
 The first version of the Alfe AI Cloud Platform https://alfe.sh <!-- has been released --> (beta-2.30).
 This initial cloud release includes the image design component of the Alfe AI Platform.


### PR DESCRIPTION
## Summary
- reorder tagline to emphasize project management before images and software

## Testing
- `node codex_cli_test.js --help` *(fails: Set OPENAI_API_KEY env var)*

------
https://chatgpt.com/codex/tasks/task_b_686fc52a45fc8323a5c3548f64ef6e0b