### PR TITLE
Fix session cookie domain for dev.alfe.sh

### DIFF
--- a/Aurora/public/session.js
+++ b/Aurora/public/session.js
@@ -4,7 +4,11 @@ function getCookie(name){
 }
 function setCookie(name, value, days=365){
   const expires = new Date(Date.now() + days*864e5).toUTCString();
-  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
+  let cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
+  if(location.hostname.endsWith('.alfe.sh')){
+    cookie += '; domain=.alfe.sh';
+  }
+  document.cookie = cookie;
 }
 function generateUUID(){
   if(window.crypto && typeof window.crypto.randomUUID === 'function'){


### PR DESCRIPTION
## Summary
- allow cross-subdomain sharing of `sessionId` cookie

## Testing
- `npm run lint --prefix Aurora`

------
https://chatgpt.com/codex/tasks/task_b_687163fd5d148323bd73ed6316820fc2