### PR TITLE
Add cyan styling for markdown links

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -365,7 +365,7 @@ function applyMarkdownSyntax(text){
   html = html.replace(/`([^`]+)`/g, '<span class="md-inline-code">`$1`</span>');
   // Links
   html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g,
-      '<a href="$2" target="_blank" title="$2">$1</a>');
+      '<a class="md-link" href="$2" target="_blank" title="$2">$1</a>');
   return html.replace(/\n/g, "<br>");
 }
 

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1476,4 +1476,9 @@ button:disabled {
   border-radius:4px;
 }
 
+/* Links generated from applyMarkdownSyntax */
+.md-link {
+  color: lightblue;
+}
+
 

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -1440,4 +1440,9 @@ button:disabled {
   border-radius:4px;
 }
 
+/* Links generated from applyMarkdownSyntax */
+.md-link {
+  color: lightblue;
+}
+
 


### PR DESCRIPTION
## Summary
- make markdown link styling use a new `.md-link` class
- color `.md-link` anchors light blue in both dark and light themes

## Testing
- (no tests specified)


------
https://chatgpt.com/codex/tasks/task_b_68740bf5a624832383a004e43d2d038a