### PR TITLE
Add SKU import functionality

### DIFF
--- a/Aurora/public/get_skus.html
+++ b/Aurora/public/get_skus.html
@@ -19,12 +19,21 @@
       <button type="button" id="saveBtn">Save</button>
     </div>
   </form>
+  <div style="margin-top:1rem;max-width:600px;">
+    <h3>Import SKUs from Amazon page</h3>
+    <textarea id="importText" rows="10" style="width:100%;"></textarea>
+    <div style="margin-top:0.5rem;">
+      <button type="button" id="importBtn">Import</button>
+    </div>
+  </div>
   <pre id="output" style="margin-top:1rem;background:#000;color:#0f0;padding:0.5rem;height:200px;overflow:auto;"></pre>
   <script src="/session.js"></script>
   <script>
-    const form = document.getElementById('skuForm');
-    const out = document.getElementById('output');
-    const saveBtn = document.getElementById('saveBtn');
+  const form = document.getElementById('skuForm');
+  const out = document.getElementById('output');
+  const saveBtn = document.getElementById('saveBtn');
+  const importBtn = document.getElementById('importBtn');
+  const importText = document.getElementById('importText');
 
     async function loadSettings(){
       try {
@@ -62,9 +71,9 @@
       }
     });
 
-    form.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      out.textContent = 'Loading...';
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    out.textContent = 'Loading...';
       const sellerId = document.getElementById('sellerId').value;
       const marketplaceId = document.getElementById('marketplaceId').value;
       try {
@@ -72,9 +81,29 @@
         const data = await resp.json();
         out.textContent = JSON.stringify(data, null, 2);
       } catch(err){
-        out.textContent = 'Error: ' + err.message;
-      }
-    });
+      out.textContent = 'Error: ' + err.message;
+    }
+  });
+
+  importBtn.addEventListener('click', async () => {
+    const text = importText.value.trim();
+    if(!text){
+      out.textContent = 'Nothing to import';
+      return;
+    }
+    out.textContent = 'Importing...';
+    try {
+      const resp = await fetch('/api/local_skus/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text })
+      });
+      const data = await resp.json();
+      out.textContent = JSON.stringify(data, null, 2);
+    } catch(err){
+      out.textContent = 'Import failed: ' + err.message;
+    }
+  });
 
     loadSettings();
   </script>


### PR DESCRIPTION
## Summary
- add section on the Get SKUs page for importing page text from Amazon
- import SKUs via new `/api/local_skus/import` endpoint
- store imported SKUs in new `amazon_skus` table

## Testing
- `npm test --silent`
- `node --check src/server.js`
- `node --check src/taskDb.js`


------
https://chatgpt.com/codex/tasks/task_b_6877e471b2e883239b92556369e974d6