### PR TITLE
Add SQL passthrough server

### DIFF
--- a/Aurora/.env.example
+++ b/Aurora/.env.example
@@ -49,3 +49,9 @@
 
 # Optional IP address allowed to access the web UI. Requests from localhost are always allowed
 # WHITELIST_IP=1.2.3.4
+
+# Port for the SQL passthrough server
+# SQL_SERVER_PORT=7000
+
+# Path to the SQLite database
+# SQLITE_DB_PATH=issues.sqlite

--- a/Aurora/package.json
+++ b/Aurora/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "node src/index.js",
     "web": "node src/server.js",
-    "lint": "echo \"(no linter configured)\""
+    "lint": "echo \"(no linter configured)\"",
+    "sqlserver": "node src/sqlServer.js"
   },
   "author": "Alfe AI",
   "license": "MIT",

--- a/Aurora/src/sqlServer.js
+++ b/Aurora/src/sqlServer.js
@@ -1,0 +1,35 @@
+import dotenv from "dotenv";
+import express from "express";
+import Database from "better-sqlite3";
+
+dotenv.config();
+
+const port = process.env.SQL_SERVER_PORT || 7000;
+const dbPath = process.env.SQLITE_DB_PATH || "issues.sqlite";
+
+const db = new Database(dbPath);
+const app = express();
+app.use(express.json());
+
+app.post("/sql", (req, res) => {
+  const { sql, params } = req.body || {};
+  if (!sql) {
+    return res.status(400).json({ error: "sql is required" });
+  }
+  try {
+    const stmt = db.prepare(sql);
+    if (stmt.reader) {
+      const rows = stmt.all(params || []);
+      res.json({ rows });
+    } else {
+      const info = stmt.run(params || []);
+      res.json({ changes: info.changes, lastInsertRowid: info.lastInsertRowid });
+    }
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`SQL passthrough server listening on port ${port}`);
+});

--- a/README.md
+++ b/README.md
@@ -56,3 +56,16 @@ sudo ./forward_port_443.sh 3000
 Replace `3000` with your chosen `AURORA_PORT`. After adding the rule, start the
 server normally and clients can connect using `https://your-domain/` on port
 `443` while the Node.js process continues to run on the higher port.
+
+### Passthrough SQL server
+
+Set `SQL_SERVER_PORT` in `.env` (see `Aurora/.env.example`) to configure the port
+for a simple HTTP interface to the SQLite database. Start the server with:
+
+```bash
+npm run sqlserver --prefix Aurora
+```
+
+Send POST requests to `/sql` with a JSON body containing a `sql` string and
+optional `params` array. Select queries return rows while other statements
+return change information.


### PR DESCRIPTION
## Summary
- expose a simple SQLite passthrough service
- allow configuring the port via `.env`
- document usage in README

## Testing
- `node Aurora/src/sqlServer.js` *(fails: Cannot find package 'dotenv' because dependencies are not installed)*
- `npm install` *(fails: internet is disabled)*


------
https://chatgpt.com/codex/tasks/task_b_6877fad3ecbc832399bdc61323258ea8