### PR TITLE
Switch default model to env var

### DIFF
--- a/Aurora/.env.example
+++ b/Aurora/.env.example
@@ -3,7 +3,7 @@
 # OPENAI_API_KEY=sk-xxxxxxxx
 
 # Optional default AI model (overrides DB)
-# OPENAI_MODEL=deepseek/deepseek-chat
+# AI_MODEL=deepseek/deepseek-chat
 
 # Stability AI API key for the upscale script (optional)
 # STABILITY_API_KEY=sk-xxxxxxxx

--- a/Aurora/.env.example
+++ b/Aurora/.env.example
@@ -2,7 +2,7 @@
 # OpenAI API key for AI features (optional)
 # OPENAI_API_KEY=sk-xxxxxxxx
 
-# Optional model ID for completions
+# Optional default AI model (overrides DB)
 # OPENAI_MODEL=deepseek/deepseek-chat
 
 # Stability AI API key for the upscale script (optional)

--- a/Aurora/README.md
+++ b/Aurora/README.md
@@ -15,7 +15,7 @@ npm start
 | Name             | Purpose                                               |
 | ---------------- | ----------------------------------------------------- |
 | `OPENAI_API_KEY` | OpenAI API key for AI features ([get here](https://platform.openai.com/api-keys)) |
-| `OPENAI_MODEL`   | (Optional) Default global AI model (overrides DB, default: deepseek/deepseek-chat) |
+| `AI_MODEL`   | (Optional) Default global AI model (overrides DB, default: deepseek/deepseek-chat) |
 | `STABILITY_API_KEY` | (Optional) API key for the Stability AI upscaler |
 | `PRINTIFY_SCRIPT_PATH` | (Optional) Path to the Printify submission script. Defaults to the included run.sh |
 | `PRINTIFY_PRICE_SCRIPT_PATH` | (Optional) Path to the Printify price update script. Defaults to `/home/admin/Puppets/PrintifyPricePuppet/run.sh` |

--- a/Aurora/README.md
+++ b/Aurora/README.md
@@ -15,7 +15,7 @@ npm start
 | Name             | Purpose                                               |
 | ---------------- | ----------------------------------------------------- |
 | `OPENAI_API_KEY` | OpenAI API key for AI features ([get here](https://platform.openai.com/api-keys)) |
-| `OPENAI_MODEL`   | (Optional) Model ID for completions (default: deepseek/deepseek-chat)  |
+| `OPENAI_MODEL`   | (Optional) Default global AI model (overrides DB, default: deepseek/deepseek-chat) |
 | `STABILITY_API_KEY` | (Optional) API key for the Stability AI upscaler |
 | `PRINTIFY_SCRIPT_PATH` | (Optional) Path to the Printify submission script. Defaults to the included run.sh |
 | `PRINTIFY_PRICE_SCRIPT_PATH` | (Optional) Path to the Printify price update script. Defaults to `/home/admin/Puppets/PrintifyPricePuppet/run.sh` |

--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -598,7 +598,7 @@
     </div>
     <div style="margin-top:8px;">
       <label>AI Model:
-        <select id="globalAiModelSelect" disabled title="Set via OPENAI_MODEL env var"></select>
+        <select id="globalAiModelSelect" disabled title="Set via AI_MODEL env var"></select>
       </label>
     </div>
     <div style="margin-top:8px;">

--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -598,7 +598,7 @@
     </div>
     <div style="margin-top:8px;">
       <label>AI Model:
-        <select id="globalAiModelSelect"></select>
+        <select id="globalAiModelSelect" disabled title="Set via OPENAI_MODEL env var"></select>
       </label>
     </div>
     <div style="margin-top:8px;">

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -6346,7 +6346,6 @@ async function openGlobalAiSettings(){
       if(imageSel) imageSel.innerHTML = "";
       const favs = (data.models || []).filter(m => m.favorite);
       if(favs.length === 0){
-        sel.appendChild(new Option("(no favorites)", ""));
         reasoningSel.appendChild(new Option("(no favorites)", ""));
         if(visionSel) visionSel.appendChild(new Option("(no favorites)", ""));
         if(imageSel){
@@ -6358,7 +6357,6 @@ async function openGlobalAiSettings(){
           const label = showPrices
               ? `${m.id} (limit ${m.tokenLimit}, in ${m.inputCost}, out ${m.outputCost})`
               : `${m.id} (limit ${m.tokenLimit})`;
-          sel.appendChild(new Option(label, m.id));
           reasoningSel.appendChild(new Option(label, m.id));
           if(visionSel) visionSel.appendChild(new Option(label, m.id));
         });
@@ -6367,7 +6365,13 @@ async function openGlobalAiSettings(){
         }
       }
       const curModel = await getSetting("ai_model");
-      if(curModel) sel.value = curModel;
+      if(curModel){
+        sel.appendChild(new Option(curModel, curModel));
+        sel.value = curModel;
+      } else {
+        sel.appendChild(new Option("(env controlled)", ""));
+      }
+      sel.disabled = true;
       if(reasoningModel) reasoningSel.value = reasoningModel;
       if(visionModel && visionSel) visionSel.value = visionModel;
       if(imageModel && imageSel) imageSel.value = imageModel;
@@ -6400,21 +6404,18 @@ async function openGlobalAiSettings(){
 
 async function saveGlobalAiSettings(){
   const svc = document.getElementById("globalAiServiceSelect").value;
-  const model = document.getElementById("globalAiModelSelect").value;
   const searchModel = document.getElementById("globalAiSearchModelSelect").value;
   const reasoningModel = document.getElementById("globalAiReasoningModelSelect").value;
   const visionModel = document.getElementById("globalAiVisionModelSelect").value;
   const imageModel = document.getElementById("globalImageModelSelect").value;
-  await setSettings({ ai_service: svc, ai_model: model, ai_search_model: searchModel, ai_reasoning_model: reasoningModel, ai_vision_model: visionModel, image_gen_model: imageModel });
+  await setSettings({ ai_service: svc, ai_search_model: searchModel, ai_reasoning_model: reasoningModel, ai_vision_model: visionModel, image_gen_model: imageModel });
   // keep local cache in sync so toggles use latest values immediately
   settingsCache.ai_service = svc;
-  settingsCache.ai_model = model;
   settingsCache.ai_search_model = searchModel;
   settingsCache.ai_reasoning_model = reasoningModel;
   settingsCache.ai_vision_model = visionModel;
   settingsCache.image_gen_model = imageModel;
   imageGenModel = imageModel;
-  modelName = model || "unknown";
   updateModelHud();
   hideModal(document.getElementById("globalAiSettingsModal"));
 }

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -96,10 +96,10 @@ import { extractProductUrl, extractPrintifyUrl, extractUpdatedTitle } from "./pr
 
 const db = new TaskDB();
 console.debug("[Server Debug] Checking or setting default 'ai_model' in DB...");
-const envModel = process.env.OPENAI_MODEL;
+const envModel = process.env.AI_MODEL;
 let currentModel = db.getSetting("ai_model");
 if (envModel) {
-  console.debug(`[Server Debug] OPENAI_MODEL env var detected => ${envModel}`);
+  console.debug(`[Server Debug] AI_MODEL env var detected => ${envModel}`);
   if (currentModel !== envModel) {
     db.setSetting("ai_model", envModel);
     currentModel = envModel;
@@ -1119,8 +1119,8 @@ app.post("/api/settings", (req, res) => {
   console.debug("[Server Debug] POST /api/settings => body:", req.body);
   try {
     const { key, value } = req.body;
-    if (key === "ai_model" && process.env.OPENAI_MODEL) {
-      console.debug("[Server Debug] Ignoring ai_model update because OPENAI_MODEL env var is set.");
+    if (key === "ai_model" && process.env.AI_MODEL) {
+      console.debug("[Server Debug] Ignoring ai_model update because AI_MODEL env var is set.");
     } else {
       db.setSetting(key, value);
     }
@@ -1140,8 +1140,8 @@ app.post("/api/settings/batch", (req, res) => {
     }
     settings.forEach(({ key, value }) => {
       if (typeof key !== "undefined") {
-        if (key === "ai_model" && process.env.OPENAI_MODEL) {
-          console.debug("[Server Debug] Ignoring ai_model update in batch because OPENAI_MODEL env var is set.");
+        if (key === "ai_model" && process.env.AI_MODEL) {
+          console.debug("[Server Debug] Ignoring ai_model update in batch because AI_MODEL env var is set.");
         } else {
           db.setSetting(key, value);
         }

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -96,10 +96,18 @@ import { extractProductUrl, extractPrintifyUrl, extractUpdatedTitle } from "./pr
 
 const db = new TaskDB();
 console.debug("[Server Debug] Checking or setting default 'ai_model' in DB...");
-const currentModel = db.getSetting("ai_model");
-if (!currentModel) {
+const envModel = process.env.OPENAI_MODEL;
+let currentModel = db.getSetting("ai_model");
+if (envModel) {
+  console.debug(`[Server Debug] OPENAI_MODEL env var detected => ${envModel}`);
+  if (currentModel !== envModel) {
+    db.setSetting("ai_model", envModel);
+    currentModel = envModel;
+  }
+} else if (!currentModel) {
   console.debug("[Server Debug] 'ai_model' is missing in DB, setting default to 'deepseek/deepseek-chat'.");
   db.setSetting("ai_model", "deepseek/deepseek-chat");
+  currentModel = "deepseek/deepseek-chat";
 } else {
   console.debug("[Server Debug] 'ai_model' found =>", currentModel);
 }
@@ -1111,7 +1119,11 @@ app.post("/api/settings", (req, res) => {
   console.debug("[Server Debug] POST /api/settings => body:", req.body);
   try {
     const { key, value } = req.body;
-    db.setSetting(key, value);
+    if (key === "ai_model" && process.env.OPENAI_MODEL) {
+      console.debug("[Server Debug] Ignoring ai_model update because OPENAI_MODEL env var is set.");
+    } else {
+      db.setSetting(key, value);
+    }
     res.json({ success: true });
   } catch (err) {
     console.error("[TaskQueue] POST /api/settings failed:", err);
@@ -1128,7 +1140,11 @@ app.post("/api/settings/batch", (req, res) => {
     }
     settings.forEach(({ key, value }) => {
       if (typeof key !== "undefined") {
-        db.setSetting(key, value);
+        if (key === "ai_model" && process.env.OPENAI_MODEL) {
+          console.debug("[Server Debug] Ignoring ai_model update in batch because OPENAI_MODEL env var is set.");
+        } else {
+          db.setSetting(key, value);
+        }
       }
     });
     res.json({ success: true });


### PR DESCRIPTION
## Summary
- disable UI editing of global AI model
- read `OPENAI_MODEL` env var at startup and ignore POST updates when set
- document `OPENAI_MODEL` usage

## Testing
- `npm run lint --prefix Aurora`

------
https://chatgpt.com/codex/tasks/task_b_68784628f33c8323876107d8a94cb54b