### PR TITLE
Add /search route

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -259,6 +259,9 @@ function getTabUuidFromLocation(){
 }
 
 initialTabUuid = getTabUuidFromLocation();
+const urlParamsInit = new URLSearchParams(window.location.search);
+const initialSearchQuery = urlParamsInit.get('q') || '';
+const initialSearchMode = urlParamsInit.has('search');
 
 /* Introduce an image buffer and preview, plus an array to hold their descriptions. */
 let pendingImages = [];
@@ -4184,6 +4187,23 @@ async function toggleCodexMini(){
   updateReasoningButton();
 }
 
+async function enableSearchMode(query=""){
+  if(!searchEnabled){
+    searchEnabled = true;
+    previousModelName = modelName;
+    const searchModel = await getSetting("ai_search_model") || "openrouter/perplexity/sonar";
+    modelName = searchModel;
+    updateModelHud();
+    updateSearchButton();
+    updateReasoningButton();
+    updateCodexButton();
+  }
+  if(query){
+    chatInputEl.value = query;
+    chatSendBtnEl.click();
+  }
+}
+
 (function installDividerDrag(){
   const divider = $("#divider");
   let isDragging = false;
@@ -5380,6 +5400,10 @@ thinPrintifyIcon?.addEventListener("touchstart", ev => {
     }
   } catch(e) {
     console.error("Error loading markdown content:", e);
+  }
+
+  if(initialSearchMode){
+    await enableSearchMode(initialSearchQuery);
   }
 })();
 

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -3577,6 +3577,31 @@ app.get("/", (req, res) => {
   res.sendFile(path.join(__dirname, "../public/aurora.html"));
 });
 
+app.get("/search", (req, res) => {
+  try {
+    const q = String(req.query.q || "");
+    const sessionId = getSessionIdFromRequest(req);
+    const { id: tabId, uuid } = db.createChatTab(
+      "Search",
+      0,
+      "",
+      "",
+      "",
+      0,
+      "chat",
+      sessionId
+    );
+    const searchModel =
+      db.getSetting("ai_search_model") || "openrouter/perplexity/sonar";
+    db.setChatTabModel(tabId, searchModel);
+    const query = q ? `?search=1&q=${encodeURIComponent(q)}` : "?search=1";
+    return res.redirect(`/chat/${uuid}${query}`);
+  } catch (err) {
+    console.error("[Server Debug] GET /search error:", err);
+    res.redirect("/index.html");
+  }
+});
+
 app.use(express.static(path.join(__dirname, "../public")));
 
 app.get("/beta", (req, res) => {


### PR DESCRIPTION
## Summary
- add server side handler for `/search?q=` to create new chat in search mode
- enable detecting search requests in the frontend
- provide helper to enable search mode and auto-send query

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68784a1717c8832388f31b98e2ea17c6