### PR TITLE
Add search link at page top

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -20,7 +20,7 @@
     <img id="sidebarToggleIcon" class="sidebar-toggle-icon" src="/alfe_favicon_64x64.ico" alt="Toggle sidebar" title="Toggle sidebar"/>
     <span id="sidebarBrandText" class="sidebar-brand-text">Alfe AI</span>
     <span id="closeSidebarIcon" class="close-sidebar-icon">&laquo;</span>
-    <div id="versionInfo" class="version-info" style="margin-bottom: 5px;"><span id="versionSpan">beta-...</span> <a href="/about.html" target="_blank" style="color: cyan">about</a> <a href="/pipeline_queue.html" target="_blank" style="color: cyan; margin-left:4px;">queue</a></div>
+    <div id="versionInfo" class="version-info" style="margin-bottom: 5px;"><span id="versionSpan">beta-...</span> <a href="/about.html" target="_blank" style="color: cyan">about</a> <a href="https://dev.alfe.sh/search?q=" target="_blank" style="color: cyan; margin-left:4px;">search</a> <a href="/pipeline_queue.html" target="_blank" style="color: cyan; margin-left:4px;">queue</a></div>
     <span id="sessionIdText" class="session-id"></span>
     <button id="hideSidebarBtn" class="hide-sidebar-btn">Hide Sidebar</button>
     <span id="imageLimitInfo" class="session-limit"></span>

--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -46,6 +46,7 @@
     <img id="sidebarToggle" class="sidebar-toggle-icon" src="/alfe_favicon_64x64.ico" alt="Toggle sidebar" title="Toggle sidebar"/>
     <span id="logoText" style="position:absolute; top:12px; left:60px; font-size:1.4rem; color:var(--text-color);">Alfe AI</span>
     <a id="aboutLink" style="position:absolute; top:18px; left:130px; font-size:0.8rem; color:var(--text-color); cursor:pointer;">About</a>
+    <a id="searchLink" href="https://dev.alfe.sh/search?q=" target="_blank" style="position:absolute; top:18px; left:175px; font-size:0.8rem; color:var(--text-color);">Search</a>
     <aside id="sidebar">
       <div id="tabsList" style="position:relative; top: 40px;"></div>
       <div id="archiveList" style="position:relative; top: 40px; display:none;"></div>
@@ -240,6 +241,7 @@
   </div>
   <div id="startDialog" class="modal" style="display:flex;">
     <a href="/about.html" target="_blank" style="position:absolute; top:8px; left:8px; font-size:0.8rem; color:var(--text-color);">About</a>
+    <a href="https://dev.alfe.sh/search?q=" target="_blank" style="position:absolute; top:8px; left:60px; font-size:0.8rem; color:var(--text-color);">Search</a>
     <div id="splashAnim">
       <div id="splashTitle">Alfe AI</div>
         <div id="splashYour">AI Project Management, Image Design, and Software Development</div>

--- a/Aurora/public/portfolio.html
+++ b/Aurora/public/portfolio.html
@@ -99,6 +99,11 @@
     href="/about_confused.html"
     style="position:fixed; top:8px; left:100px; font-size:0.8rem; color:#0ff; z-index:1001;"
   >About</a>
+  <a
+    href="https://dev.alfe.sh/search?q="
+    target="_blank"
+    style="position:fixed; top:8px; left:160px; font-size:0.8rem; color:#0ff; z-index:1001;"
+  >Search</a>
   <h1>Confused Art - Powered by <a href="https://alfe.sh" target="_blank">Alfe AI</a></h1>
   <div id="imageCounter">0 / 0</div>
   <div id="grid" class="grid"></div>

--- a/Aurora/public/splash.html
+++ b/Aurora/public/splash.html
@@ -43,6 +43,7 @@
 </head>
 <body>
   <a href="/about.html" style="position:absolute; top:8px; left:8px; font-size:0.8rem; color:#fff;">About</a>
+  <a href="https://dev.alfe.sh/search?q=" target="_blank" style="position:absolute; top:8px; left:60px; font-size:0.8rem; color:#fff;">Search</a>
   <div id="title">Alfe AI</div>
   <div id="your">AI Project Management, Image Design, and Software Development</div>
 </body>


### PR DESCRIPTION
## Summary
- add `Search` link next to existing `About` link on multiple pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68785aad6aa48323a8f205352e04b38b