### PR TITLE
Fix Amazon SP-API endpoint

### DIFF
--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -1464,6 +1464,11 @@ export default class TaskDB {
   listAmazonSkus() {
     return this.db.prepare('SELECT * FROM amazon_skus ORDER BY id DESC').all();
   }
+
+  getAsinForSku(sku) {
+    const row = this.db.prepare('SELECT asin FROM amazon_skus WHERE sku=?').get(sku);
+    return row ? row.asin : null;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- implement `getAsinForSku` DB helper
- use FBA Inbound Eligibility API in `updatePrepInfo`

## Testing
- `npm --prefix Aurora run lint`
- `npm --prefix AutoPR run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68786f0999a483239f978d9923cc1cb3