### PR TITLE
Fix project tab ordering for new chats

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2200,6 +2200,11 @@ async function quickAddTabToProject(project){
   if(r.ok){
     const data = await r.json();
     await loadTabs();
+    // Prepend the new tab ID to the project's order so it appears at the top
+    chatTabOrder[project] = chatTabOrder[project] || [];
+    chatTabOrder[project] = chatTabOrder[project].filter(id => id !== data.id);
+    chatTabOrder[project].unshift(data.id);
+    saveChatTabOrder();
     await selectTab(data.id);
   }
 }


### PR DESCRIPTION
## Summary
- ensure new tabs created with the project `+` button appear first in that project

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_68790f32d5ec832391c10601bb039675