### PR TITLE
Add search tab button for projects

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2194,16 +2194,23 @@ async function openProjectSettingsModal(project){
   setTimeout(() => { input.focus(); input.select(); }, 0);
 }
 
-async function quickAddTabToProject(project){
+async function quickAddTabToProject(project, type = "chat"){
+  const reloadNeeded = chatTabs.length === 0;
   const r = await fetch("/api/chat/tabs/new", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name: "", nexum: 0, project, type: "chat", sessionId })
+    body: JSON.stringify({ name: "", nexum: 0, project, type, sessionId })
   });
   if(r.ok){
     const data = await r.json();
     await loadTabs();
     await selectTab(data.id);
+    if(type === "search"){
+      await enableSearchMode("");
+    }
+    if(reloadNeeded){
+      window.location.reload();
+    }
   }
 }
 
@@ -2505,6 +2512,11 @@ function renderSidebarTabs(){
         addBtn.className = "project-add-btn config-btn";
         addBtn.addEventListener("click", e => { e.stopPropagation(); quickAddTabToProject(project); });
         header.appendChild(addBtn);
+        const searchBtn = document.createElement("button");
+        searchBtn.innerHTML = "&#128269;";
+        searchBtn.className = "project-search-btn config-btn";
+        searchBtn.addEventListener("click", e => { e.stopPropagation(); quickAddTabToProject(project, 'search'); });
+        header.appendChild(searchBtn);
       }
       header.addEventListener("click", e => {
         e.stopPropagation();

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -868,10 +868,28 @@ body {
   align-items: center;
   justify-content: center;
 }
+#verticalTabsContainer .project-search-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-weight: bold;
+  font-size: 1rem;
+  margin-left: 4px;
+  transition: color 0.3s;
+  width: 24px;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 #verticalTabsContainer .project-gear-btn:hover {
   color: var(--accent-light);
 }
 #verticalTabsContainer .project-add-btn:hover {
+  color: var(--accent-light);
+}
+#verticalTabsContainer .project-search-btn:hover {
   color: var(--accent-light);
 }
 

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -870,10 +870,28 @@ body {
   align-items: center;
   justify-content: center;
 }
+#verticalTabsContainer .project-search-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-weight: bold;
+  font-size: 1rem;
+  margin-left: 4px;
+  transition: color 0.3s;
+  width: 24px;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 #verticalTabsContainer .project-gear-btn:hover {
   color: var(--accent-light);
 }
 #verticalTabsContainer .project-add-btn:hover {
+  color: var(--accent-light);
+}
+#verticalTabsContainer .project-search-btn:hover {
   color: var(--accent-light);
 }
 


### PR DESCRIPTION
## Summary
- add ability to quick-create search tabs via `quickAddTabToProject`
- render a magnifying glass button next to project add button
- style new search button in dark/light themes

## Testing
- `node test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_68792b24c9ac8323a67c48165fdda624