### PR TITLE
Fix Aurora chat textbox alignment

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -313,7 +313,7 @@
         <button id="reasoningToggleBtn" class="send-btn reasoning-toggle-btn" title="Toggle Reasoning">🧠</button>
         <button id="codexToggleBtn" class="send-btn codex-toggle-btn" title="Toggle Codex Mini">&lt;/&gt;</button>
 
-        <textarea id="chatInput" placeholder="Type your message..." style="position:relative; top:20px;"></textarea>
+        <textarea id="chatInput" placeholder="Type your message..."></textarea>
         <button id="chatSendBtn" class="send-btn">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                stroke-linecap="round" stroke-linejoin="round" class="feather feather-send">


### PR DESCRIPTION
## Summary
- remove inline style shifting the chat input down

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687939f3cabc8323867b54149074139d