### PR TITLE
Add /new route

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -5310,7 +5310,9 @@ thinPrintifyIcon?.addEventListener("touchstart", ev => {
     await loadChatHistory(currentTabId, true);
     const ct = chatTabs.find(t => t.id === currentTabId);
     if(ct && ct.tab_uuid){
-      window.history.replaceState({}, '', `/chat/${ct.tab_uuid}`);
+      if(window.location.pathname.startsWith('/chat/')){
+        window.history.replaceState({}, '', `/chat/${ct.tab_uuid}`);
+      }
     }
   }
 

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -3618,6 +3618,27 @@ app.get("/search", (req, res) => {
   }
 });
 
+app.get("/new", (req, res) => {
+  try {
+    const sessionId = getSessionIdFromRequest(req);
+    const { id: tabId } = db.createChatTab(
+      "New Tab",
+      0,
+      "",
+      "",
+      "",
+      0,
+      "chat",
+      sessionId
+    );
+    db.setSetting("last_chat_tab", tabId);
+    res.sendFile(path.join(__dirname, "../public/aurora.html"));
+  } catch (err) {
+    console.error("[Server Debug] GET /new error:", err);
+    res.redirect("/index.html");
+  }
+});
+
 app.use(express.static(path.join(__dirname, "../public")));
 
 app.get("/beta", (req, res) => {


### PR DESCRIPTION
## Summary
- create `/new` route to start a new chat tab and serve `aurora.html`
- keep URL unchanged for non-`/chat/` pages at startup

## Testing
- `npm run lint --prefix Aurora`

------
https://chatgpt.com/codex/tasks/task_b_6879260cceb08323959a8c7205bef476