### PR TITLE
Show add/search in default project header

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2540,17 +2540,17 @@ function renderSidebarTabs(){
         gear.className = "project-gear-btn config-btn";
         gear.addEventListener("click", e => { e.stopPropagation(); openProjectSettingsModal(project); });
         header.appendChild(gear);
-        const addBtn = document.createElement("button");
-        addBtn.textContent = "+";
-        addBtn.className = "project-add-btn config-btn";
-        addBtn.addEventListener("click", e => { e.stopPropagation(); quickAddTabToProject(project); });
-        header.appendChild(addBtn);
-        const searchBtn = document.createElement("button");
-        searchBtn.innerHTML = "&#128269;";
-        searchBtn.className = "project-search-btn config-btn";
-        searchBtn.addEventListener("click", e => { e.stopPropagation(); quickAddTabToProject(project, 'search'); });
-        header.appendChild(searchBtn);
       }
+      const addBtn = document.createElement("button");
+      addBtn.textContent = "+";
+      addBtn.className = "project-add-btn config-btn";
+      addBtn.addEventListener("click", e => { e.stopPropagation(); quickAddTabToProject(project); });
+      header.appendChild(addBtn);
+      const searchBtn = document.createElement("button");
+      searchBtn.innerHTML = "&#128269;";
+      searchBtn.className = "project-search-btn config-btn";
+      searchBtn.addEventListener("click", e => { e.stopPropagation(); quickAddTabToProject(project, 'search'); });
+      header.appendChild(searchBtn);
       header.addEventListener("click", e => {
         e.stopPropagation();
         collapsedProjectGroups[project] = !collapsedProjectGroups[project];


### PR DESCRIPTION
## Summary
- show add and search buttons even for the "No project" group in the Aurora UI

## Testing
- `npm run lint` *(fails: no linter configured)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687a7faf4b34832387eccedec95dac15