### PR TITLE
Fix project context retrieval for non-project chats

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1793,7 +1793,9 @@ app.post("/api/chat", async (req, res) => {
     let projectContext = '';
     if (tabInfo && (tabInfo.project_name || tabInfo.extra_projects)) {
       const allProjects = [];
-      if (tabInfo.project_name) allProjects.push(tabInfo.project_name);
+      if (tabInfo.project_name && tabInfo.project_name.trim()) {
+        allProjects.push(tabInfo.project_name.trim());
+      }
       if (tabInfo.extra_projects) {
         tabInfo.extra_projects.split(',').forEach(p => {
           p = p.trim();

--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -826,6 +826,9 @@ export default class TaskDB {
   }
 
   getChatPairsByProject(projectName) {
+    if (!projectName) {
+      return [];
+    }
     return this.db
         .prepare(
           `SELECT cp.* FROM chat_pairs cp


### PR DESCRIPTION
## Summary
- avoid pushing blank project names when building project context
- ignore requests for project context when no project is specified

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687a8444423c8323b6d2a156063b26bb