### PR TITLE
Add project context toggle to chat tabs

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -467,6 +467,7 @@
     <label style="display:block;margin-top:8px;">Assign to task:<br/>
       <select id="renameTaskSelect" style="width:100%;"></select>
     </label>
+    <label style="display:block;margin-top:8px;"><input type="checkbox" id="renameSendProjectContextCheck" checked/> Send project context</label>
     <div class="modal-buttons">
       <button id="renameTabCreateTaskBtn">Create Task</button>
       <button id="renameTabSaveBtn">Save</button>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2127,6 +2127,10 @@ async function openRenameTabModal(tabId){
   if(extraInp){
     extraInp.value = t && t.extra_projects ? t.extra_projects : '';
   }
+  const sendCtx = $("#renameSendProjectContextCheck");
+  if(sendCtx){
+    sendCtx.checked = t ? t.send_project_context !== 0 : true;
+  }
   const modal = $("#renameTabModal");
   if(!modal){
     renameTab(tabId);
@@ -2208,11 +2212,13 @@ $("#renameTabSaveBtn").addEventListener("click", async () => {
   let taskId = taskSel ? parseInt(taskSel.value,10) || 0 : 0;
   const extraInp = $("#renameExtraProjectsInput");
   let extraProjects = extraInp ? extraInp.value.trim() : '';
+  const sendCtx = $("#renameSendProjectContextCheck");
+  const sendProjectContext = sendCtx ? sendCtx.checked : true;
   const repo = tab.repo_ssh_url || '';
   await fetch('/api/chat/tabs/config', {
     method:'POST',
     headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({tabId, project, repo, extraProjects, taskId, type, sessionId})
+    body: JSON.stringify({tabId, project, repo, extraProjects, taskId, type, sendProjectContext, sessionId})
   });
   await loadTabs();
   renderTabs();
@@ -2248,11 +2254,13 @@ $("#renameTabCreateTaskBtn").addEventListener("click", async () => {
   } catch(e) { console.error(e); }
   const extraInp = $("#renameExtraProjectsInput");
   let extraProjects = extraInp ? extraInp.value.trim() : '';
+  const sendCtx = $("#renameSendProjectContextCheck");
+  const sendProjectContext = sendCtx ? sendCtx.checked : true;
   const repo = tab.repo_ssh_url || '';
   await fetch('/api/chat/tabs/config', {
     method:'POST',
     headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({tabId, project, repo, extraProjects, taskId, type, sessionId})
+    body: JSON.stringify({tabId, project, repo, extraProjects, taskId, type, sendProjectContext, sessionId})
   });
   await loadTabs();
   renderTabs();

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1776,7 +1776,7 @@ app.post("/api/chat", async (req, res) => {
     const { provider } = parseProviderModel(model || "deepseek/deepseek-chat");
     let systemContext = `System Context:\n${savedInstructions}`;
     let projectContext = '';
-    if (tabInfo && (tabInfo.project_name || tabInfo.extra_projects)) {
+    if (tabInfo && tabInfo.send_project_context && (tabInfo.project_name || tabInfo.extra_projects)) {
       const allProjects = [];
       if (tabInfo.project_name && tabInfo.project_name.trim()) {
         allProjects.push(tabInfo.project_name.trim());
@@ -2136,7 +2136,7 @@ app.post("/api/chat/tabs/generate_images", (req, res) => {
 app.post("/api/chat/tabs/config", (req, res) => {
   console.debug("[Server Debug] POST /api/chat/tabs/config =>", req.body);
   try {
-    const { tabId, project = '', repo = '', extraProjects = '', taskId = 0, type = 'chat', sessionId = '' } = req.body;
+    const { tabId, project = '', repo = '', extraProjects = '', taskId = 0, type = 'chat', sendProjectContext = 1, sessionId = '' } = req.body;
     if (!tabId) {
       return res.status(400).json({ error: "Missing tabId" });
     }
@@ -2144,7 +2144,7 @@ app.post("/api/chat/tabs/config", (req, res) => {
     if (!tab) {
       return res.status(403).json({ error: 'Forbidden' });
     }
-    db.setChatTabConfig(tabId, project, repo, extraProjects, taskId, type);
+    db.setChatTabConfig(tabId, project, repo, extraProjects, taskId, type, sendProjectContext ? 1 : 0);
     res.json({ success: true });
   } catch (err) {
     console.error("[TaskQueue] POST /api/chat/tabs/config error:", err);

--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -101,6 +101,7 @@ export default class TaskDB {
                                                task_id INTEGER DEFAULT 0,
                                                model_override TEXT DEFAULT '',
                                                tab_type TEXT DEFAULT 'chat',
+                                               send_project_context INTEGER DEFAULT 1,
                                                session_id TEXT DEFAULT '',
                                              tab_uuid TEXT DEFAULT ''
       );
@@ -164,6 +165,12 @@ export default class TaskDB {
       console.debug("[TaskDB Debug] Added chat_tabs.tab_type column");
     } catch(e) {
       //console.debug("[TaskDB Debug] chat_tabs.tab_type column exists, skipping.", e.message);
+    }
+    try {
+      this.db.exec('ALTER TABLE chat_tabs ADD COLUMN send_project_context INTEGER DEFAULT 1;');
+      console.debug("[TaskDB Debug] Added chat_tabs.send_project_context column");
+    } catch(e) {
+      //console.debug("[TaskDB Debug] chat_tabs.send_project_context column exists, skipping.", e.message);
     }
     try {
       this.db.exec("ALTER TABLE chat_tabs ADD COLUMN session_id TEXT DEFAULT '';" );
@@ -862,14 +869,14 @@ export default class TaskDB {
         .get(id);
   }
 
-  createChatTab(name, nexum = 0, project = '', repo = '', extraProjects = '', taskId = 0, type = 'chat', sessionId = '') {
+  createChatTab(name, nexum = 0, project = '', repo = '', extraProjects = '', taskId = 0, type = 'chat', sessionId = '', sendProjectContext = 1) {
     const ts = new Date().toISOString();
     const genImages = type === 'design' ? 1 : 0;
     if (project) this.ensureProjectMeta(project);
     const uuid = randomUUID().replace(/-/g, '').slice(0, 12);
     const { lastInsertRowid } = this.db.prepare(`
-      INSERT INTO chat_tabs (name, created_at, generate_images, nexum, project_name, repo_ssh_url, extra_projects, task_id, tab_type, session_id, tab_uuid)
-      VALUES (@name, @created_at, @generate_images, @nexum, @project_name, @repo_ssh_url, @extra_projects, @task_id, @tab_type, @session_id, @uuid)
+      INSERT INTO chat_tabs (name, created_at, generate_images, nexum, project_name, repo_ssh_url, extra_projects, task_id, tab_type, send_project_context, session_id, tab_uuid)
+      VALUES (@name, @created_at, @generate_images, @nexum, @project_name, @repo_ssh_url, @extra_projects, @task_id, @tab_type, @send_project_context, @session_id, @uuid)
     `).run({
       name,
       created_at: ts,
@@ -880,6 +887,7 @@ export default class TaskDB {
       extra_projects: extraProjects,
       task_id: taskId,
       tab_type: type,
+      send_project_context: sendProjectContext ? 1 : 0,
       session_id: sessionId,
       uuid
     });
@@ -976,11 +984,23 @@ export default class TaskDB {
     return row ? !!row.generate_images : true;
   }
 
-  setChatTabConfig(tabId, project = '', repo = '', extraProjects = '', taskId = 0, type = 'chat') {
+  setChatTabSendProjectContext(tabId, enabled = 1) {
+    this.db.prepare("UPDATE chat_tabs SET send_project_context=? WHERE id=?")
+        .run(enabled ? 1 : 0, tabId);
+  }
+
+  getChatTabSendProjectContext(tabId) {
+    const row = this.db
+        .prepare("SELECT send_project_context FROM chat_tabs WHERE id=?")
+        .get(tabId);
+    return row ? !!row.send_project_context : true;
+  }
+
+  setChatTabConfig(tabId, project = '', repo = '', extraProjects = '', taskId = 0, type = 'chat', sendProjectContext = 1) {
     const genImages = type === 'design' ? 1 : 0;
     this.db.prepare(
-        "UPDATE chat_tabs SET project_name=?, repo_ssh_url=?, extra_projects=?, task_id=?, tab_type=?, generate_images=? WHERE id=?"
-    ).run(project, repo, extraProjects, taskId, type, genImages, tabId);
+        "UPDATE chat_tabs SET project_name=?, repo_ssh_url=?, extra_projects=?, task_id=?, tab_type=?, generate_images=?, send_project_context=? WHERE id=?"
+    ).run(project, repo, extraProjects, taskId, type, genImages, sendProjectContext ? 1 : 0, tabId);
   }
 
   getChatTab(tabId, sessionId = null) {
@@ -1010,8 +1030,8 @@ export default class TaskDB {
     const uuid = randomUUID().replace(/-/g, '').slice(0, 12);
     const newName = name || `${tab.name} Copy`;
     const { lastInsertRowid } = this.db.prepare(`
-      INSERT INTO chat_tabs (name, created_at, generate_images, nexum, project_name, repo_ssh_url, extra_projects, task_id, tab_type, session_id, tab_uuid)
-      VALUES (@name, @created_at, @generate_images, @nexum, @project_name, @repo_ssh_url, @extra_projects, @task_id, @tab_type, @session_id, @uuid)
+      INSERT INTO chat_tabs (name, created_at, generate_images, nexum, project_name, repo_ssh_url, extra_projects, task_id, tab_type, send_project_context, session_id, tab_uuid)
+      VALUES (@name, @created_at, @generate_images, @nexum, @project_name, @repo_ssh_url, @extra_projects, @task_id, @tab_type, @send_project_context, @session_id, @uuid)
     `).run({
       name: newName,
       created_at: ts,
@@ -1022,6 +1042,7 @@ export default class TaskDB {
       extra_projects: tab.extra_projects,
       task_id: tab.task_id,
       tab_type: tab.tab_type,
+      send_project_context: tab.send_project_context,
       session_id: tab.session_id,
       uuid
     });


### PR DESCRIPTION
## Summary
- allow enabling/disabling project context for each chat tab
- store new `send_project_context` flag in DB and expose through API
- add checkbox in Aurora tab settings modal
- support flag in UI and server when saving settings

## Testing
- `npm run lint`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_687abef3ffa083238e2bb9a55d3c8c6e