### PR TITLE
Block tab model settings during search/reasoning

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -6551,6 +6551,10 @@ document.getElementById("globalAiSettingsCancelBtn").addEventListener("click", (
 // Tab Model Settings modal
 // ----------------------------------------------------------------------
 async function openTabModelSettings(){
+  if(searchEnabled || reasoningEnabled){
+    showToast("Disable search/reasoning mode first");
+    return;
+  }
   if(!currentTabId) return;
   showPageLoader();
   try{


### PR DESCRIPTION
## Summary
- prevent opening tab model settings if Search or Reasoning mode is active

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_687ad38945e08323a81c1135e6cc1b69