### PR TITLE
Add reasoning model tooltip

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -132,6 +132,8 @@ let draggingTabRow = null;        // element of tab row being dragged
 let projectAddTooltip = null;     // floating toolbar for project add button
 let projectAddTooltipProject = null;
 let projectAddTooltipTimer = null;
+let reasoningTooltip = null;      // tooltip for reasoning config
+let reasoningTooltipTimer = null;
 let printifyPage = 1; // current Printify product page
 let showDependenciesColumn = false;
 let tabGenerateImages = false; // per-tab auto image toggle (design tabs only)
@@ -2230,6 +2232,61 @@ function hideProjectAddTooltip(){
 function scheduleHideProjectAddTooltip(){
   clearTimeout(projectAddTooltipTimer);
   projectAddTooltipTimer = setTimeout(hideProjectAddTooltip, 200);
+}
+
+function initReasoningTooltip(){
+  if(reasoningTooltip) return;
+  reasoningTooltip = document.createElement('div');
+  reasoningTooltip.className = 'reasoning-tooltip';
+  const select = document.createElement('select');
+  select.id = 'reasoningModelSelect';
+  const models = [
+    'openai/o4-mini',
+    'openrouter/openai/o4-mini-high',
+    'deepseek/r1-distill-llama-70b',
+    'openai/codex-mini-latest',
+    'openai/codex-mini'
+  ];
+  models.forEach(m => select.appendChild(new Option(m, m)));
+  select.addEventListener('change', async e => {
+    const model = e.target.value;
+    await setSetting('ai_reasoning_model', model);
+    if(reasoningEnabled){
+      await fetch('/api/chat/tabs/model', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({tabId: currentTabId, model, sessionId})
+      });
+      tabModelOverride = model;
+      modelName = model;
+      updateModelHud();
+    }
+  });
+  reasoningTooltip.appendChild(select);
+  reasoningTooltip.addEventListener('mouseenter', () => clearTimeout(reasoningTooltipTimer));
+  reasoningTooltip.addEventListener('mouseleave', scheduleHideReasoningTooltip);
+  document.body.appendChild(reasoningTooltip);
+}
+
+async function showReasoningTooltip(e){
+  initReasoningTooltip();
+  const select = document.getElementById('reasoningModelSelect');
+  const current = await getSetting('ai_reasoning_model');
+  if(current) select.value = current;
+  const rect = e.target.getBoundingClientRect();
+  reasoningTooltip.style.display = 'block';
+  reasoningTooltip.style.left = (rect.left + window.scrollX) + 'px';
+  reasoningTooltip.style.top = (rect.top + window.scrollY - reasoningTooltip.offsetHeight - 8) + 'px';
+  clearTimeout(reasoningTooltipTimer);
+}
+
+function hideReasoningTooltip(){
+  if(reasoningTooltip) reasoningTooltip.style.display = 'none';
+}
+
+function scheduleHideReasoningTooltip(){
+  clearTimeout(reasoningTooltipTimer);
+  reasoningTooltipTimer = setTimeout(hideReasoningTooltip, 200);
 }
 
 $("#renameTabSaveBtn").addEventListener("click", async () => {
@@ -7117,7 +7174,14 @@ registerActionHook("embedMockImages", async ({response}) => {
 });
 
 document.getElementById("searchToggleBtn")?.addEventListener("click", toggleSearch);
-document.getElementById("reasoningToggleBtn")?.addEventListener("click", toggleReasoning);
+document.getElementById("reasoningToggleBtn")?.addEventListener("click", e => {
+  e.stopPropagation();
+  if(reasoningTooltip && reasoningTooltip.style.display === 'block'){
+    hideReasoningTooltip();
+  } else {
+    showReasoningTooltip(e);
+  }
+});
 document.getElementById("codexToggleBtn")?.addEventListener("click", toggleCodexMini);
 
 console.log("[Server Debug] main.js fully loaded. End of script.");

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -907,6 +907,24 @@ body {
   margin-left: 0;
 }
 
+/* Tooltip for reasoning model configuration */
+.reasoning-tooltip {
+  position: absolute;
+  background: #333;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 4px;
+  display: none;
+  z-index: 10000;
+  box-shadow: var(--shadow);
+}
+.reasoning-tooltip select {
+  background: #474747;
+  border: 1px solid #666;
+  color: #ddd;
+  padding: 2px 4px;
+}
+
 #projectGroupsContainer button {
   display: inline-flex;
   background-color: #333;


### PR DESCRIPTION
## Summary
- add reasoning model config tooltip styles
- allow configuring reasoning model via tooltip
- open the tooltip from the reasoning brain button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687ac191d8508323a8e785aaef157363