### PR TITLE
Toggle reasoning on click

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -7186,7 +7186,10 @@ registerActionHook("embedMockImages", async ({response}) => {
 });
 
 document.getElementById("searchToggleBtn")?.addEventListener("click", toggleSearch);
-document.getElementById("reasoningToggleBtn")?.addEventListener("click", showReasoningTooltip);
+const reasoningToggleBtn = document.getElementById("reasoningToggleBtn");
+reasoningToggleBtn?.addEventListener("click", toggleReasoning);
+reasoningToggleBtn?.addEventListener("mouseenter", showReasoningTooltip);
+reasoningToggleBtn?.addEventListener("mouseleave", scheduleHideReasoningTooltip);
 document.getElementById("codexToggleBtn")?.addEventListener("click", toggleCodexMini);
 document.addEventListener('click', e => {
   if(reasoningTooltip && reasoningTooltip.style.display === 'flex' &&


### PR DESCRIPTION
## Summary
- make reasoning button click toggle reasoning mode
- show reasoning tooltip on hover

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_687ad7839158832384d5d6b7042fa5ca