### PR TITLE
Change reasoning tooltip icon

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -309,7 +309,7 @@
         <button id="chatImageBtn" class="send-btn" title="Upload Image" style="display:none;">🖼</button>
         <button id="searchToggleBtn" class="send-btn search-toggle-btn" title="Toggle Search">🔍</button>
 
-        <button id="reasoningToggleBtn" class="send-btn reasoning-toggle-btn" title="Toggle Reasoning">🧠</button>
+        <button id="reasoningToggleBtn" class="send-btn reasoning-toggle-btn" title="Toggle Reasoning">⚙️</button>
         <button id="codexToggleBtn" class="send-btn codex-toggle-btn" title="Toggle Codex Mini">&lt;/&gt;</button>
 
         <textarea id="chatInput" placeholder="Type your message..."></textarea>


### PR DESCRIPTION
## Summary
- swap out the brain emoji for a gear icon on the reasoning toggle button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687afead6a0c8323a7f37708de1d5921