### PR TITLE
Update reasoning tooltip with chat section

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4181,6 +4181,41 @@ function initReasoningTooltip(){
     await toggleReasoning();
   });
   reasoningTooltip.appendChild(tBtn);
+  const chatHeader = document.createElement('div');
+  chatHeader.className = 'tooltip-section-title';
+  chatHeader.textContent = 'Chat';
+  reasoningTooltip.appendChild(chatHeader);
+  const chatModels = [
+    'deepseek/deepseek-chat-v3-0324',
+    'openai/gpt-4o'
+  ];
+  chatModels.forEach(m => {
+    const b = document.createElement('button');
+    b.textContent = m;
+    b.addEventListener('click', async ev => {
+      ev.stopPropagation();
+      await setSetting('ai_model', m);
+      settingsCache.ai_model = m;
+      if(!searchEnabled && !reasoningEnabled && !codexMiniEnabled){
+        await fetch('/api/chat/tabs/model', {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify({tabId: currentTabId, model: m, sessionId})
+        });
+        tabModelOverride = m;
+        modelName = m;
+        updateModelHud();
+      }
+      hideReasoningTooltip();
+      showToast(`Chat model set to ${m}`);
+    });
+    reasoningTooltip.appendChild(b);
+  });
+
+  const reasoningHeader = document.createElement('div');
+  reasoningHeader.className = 'tooltip-section-title';
+  reasoningHeader.textContent = 'Reasoning';
+  reasoningTooltip.appendChild(reasoningHeader);
   const models = [
     'openai/o4-mini',
     'openrouter/openai/o4-mini-high',

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1516,6 +1516,10 @@ button:disabled {
   background: #666;
   color: #fff;
 }
+.reasoning-tooltip .tooltip-section-title {
+  font-weight: bold;
+  margin-top: 4px;
+}
 
 /* Minimal markdown highlighting */
 .md-h1,.md-h2,.md-h3,.md-h4,.md-h5,.md-h6{


### PR DESCRIPTION
## Summary
- extend tooltip to feature chat and reasoning sections
- add styling for section titles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687afdbd0e288323beedfdbd5c6ea966