### PR TITLE
Auto switch search & reasoning modes

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4169,8 +4169,8 @@ function updateCodexButton(){
 
 async function toggleSearch(){
   if(!searchEnabled && (reasoningEnabled || codexMiniEnabled)){
-    showToast("Disable Reasoning/Codex mode first");
-    return;
+    if(reasoningEnabled) await toggleReasoning();
+    if(codexMiniEnabled) await toggleCodexMini();
   }
   searchEnabled = !searchEnabled;
   await setSetting("search_enabled", searchEnabled);
@@ -4203,8 +4203,8 @@ async function toggleSearch(){
 
 async function toggleReasoning(){
   if(!reasoningEnabled && (searchEnabled || codexMiniEnabled)){
-    showToast("Disable Search/Codex mode first");
-    return;
+    if(searchEnabled) await toggleSearch();
+    if(codexMiniEnabled) await toggleCodexMini();
   }
   reasoningEnabled = !reasoningEnabled;
   await setSetting("reasoning_enabled", reasoningEnabled);


### PR DESCRIPTION
## Summary
- update search toggle to disable reasoning or Codex automatically
- update reasoning toggle to disable search or Codex automatically
- keep toast requirement for Tab Model settings

## Testing
- `npm run lint --prefix Aurora`
- `npm test --prefix Aurora` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687ad60477ac83239865ce1f8f64c0ff