### PR TITLE
Update reasoning models

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4231,9 +4231,10 @@ function initReasoningTooltip(){
   reasoningTooltip.appendChild(reasoningHeader);
 
   const models = [
+    'deepseek/deepseek-r1-distill-llama-70b',
     'openai/o4-mini',
     'openai/o4-mini-high',
-    'deepseek/deepseek-r1-distill-llama-70b',
+    'openai/o3',
     'openai/codex-mini'
   ];
   models.forEach(m => {


### PR DESCRIPTION
## Summary
- add `openai/o3` to the reasoning models list
- show deepseek option before openai in the UI

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687b06e8d95483239a8ebabef81a560f