### PR TITLE
Add search model tooltip menu

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4288,6 +4288,88 @@ function scheduleHideReasoningTooltip(){
   reasoningTooltipTimer = setTimeout(hideReasoningTooltip, 200);
 }
 
+let searchTooltip = null;
+let searchTooltipTimer = null;
+
+function highlightSearchModel(model){
+  if(!searchTooltip) return;
+  Array.from(searchTooltip.querySelectorAll('button[data-model]')).forEach(b => {
+    b.classList.toggle('active', b.dataset.model === model);
+  });
+}
+
+function initSearchTooltip(){
+  if(searchTooltip) return;
+  searchTooltip = document.createElement('div');
+  searchTooltip.className = 'search-tooltip';
+  const tBtn = document.createElement('button');
+  tBtn.textContent = 'Toggle Search';
+  tBtn.addEventListener('click', async ev => {
+    ev.stopPropagation();
+    await toggleSearch();
+  });
+  searchTooltip.appendChild(tBtn);
+
+  const models = [
+    'openai/gpt-4o-search-preview',
+    'openai/gpt-4o-mini-search-preview',
+    'openrouter/perplexity/sonar',
+    'openrouter/perplexity/sonar-pro',
+    'openrouter/perplexity/sonar-reasoning',
+    'openrouter/perplexity/sonar-reasoning-pro'
+  ];
+  models.forEach(m => {
+    const b = document.createElement('button');
+    b.dataset.model = m;
+    b.textContent = m;
+    b.classList.toggle('active', settingsCache.ai_search_model === m);
+    b.addEventListener('click', async ev => {
+      ev.stopPropagation();
+      await setSetting('ai_search_model', m);
+      settingsCache.ai_search_model = m;
+      if(!searchEnabled){
+        await toggleSearch();
+      } else {
+        await fetch('/api/chat/tabs/model', {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify({tabId: currentTabId, model: m, sessionId})
+        });
+        tabModelOverride = m;
+        modelName = m;
+        updateModelHud();
+      }
+      highlightSearchModel(m);
+      hideSearchTooltip();
+      showToast(`Search model set to ${m}`);
+    });
+    searchTooltip.appendChild(b);
+  });
+  highlightSearchModel(settingsCache.ai_search_model);
+  searchTooltip.addEventListener('mouseenter', () => clearTimeout(searchTooltipTimer));
+  searchTooltip.addEventListener('mouseleave', scheduleHideSearchTooltip);
+  document.body.appendChild(searchTooltip);
+}
+
+function showSearchTooltip(e){
+  initSearchTooltip();
+  const rect = e.target.getBoundingClientRect();
+  searchTooltip.style.display = 'flex';
+  searchTooltip.style.flexDirection = 'column';
+  searchTooltip.style.left = rect.left + 'px';
+  searchTooltip.style.top = (rect.top - searchTooltip.offsetHeight - 4) + 'px';
+  clearTimeout(searchTooltipTimer);
+}
+
+function hideSearchTooltip(){
+  if(searchTooltip) searchTooltip.style.display = 'none';
+}
+
+function scheduleHideSearchTooltip(){
+  clearTimeout(searchTooltipTimer);
+  searchTooltipTimer = setTimeout(hideSearchTooltip, 200);
+}
+
 async function toggleSearch(){
   if(!searchEnabled && (reasoningEnabled || codexMiniEnabled)){
     if(reasoningEnabled) await toggleReasoning();
@@ -7249,7 +7331,10 @@ registerActionHook("embedMockImages", async ({response}) => {
   scrollChatToBottom();
 });
 
-document.getElementById("searchToggleBtn")?.addEventListener("click", toggleSearch);
+const searchToggleBtn = document.getElementById("searchToggleBtn");
+searchToggleBtn?.addEventListener("click", toggleSearch);
+searchToggleBtn?.addEventListener("mouseenter", showSearchTooltip);
+searchToggleBtn?.addEventListener("mouseleave", scheduleHideSearchTooltip);
 const reasoningToggleBtn = document.getElementById("reasoningToggleBtn");
 reasoningToggleBtn?.addEventListener("click", toggleReasoning);
 reasoningToggleBtn?.addEventListener("mouseenter", showReasoningTooltip);
@@ -7259,6 +7344,10 @@ document.addEventListener('click', e => {
   if(reasoningTooltip && reasoningTooltip.style.display === 'flex' &&
     !reasoningTooltip.contains(e.target) && e.target.id !== 'reasoningToggleBtn'){
     hideReasoningTooltip();
+  }
+  if(searchTooltip && searchTooltip.style.display === 'flex' &&
+    !searchTooltip.contains(e.target) && e.target.id !== 'searchToggleBtn'){
+    hideSearchTooltip();
   }
 });
 

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1527,6 +1527,41 @@ button:disabled {
   color: #fff;
 }
 
+.search-tooltip {
+  position: absolute;
+  background: #333;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 4px;
+  display: none;
+  z-index: 10000;
+  box-shadow: var(--shadow);
+}
+.search-tooltip .tooltip-section-header {
+  font-weight: bold;
+  color: #ddd;
+  margin-top: 4px;
+  margin-bottom: 2px;
+}
+.search-tooltip button {
+  display: block;
+  margin: 2px 0;
+  padding: 2px 4px;
+  background: #474747;
+  border: 1px solid #666;
+  color: #ddd;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.search-tooltip button:hover {
+  background: #666;
+  color: #fff;
+}
+.search-tooltip button.active {
+  background: #0062cc;
+  color: #fff;
+}
+
 /* Minimal markdown highlighting */
 .md-h1,.md-h2,.md-h3,.md-h4,.md-h5,.md-h6{
   display:block;


### PR DESCRIPTION
## Summary
- add `.search-tooltip` styles
- implement `searchTooltip` widget in JS
- show/hide search model tooltip on hover

## Testing
- `node Aurora/test/pipelineQueueRoute.test.cjs` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_687b0775d6f08323bc988bf2f410ecb6