### PR TITLE
Fix Firefox caching by changing SW and headers

### DIFF
--- a/Aurora/public/service-worker.js
+++ b/Aurora/public/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'alfe-cache-v1';
+const CACHE_NAME = 'alfe-cache-v2';
 const URLS_TO_CACHE = [
   '/aurora.html',
   '/manifest.json',
@@ -8,13 +8,28 @@ const URLS_TO_CACHE = [
 ];
 
 self.addEventListener('install', event => {
+  self.skipWaiting();
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
   );
 });
 
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    ).then(() => self.clients.claim())
+  );
+});
+
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request).then(response => response || fetch(event.request))
+    fetch(event.request)
+      .then(response => {
+        const copy = response.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, copy));
+        return response;
+      })
+      .catch(() => caches.match(event.request))
   );
 });

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -3665,7 +3665,15 @@ app.get("/new", (req, res) => {
   }
 });
 
-app.use(express.static(path.join(__dirname, "../public")));
+app.use(
+  express.static(path.join(__dirname, "../public"), {
+    etag: false,
+    maxAge: 0,
+    setHeaders: (res) => {
+      res.set("Cache-Control", "no-cache, no-store, must-revalidate");
+    },
+  })
+);
 
 app.get("/beta", (req, res) => {
   console.debug("[Server Debug] GET /beta => Redirecting to home page");


### PR DESCRIPTION
## Summary
- update the service worker to use a network-first strategy and clear old caches
- disable browser caching for public assets in the Express server

## Testing
- `npm test` *(fails: no test specified)*
- `npm test` in `VMRunner` *(fails: no test specified)*
- `npm test` in `AutoPR` *(prints `No tests specified`)*
- `npm test` in `AlfeRedirect` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687b1f615b98832389df41d35f6658dc