### PR TITLE
Add labels for reasoning models

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4285,36 +4285,40 @@ function initReasoningTooltip(){
   reasoningTooltip.appendChild(reasoningHeader);
 
   const models = [
-    'deepseek/deepseek-r1-distill-llama-70b',
-    'openai/o4-mini',
-    'openai/o4-mini-high',
-    'openai/o3',
-    'openai/codex-mini'
+    { name: 'deepseek/deepseek-r1-distill-llama-70b' },
+    { name: 'openai/o4-mini', label: 'pro' },
+    { name: 'openai/o4-mini-high', label: 'pro' },
+    { name: 'openai/o3', label: 'ultimate' },
+    { name: 'openai/codex-mini', label: 'pro' }
   ];
-  models.forEach(m => {
+  models.forEach(({name, label}) => {
       const b = document.createElement('button');
-      b.dataset.model = m;
-      b.textContent = m;
-      b.classList.toggle('active', settingsCache.ai_reasoning_model === m);
+      b.dataset.model = name;
+      if(label){
+        b.innerHTML = `<span class="model-label ${label}">${label}</span> ${name}`;
+      }else{
+        b.textContent = name;
+      }
+      b.classList.toggle('active', settingsCache.ai_reasoning_model === name);
       b.addEventListener('click', async ev => {
         ev.stopPropagation();
-        await setSetting('ai_reasoning_model', m);
-        settingsCache.ai_reasoning_model = m;
+        await setSetting('ai_reasoning_model', name);
+        settingsCache.ai_reasoning_model = name;
         if(!reasoningEnabled){
           await toggleReasoning();
         } else {
           await fetch("/api/chat/tabs/model", {
             method:"POST",
             headers:{"Content-Type":"application/json"},
-            body:JSON.stringify({tabId: currentTabId, model: m, sessionId})
+            body:JSON.stringify({tabId: currentTabId, model: name, sessionId})
           });
-          tabModelOverride = m;
-          modelName = m;
+          tabModelOverride = name;
+          modelName = name;
           updateModelHud();
         }
-        highlightReasoningModel(m);
+        highlightReasoningModel(name);
         hideReasoningTooltip();
-        showToast(`Reasoning model set to ${m}`);
+        showToast(`Reasoning model set to ${name}`);
       });
       reasoningTooltip.appendChild(b);
     });

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1527,6 +1527,20 @@ button:disabled {
   color: #fff;
 }
 
+.reasoning-tooltip .model-label {
+  display: inline-block;
+  font-size: 0.7em;
+  padding: 1px 4px;
+  margin-right: 4px;
+  border-radius: 4px;
+  background: #0062cc;
+  color: #fff;
+  text-transform: uppercase;
+}
+.reasoning-tooltip .model-label.ultimate {
+  background: #8e44ad;
+}
+
 .search-tooltip {
   position: absolute;
   background: #333;


### PR DESCRIPTION
## Summary
- add CSS styling for reasoning model labels
- label PRO and ULTIMATE reasoning models in the tooltip menu

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687b3848a4f483239ff628ff25cc14ee