### PR TITLE
Move o3 model after Codex in UI

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4288,8 +4288,8 @@ function initReasoningTooltip(){
     { name: 'deepseek/deepseek-r1-distill-llama-70b' },
     { name: 'openai/o4-mini', label: 'pro' },
     { name: 'openai/o4-mini-high', label: 'pro' },
-    { name: 'openai/o3', label: 'ultimate' },
-    { name: 'openai/codex-mini', label: 'pro' }
+    { name: 'openai/codex-mini', label: 'pro' },
+    { name: 'openai/o3', label: 'ultimate' }
   ];
   models.forEach(({name, label}) => {
       const b = document.createElement('button');


### PR DESCRIPTION
## Summary
- reorder the reasoning models so Codex appears before the o3 model

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_687b3be6546083238fa7763e912ce6f2