### PR TITLE
Update search model labels

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4370,37 +4370,41 @@ function initSearchTooltip(){
   searchTooltip.appendChild(tBtn);
 
   const models = [
-    'openrouter/perplexity/sonar',
-    'openrouter/perplexity/sonar-pro',
-    'openrouter/perplexity/sonar-reasoning',
-    'openrouter/perplexity/sonar-reasoning-pro',
-    'openai/gpt-4o-search-preview',
-    'openai/gpt-4o-mini-search-preview'
+    { name: 'openrouter/perplexity/sonar' },
+    { name: 'openrouter/perplexity/sonar-pro', label: 'pro' },
+    { name: 'openrouter/perplexity/sonar-reasoning', label: 'pro' },
+    { name: 'openrouter/perplexity/sonar-reasoning-pro', label: 'pro' },
+    { name: 'openai/gpt-4o-search-preview' },
+    { name: 'openai/gpt-4o-mini-search-preview', label: 'pro' }
   ];
-  models.forEach(m => {
+  models.forEach(({name, label}) => {
     const b = document.createElement('button');
-    b.dataset.model = m;
-    b.textContent = m;
-    b.classList.toggle('active', settingsCache.ai_search_model === m);
+    b.dataset.model = name;
+    if(label){
+      b.innerHTML = `<span class="model-label ${label}">${label}</span> ${name}`;
+    } else {
+      b.textContent = name;
+    }
+    b.classList.toggle('active', settingsCache.ai_search_model === name);
     b.addEventListener('click', async ev => {
       ev.stopPropagation();
-      await setSetting('ai_search_model', m);
-      settingsCache.ai_search_model = m;
+      await setSetting('ai_search_model', name);
+      settingsCache.ai_search_model = name;
       if(!searchEnabled){
         await toggleSearch();
       } else {
         await fetch('/api/chat/tabs/model', {
           method:'POST',
           headers:{'Content-Type':'application/json'},
-          body:JSON.stringify({tabId: currentTabId, model: m, sessionId})
+          body:JSON.stringify({tabId: currentTabId, model: name, sessionId})
         });
-        tabModelOverride = m;
-        modelName = m;
+        tabModelOverride = name;
+        modelName = name;
         updateModelHud();
       }
-      highlightSearchModel(m);
+      highlightSearchModel(name);
       hideSearchTooltip();
-      showToast(`Search model set to ${m}`);
+      showToast(`Search model set to ${name}`);
     });
     searchTooltip.appendChild(b);
   });

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1575,6 +1575,19 @@ button:disabled {
   background: #0062cc;
   color: #fff;
 }
+.search-tooltip .model-label {
+  display: inline-block;
+  font-size: 0.7em;
+  padding: 1px 4px;
+  margin-right: 4px;
+  border-radius: 4px;
+  background: #0062cc;
+  color: #fff;
+  text-transform: uppercase;
+}
+.search-tooltip .model-label.ultimate {
+  background: #8e44ad;
+}
 
 /* Minimal markdown highlighting */
 .md-h1,.md-h2,.md-h3,.md-h4,.md-h5,.md-h6{


### PR DESCRIPTION
## Summary
- mark gpt-4o-mini-search as a Pro model in the search tooltip
- mark Perplexity sonar-pro and sonar-reasoning models as Pro in the search tooltip
- style search tooltip model labels like the reasoning tooltip

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_687b3c171c9483239a7bb624cb630226