### PR TITLE
Update search model menu labels

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -616,10 +616,10 @@
     <div style="margin-top:8px;">
       <label>AI Search Model:
         <select id="globalAiSearchModelSelect">
-          <option value="openrouter/perplexity/sonar">openrouter/perplexity/sonar</option>
-          <option value="openrouter/perplexity/sonar-pro">openrouter/perplexity/sonar-pro</option>
-          <option value="openrouter/perplexity/sonar-reasoning">openrouter/perplexity/sonar-reasoning</option>
-          <option value="openrouter/perplexity/sonar-reasoning-pro">openrouter/perplexity/sonar-reasoning-pro</option>
+          <option value="openrouter/perplexity/sonar">perplexity/sonar</option>
+          <option value="openrouter/perplexity/sonar-pro">perplexity/sonar-pro</option>
+          <option value="openrouter/perplexity/sonar-reasoning">perplexity/sonar-reasoning</option>
+          <option value="openrouter/perplexity/sonar-reasoning-pro">perplexity/sonar-reasoning-pro</option>
           <option value="openai/gpt-4o-search-preview">openai/gpt-4o-search-preview</option>
           <option value="openai/gpt-4o-mini-search-preview">openai/gpt-4o-mini-search-preview</option>
         </select>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4377,10 +4377,13 @@ function initSearchTooltip(){
     'openai/gpt-4o-search-preview',
     'openai/gpt-4o-mini-search-preview'
   ];
+  function stripOpenrouterPrefix(m){
+    return m.startsWith('openrouter/') ? m.substring('openrouter/'.length) : m;
+  }
   models.forEach(m => {
     const b = document.createElement('button');
     b.dataset.model = m;
-    b.textContent = m;
+    b.textContent = stripOpenrouterPrefix(m);
     b.classList.toggle('active', settingsCache.ai_search_model === m);
     b.addEventListener('click', async ev => {
       ev.stopPropagation();
@@ -4400,7 +4403,7 @@ function initSearchTooltip(){
       }
       highlightSearchModel(m);
       hideSearchTooltip();
-      showToast(`Search model set to ${m}`);
+      showToast(`Search model set to ${stripOpenrouterPrefix(m)}`);
     });
     searchTooltip.appendChild(b);
   });


### PR DESCRIPTION
## Summary
- drop `openrouter/` prefix from search model dropdown labels
- show prefixless names inside the search model tooltip menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687b3cfac1a88323b2e4ae3e0830803d