### PR TITLE
Adjust model ordering and labels

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -617,11 +617,11 @@
       <label>AI Search Model:
         <select id="globalAiSearchModelSelect">
           <option value="openrouter/perplexity/sonar">openrouter/perplexity/sonar</option>
+          <option value="openai/gpt-4o-mini-search-preview">openai/gpt-4o-mini-search-preview</option>
           <option value="openrouter/perplexity/sonar-pro">openrouter/perplexity/sonar-pro</option>
           <option value="openrouter/perplexity/sonar-reasoning">openrouter/perplexity/sonar-reasoning</option>
           <option value="openrouter/perplexity/sonar-reasoning-pro">openrouter/perplexity/sonar-reasoning-pro</option>
           <option value="openai/gpt-4o-search-preview">openai/gpt-4o-search-preview</option>
-          <option value="openai/gpt-4o-mini-search-preview">openai/gpt-4o-mini-search-preview</option>
         </select>
       </label>
     </div>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4379,11 +4379,11 @@ function initSearchTooltip(){
 
   const models = [
     { name: 'openrouter/perplexity/sonar' },
+    { name: 'openai/gpt-4o-mini-search-preview' },
     { name: 'openrouter/perplexity/sonar-pro', label: 'pro' },
     { name: 'openrouter/perplexity/sonar-reasoning', label: 'pro' },
     { name: 'openrouter/perplexity/sonar-reasoning-pro', label: 'pro' },
-    { name: 'openai/gpt-4o-search-preview' },
-    { name: 'openai/gpt-4o-mini-search-preview', label: 'pro' }
+    { name: 'openai/gpt-4o-search-preview', label: 'pro' }
   ];
   models.forEach(({name, label}) => {
     const b = document.createElement('button');


### PR DESCRIPTION
## Summary
- reorder search models in Aurora
- mark `gpt-4o-search-preview` as a pro model
- move `gpt-4o-mini-search-preview` to free models list

## Testing
- `git show -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_687b3de68e4083239ff724b1b6a6f2b5