### PR TITLE
Fix static placement for project add tooltip

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2248,8 +2248,9 @@ function showProjectAddTooltip(project, e){
   initProjectAddTooltip();
   projectAddTooltipProject = project;
   projectAddTooltip.style.display = 'flex';
-  projectAddTooltip.style.left = (e.pageX + 8) + 'px';
-  projectAddTooltip.style.top = (e.pageY + 8) + 'px';
+  const rect = e.currentTarget.getBoundingClientRect();
+  projectAddTooltip.style.left = (rect.right + 4 + window.scrollX) + 'px';
+  projectAddTooltip.style.top = (rect.top + window.scrollY) + 'px';
   clearTimeout(projectAddTooltipTimer);
 }
 
@@ -2568,7 +2569,6 @@ function renderSidebarTabs(){
       addBtn.addEventListener("click", e => { e.stopPropagation(); quickAddTabToProject(project); });
       header.appendChild(addBtn);
       addBtn.addEventListener("mouseenter", e => showProjectAddTooltip(project, e));
-      addBtn.addEventListener("mousemove", e => showProjectAddTooltip(project, e));
       addBtn.addEventListener("mouseleave", scheduleHideProjectAddTooltip);
       header.addEventListener("click", e => {
         e.stopPropagation();


### PR DESCRIPTION
## Summary
- show the project add tooltip beside the + button instead of following the cursor
- stop updating tooltip position on mousemove

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687d11d726b08323ac603db3dfe1f68b