### PR TITLE
Disable search toggle when reasoning mode active

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4228,6 +4228,7 @@ function updateModelHud(){
 function updateSearchButton(){
   const btn = document.getElementById("searchToggleBtn");
   if(!btn) return;
+  btn.disabled = reasoningEnabled;
   btn.classList.toggle("active", searchEnabled);
 }
 


### PR DESCRIPTION
## Summary
- disable the search toggle button when reasoning mode is active

## Testing
- `npm test` *(fails: missing script)*
- `npm test` in `Aurora` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687d48ba4718832381cc3875069a62f1