### PR TITLE
Fix search highlight when AI disabled

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4591,6 +4591,11 @@ async function toggleAiResponses(){
   aiResponsesEnabled = !aiResponsesEnabled;
   await setSetting('ai_responses_enabled', aiResponsesEnabled);
   updateAiResponsesButton();
+  if(!aiResponsesEnabled && searchEnabled){
+    searchEnabled = false;
+    await setSetting('search_enabled', searchEnabled);
+    updateSearchButton();
+  }
 }
 
 async function enableSearchMode(query=""){ 


### PR DESCRIPTION
## Summary
- turn off `searchEnabled` when AI responses are disabled

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_687ed2fad64c8323803fffe90ed4fe41