### PR TITLE
Fix reasoning chat model selection disabling search

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4305,6 +4305,9 @@ function initReasoningTooltip(){
       if(reasoningEnabled){
         await toggleReasoning();
       }
+      if(searchEnabled){
+        await toggleSearch();
+      }
       await setSetting('ai_model', name);
       settingsCache.ai_model = name;
       await fetch('/api/chat/tabs/model', {


### PR DESCRIPTION
## Summary
- disable search when a reasoning chat model is selected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687ed78c4a5883239c867a9997bfdce3