### PR TITLE
Fix reasoning model button highlight

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4259,7 +4259,9 @@ let reasoningTooltipTimer = null;
 function highlightReasoningModel(model){
   if(!reasoningTooltip) return;
   Array.from(reasoningTooltip.querySelectorAll('button[data-model]')).forEach(b => {
-    const highlight = reasoningEnabled && b.dataset.model === model;
+    const isChatModel = reasoningChatModels.includes(b.dataset.model);
+    const highlight = (reasoningEnabled && !isChatModel && b.dataset.model === model) ||
+                      (!reasoningEnabled && isChatModel && b.dataset.model === model);
     b.classList.toggle('active', highlight);
   });
   updateReasoningButton();


### PR DESCRIPTION
## Summary
- fix highlight logic for selected chat models in reasoning tooltip

## Testing
- `npm run lint` (Aurora)
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687ed89f171883239e72de79415259c0