### PR TITLE
Fix search toggle disabled by reasoning mode

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4271,7 +4271,7 @@ function updateModelHud(){
 function updateSearchButton(){
   const btn = document.getElementById("searchToggleBtn");
   if(!btn) return;
-  btn.disabled = reasoningEnabled;
+  btn.disabled = false;
   btn.classList.toggle("active", searchEnabled);
 }
 


### PR DESCRIPTION
## Summary
- stop disabling the search button when reasoning is active

## Testing
- `npm test` *(fails: ENOENT because there is no root `package.json`)*
- `npm run lint` in `Aurora` *(no linter configured)*
- `npm test` in `Aurora` *(fails: missing script)*
- `npm test` in `Sterling` *(fails: missing script)*
- `npm test` in `AutoPR` *(prints 'No tests specified')*


------
https://chatgpt.com/codex/tasks/task_b_687f146a3c008323a7d09296f12fb0a2