### PR TITLE
Remove openrouter prefix from perplexity model labels

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -616,11 +616,11 @@
     <div style="margin-top:8px;">
       <label>AI Search Model:
         <select id="globalAiSearchModelSelect">
-          <option value="openrouter/perplexity/sonar">openrouter/perplexity/sonar</option>
+          <option value="openrouter/perplexity/sonar">perplexity/sonar</option>
           <option value="openai/gpt-4o-mini-search-preview">openai/gpt-4o-mini-search-preview</option>
-          <option value="openrouter/perplexity/sonar-pro">openrouter/perplexity/sonar-pro</option>
-          <option value="openrouter/perplexity/sonar-reasoning">openrouter/perplexity/sonar-reasoning</option>
-          <option value="openrouter/perplexity/sonar-reasoning-pro">openrouter/perplexity/sonar-reasoning-pro</option>
+          <option value="openrouter/perplexity/sonar-pro">perplexity/sonar-pro</option>
+          <option value="openrouter/perplexity/sonar-reasoning">perplexity/sonar-reasoning</option>
+          <option value="openrouter/perplexity/sonar-reasoning-pro">perplexity/sonar-reasoning-pro</option>
           <option value="openai/gpt-4o-search-preview">openai/gpt-4o-search-preview</option>
         </select>
       </label>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4545,14 +4545,14 @@ async function renderSearchModels(){
   await ensureAiModels();
   searchModelsContainer.innerHTML = '';
   const models = [
-    { name: 'openrouter/perplexity/sonar' },
+    { name: 'openrouter/perplexity/sonar', display: 'perplexity/sonar' },
     { name: 'openai/gpt-4o-mini-search-preview' },
-    { name: 'openrouter/perplexity/sonar-pro', label: 'pro' },
-    { name: 'openrouter/perplexity/sonar-reasoning', label: 'pro' },
-    { name: 'openrouter/perplexity/sonar-reasoning-pro', label: 'pro' },
+    { name: 'openrouter/perplexity/sonar-pro', label: 'pro', display: 'perplexity/sonar-pro' },
+    { name: 'openrouter/perplexity/sonar-reasoning', label: 'pro', display: 'perplexity/sonar-reasoning' },
+    { name: 'openrouter/perplexity/sonar-reasoning-pro', label: 'pro', display: 'perplexity/sonar-reasoning-pro' },
     { name: 'openai/gpt-4o-search-preview', label: 'pro' }
   ];
-  models.forEach(({name,label}) => {
+  models.forEach(({name,label,display}) => {
     const fav = isModelFavorite(name);
     if(!searchFavoritesEdit && !fav) return;
     const row = document.createElement('div');
@@ -4574,10 +4574,11 @@ async function renderSearchModels(){
     }
     const b = document.createElement('button');
     b.dataset.model = name;
+    const text = display || name;
     if(label){
-      b.innerHTML = `<span class="model-label ${label}">${label}</span> ${name}`;
+      b.innerHTML = `<span class="model-label ${label}">${label}</span> ${text}`;
     } else {
-      b.textContent = name;
+      b.textContent = text;
     }
     b.classList.toggle('active', settingsCache.ai_search_model === name);
     b.addEventListener('click', async ev => {
@@ -4598,7 +4599,7 @@ async function renderSearchModels(){
       }
       highlightSearchModel(name);
       hideSearchTooltip();
-      showToast(`Search model set to ${name}`);
+      showToast(`Search model set to ${display || name}`);
     });
     row.appendChild(b);
     searchModelsContainer.appendChild(row);


### PR DESCRIPTION
## Summary
- show Perplexity models in the search dropdown without the `openrouter/` prefix
- adjust search model buttons to display shorter labels while keeping underlying IDs

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_687fcfd0fe248323a3d7a06f94cbc7c8