### PR TITLE
Add Search header to tooltip

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4510,6 +4510,11 @@ async function initSearchTooltip(){
   });
   searchTooltip.appendChild(tBtn);
 
+  const searchHeader = document.createElement('div');
+  searchHeader.textContent = 'Search';
+  searchHeader.className = 'tooltip-section-header';
+  searchTooltip.appendChild(searchHeader);
+
   searchModelsContainer = document.createElement('div');
   searchTooltip.appendChild(searchModelsContainer);
 


### PR DESCRIPTION
## Summary
- show a "Search" section header inside the search tooltip

## Testing
- `npm run lint` in `Aurora`
- `npm test` in `Aurora` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_687fcff11cd88323bbe3bc5557403a68