### PR TITLE
Fix token usage cost calculation

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3307,7 +3307,10 @@ function getModelCost(modelId, inputTokens, outputTokens) {
   const inRate = parseFloat(String(info.inputCost || '').replace('$', ''));
   const outRate = parseFloat(String(info.outputCost || '').replace('$', ''));
   if (isNaN(inRate) || isNaN(outRate)) return null;
-  const cost = (inputTokens / 1000) * inRate + (outputTokens / 1000) * outRate;
+  // Pricing data is stored per one million tokens. Adjust calculation
+  // accordingly so displayed costs match official rates.
+  const cost = (inputTokens / 1_000_000) * inRate +
+               (outputTokens / 1_000_000) * outRate;
   return cost;
 }
 

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1488,6 +1488,8 @@ app.get("/api/ai/models", async (req, res) => {
     "openai/gpt-3.5-turbo-0301": "--"
   };
 
+  // Known model costs are stored per one million tokens so that the
+  // frontend can easily convert to user-facing pricing.
   const knownCosts = {
     "openai/gpt-4o-mini": { input: "$0.15", output: "$0.60" },
     "openai/gpt-4.1": { input: "$2", output: "$8" },


### PR DESCRIPTION
## Summary
- correct token cost calculations to use pricing per million tokens
- document pricing units in server

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687fec7cb64883238ec65cca336d038b