### PR TITLE
Fix favorites for missing AI models

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3361,7 +3361,11 @@ async function toggleModelFavorite(id, fav){
     if(r.ok){
       if(window.allAiModels){
         const idx = window.allAiModels.findIndex(m=>m.id===id);
-        if(idx>=0) window.allAiModels[idx].favorite = fav;
+        if(idx>=0){
+          window.allAiModels[idx].favorite = fav;
+        } else {
+          window.allAiModels.push({id, favorite: fav});
+        }
       }
       return true;
     }

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1596,6 +1596,24 @@ app.get("/api/ai/models", async (req, res) => {
         console.error("[TaskQueue] Error fetching OpenRouter models:", err);
       }
     }
+
+    // Ensure certain known models are always included even if not returned
+    // by the provider APIs so that users can favorite them.
+    const forcedModels = ["openai/o4-mini-high", "openai/codex-mini"];
+    for (const id of forcedModels) {
+      if (!openAIModelData.find((m) => m.id === id) &&
+          !openRouterModelData.find((m) => m.id === id)) {
+        const limit = knownTokenLimits[id] || "N/A";
+        const cInfo = knownCosts[id] ? knownCosts[id] : { input: "N/A", output: "N/A" };
+        openAIModelData.push({
+          id,
+          provider: "openai",
+          tokenLimit: limit,
+          inputCost: cInfo.input,
+          outputCost: cInfo.output,
+        });
+      }
+    }
   } catch (err) {
     console.error("[TaskQueue] /api/ai/models error:", err);
   }


### PR DESCRIPTION
## Summary
- ensure `/api/ai/models` always includes `openai/o4-mini-high` and `openai/codex-mini`
- update client-side favorites handling to add unknown models to the local cache

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6880151209d4832395683065d591fc9f