### PR TITLE
Update AI toggle to show Disabled state

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4299,7 +4299,13 @@ function updateAiResponsesButton(){
   if(!reasoningTooltip) return;
   const btn = reasoningTooltip.querySelector('button[data-action="toggle-ai"]');
   if(btn){
-    btn.textContent = aiResponsesEnabled ? 'Disable AI' : 'Enable AI';
+    if(aiResponsesEnabled){
+      btn.textContent = 'Disable AI';
+      btn.classList.remove('active');
+    } else {
+      btn.textContent = 'Disabled';
+      btn.classList.add('active');
+    }
   }
 }
 
@@ -4363,7 +4369,13 @@ async function initReasoningTooltip(){
 
   const disableBtn = document.createElement('button');
   disableBtn.dataset.action = 'toggle-ai';
-  disableBtn.textContent = aiResponsesEnabled ? 'Disable AI' : 'Enable AI';
+  if(aiResponsesEnabled){
+    disableBtn.textContent = 'Disable AI';
+    disableBtn.classList.remove('active');
+  } else {
+    disableBtn.textContent = 'Disabled';
+    disableBtn.classList.add('active');
+  }
   disableBtn.addEventListener('click', async ev => {
     ev.stopPropagation();
     await toggleAiResponses();


### PR DESCRIPTION
## Summary
- change AI toggle button to display `Disabled` text when AI responses are off
- highlight disabled state in blue using the existing `.active` class

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68801e3a6da883238e2939bc2a48a858