### PR TITLE
Auto-enable AI on model select

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4462,6 +4462,9 @@ async function renderReasoningModels(){
                                             : settingsCache.ai_reasoning_model===name));
     b.addEventListener('click', async ev => {
       ev.stopPropagation();
+      if(!aiResponsesEnabled){
+        await toggleAiResponses();
+      }
       if(container===reasoningChatContainer){
         if(reasoningEnabled){ await toggleReasoning(); }
         if(searchEnabled){ await toggleSearch(); }
@@ -4611,6 +4614,9 @@ async function renderSearchModels(){
       ev.stopPropagation();
       await setSetting('ai_search_model', name);
       settingsCache.ai_search_model = name;
+      if(!aiResponsesEnabled){
+        await toggleAiResponses();
+      }
       if(!searchEnabled){
         await toggleSearch();
       } else {


### PR DESCRIPTION
## Summary
- ensure selecting a reasoning or search model re-enables AI responses

## Testing
- `npm run lint --prefix Aurora`

------
https://chatgpt.com/codex/tasks/task_b_688021fbf3d483239531db3362e521eb