### PR TITLE
Fix permission issue in run script

### DIFF
--- a/run_full.sh
+++ b/run_full.sh
@@ -20,6 +20,14 @@ if [ "$persist" != true ]; then
   clear
 fi
 
+# Ensure we have permission to modify files under the Aurora directory. If
+# package-lock.json is not writable, attempt to fix the permissions using sudo.
+PKG_LOCK="Aurora/package-lock.json"
+if [ ! -w "$PKG_LOCK" ]; then
+  echo "package-lock.json is not writable. Attempting to fix with sudo..."
+  sudo chown -R $(whoami):$(whoami) "$(dirname "$PKG_LOCK")" || sudo chmod -R u+w "$(dirname "$PKG_LOCK")"
+fi
+
 sudo git stash
 sudo git pull
 #git log -n 3


### PR DESCRIPTION
## Summary
- ensure `Aurora/package-lock.json` is writable before running the project

## Testing
- `bash -n run_full.sh`


------
https://chatgpt.com/codex/tasks/task_b_6880303b775c8323a3417096a6531ae0