### PR TITLE
Fix perplexity model handling

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -273,6 +273,8 @@ function parseProviderModel(model) {
     return { provider: "openrouter", shortModel: model.replace(/^openrouter\//, "") };
   } else if (model.startsWith("deepseek/")) {
     return { provider: "openrouter", shortModel: model.replace(/^deepseek\//, "") };
+  } else if (model.startsWith("perplexity/")) {
+    return { provider: "perplexity", shortModel: model.replace(/^perplexity\//, "") };
   }
   return { provider: "Unknown", shortModel: model };
 }
@@ -1916,7 +1918,7 @@ app.post("/api/chat", async (req, res) => {
       return m;
     }
     const modelForOpenAI = stripModelPrefix(model);
-    const usePerplexity = provider === 'openrouter' && modelForOpenAI.startsWith('perplexity/');
+    const usePerplexity = provider === 'perplexity';
 
     console.debug("[Server Debug] Using model =>", model, " (stripped =>", modelForOpenAI, ")");
     const encoder = getEncoding(modelForOpenAI);


### PR DESCRIPTION
## Summary
- handle `perplexity/*` models in `parseProviderModel`
- only call the Perplexity API when provider is explicitly `perplexity`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_688036d8e3908323820a20e7c2207631