### PR TITLE
Update Perplexity defaults for 2025 API

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -616,13 +616,13 @@
     <div style="margin-top:8px;">
       <label>AI Search Model:
         <select id="globalAiSearchModelSelect">
-          <option value="openrouter/perplexity/sonar">perplexity/sonar</option>
+          <option value="sonar-medium-online">sonar-medium-online</option>
           <option value="openai/gpt-4o-mini-search-preview">openai/gpt-4o-mini-search-preview</option>
-          <option value="openrouter/perplexity/sonar-pro">perplexity/sonar-pro</option>
-          <option value="openrouter/perplexity/sonar-reasoning">perplexity/sonar-reasoning</option>
-          <option value="openrouter/perplexity/sonar-reasoning-pro">perplexity/sonar-reasoning-pro</option>
-          <option value="openai/gpt-4o-search-preview">openai/gpt-4o-search-preview</option>
-        </select>
+          <option value="sonar-small-online">sonar-small-online</option>
+          <option value="sonar-medium-chat">sonar-medium-chat</option>
+          <option value="sonar-small-chat">sonar-small-chat</option>
+         <option value="openai/gpt-4o-search-preview">openai/gpt-4o-search-preview</option>
+       </select>
       </label>
     </div>
     <div style="margin-top:8px;">

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4574,11 +4574,11 @@ async function renderSearchModels(){
   await ensureAiModels();
   searchModelsContainer.innerHTML = '';
   const models = [
-    { name: 'openrouter/perplexity/sonar', display: 'perplexity/sonar' },
+    { name: 'sonar-medium-online', display: 'sonar-medium-online' },
     { name: 'openai/gpt-4o-mini-search-preview' },
-    { name: 'openrouter/perplexity/sonar-pro', label: 'pro', display: 'perplexity/sonar-pro' },
-    { name: 'openrouter/perplexity/sonar-reasoning', label: 'pro', display: 'perplexity/sonar-reasoning' },
-    { name: 'openrouter/perplexity/sonar-reasoning-pro', label: 'pro', display: 'perplexity/sonar-reasoning-pro' },
+    { name: 'sonar-small-online', label: 'pro', display: 'sonar-small-online' },
+    { name: 'sonar-medium-chat', label: 'pro', display: 'sonar-medium-chat' },
+    { name: 'sonar-small-chat', label: 'pro', display: 'sonar-small-chat' },
     { name: 'openai/gpt-4o-search-preview', label: 'pro' }
   ];
   models.forEach(({name,label,display}) => {
@@ -4648,7 +4648,7 @@ async function toggleSearch(){
   await setSetting("search_enabled", searchEnabled);
   if(searchEnabled){
     previousModelName = modelName; // remember current model
-    const searchModel = await getSetting("ai_search_model") || "openrouter/perplexity/sonar";
+    const searchModel = await getSetting("ai_search_model") || "sonar-medium-online";
     await fetch("/api/chat/tabs/model", {
       method:"POST",
       headers:{"Content-Type":"application/json"},
@@ -4683,7 +4683,7 @@ async function toggleReasoning(){
   await setSetting("reasoning_enabled", reasoningEnabled);
   if(reasoningEnabled){
     reasoningPreviousModelName = modelName; // remember current model
-    const reasoningModel = await getSetting("ai_reasoning_model") || "openrouter/perplexity/sonar-reasoning";
+    const reasoningModel = await getSetting("ai_reasoning_model") || "sonar-medium-chat";
     await fetch("/api/chat/tabs/model", {
       method:"POST",
       headers:{"Content-Type":"application/json"},
@@ -4763,7 +4763,7 @@ async function enableSearchMode(query=""){
   if(!searchEnabled){
     searchEnabled = true;
     previousModelName = modelName;
-    const searchModel = await getSetting("ai_search_model") || "openrouter/perplexity/sonar";
+    const searchModel = await getSetting("ai_search_model") || "sonar-medium-online";
     await fetch("/api/chat/tabs/model", {
       method:"POST",
       headers:{"Content-Type":"application/json"},

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -116,8 +116,8 @@ if (envModel) {
 console.debug("[Server Debug] Checking or setting default 'ai_search_model' in DB...");
 const currentSearchModel = db.getSetting("ai_search_model");
 if (!currentSearchModel) {
-  console.debug("[Server Debug] 'ai_search_model' is missing in DB, setting default to 'openrouter/perplexity/sonar'.");
-  db.setSetting("ai_search_model", "openrouter/perplexity/sonar");
+  console.debug("[Server Debug] 'ai_search_model' is missing in DB, setting default to 'sonar-medium-online'.");
+  db.setSetting("ai_search_model", "sonar-medium-online");
 } else {
   console.debug("[Server Debug] 'ai_search_model' found =>", currentSearchModel);
 }
@@ -134,8 +134,8 @@ if (!currentChatSearchModel) {
 console.debug("[Server Debug] Checking or setting default 'ai_reasoning_model' in DB...");
 const currentReasoningModel = db.getSetting("ai_reasoning_model");
 if (!currentReasoningModel) {
-  console.debug("[Server Debug] 'ai_reasoning_model' is missing in DB, setting default to 'openrouter/perplexity/sonar-reasoning'.");
-  db.setSetting("ai_reasoning_model", "openrouter/perplexity/sonar-reasoning");
+  console.debug("[Server Debug] 'ai_reasoning_model' is missing in DB, setting default to 'sonar-medium-chat'.");
+  db.setSetting("ai_reasoning_model", "sonar-medium-chat");
 } else {
   console.debug("[Server Debug] 'ai_reasoning_model' found =>", currentReasoningModel);
 }
@@ -277,6 +277,11 @@ function parseProviderModel(model) {
     return { provider: "openrouter", shortModel: model.replace(/^deepseek\//, "") };
   } else if (model.startsWith("perplexity/")) {
     return { provider: "perplexity", shortModel: model.replace(/^perplexity\//, "") };
+  } else if (model.startsWith("sonar-") ||
+             model.startsWith("mistral-") ||
+             model.startsWith("llama-") ||
+             model.startsWith("codellama-")) {
+    return { provider: "perplexity", shortModel: model };
   }
   return { provider: "Unknown", shortModel: model };
 }
@@ -2132,7 +2137,7 @@ app.post("/api/chat/tabs/new", (req, res) => {
     const { id: tabId, uuid } = db.createChatTab(name, nexum, project, repo, extraProjects, taskId, type, sessionId);
     res.json({ success: true, id: tabId, uuid });
     if (type === 'search') {
-      const searchModel = db.getSetting('ai_search_model') || 'openrouter/perplexity/sonar';
+      const searchModel = db.getSetting('ai_search_model') || 'sonar-medium-online';
       db.setChatTabModel(tabId, searchModel);
     } else {
       createInitialTabMessage(tabId, type, sessionId).catch(e =>
@@ -3705,7 +3710,7 @@ app.get("/search", (req, res) => {
       sessionId
     );
     const searchModel =
-      db.getSetting("ai_search_model") || "openrouter/perplexity/sonar";
+      db.getSetting("ai_search_model") || "sonar-medium-online";
     db.setChatTabModel(tabId, searchModel);
     const query = q ? `?search=1&q=${encodeURIComponent(q)}` : "?search=1";
     return res.redirect(`/chat/${uuid}${query}`);
@@ -3731,7 +3736,7 @@ app.get("/new", (req, res) => {
     );
     if (openSearch) {
       const searchModel =
-        db.getSetting("ai_search_model") || "openrouter/perplexity/sonar";
+        db.getSetting("ai_search_model") || "sonar-medium-online";
       db.setChatTabModel(tabId, searchModel);
     }
     db.setSetting("last_chat_tab", tabId);

--- a/README.md
+++ b/README.md
@@ -91,3 +91,27 @@ chmod +x perplexity-cli.js
 
 The script outputs the answer and lists cited URLs if available.
 
+## Perplexity API Quick Reference (2025)
+
+The CLI follows Perplexity's official API which mirrors the OpenAI Chat
+Completions format. Set your API key in the `PERPLEXITY_API_KEY` environment
+variable and send requests to `https://api.perplexity.ai/chat/completions`.
+
+```json
+{
+  "model": "sonar-medium-online",
+  "messages": [
+    { "role": "system", "content": "You are a helpful assistant." },
+    { "role": "user", "content": "Who discovered penicillin?" }
+  ],
+  "max_tokens": 512,
+  "temperature": 0.7
+}
+```
+
+Responses include optional `citations` and `search_results` arrays with the
+source URLs used. Common errors are a `400 Bad Request` when the model name is
+wrong and `401`/`403` for missing or invalid API keys. Use plain Sonar model
+names such as `sonar-medium-online` or `sonar-medium-chat` without any provider
+prefix.
+


### PR DESCRIPTION
## Summary
- switch default Perplexity models to `sonar-medium` names
- detect new model names when parsing providers
- update front-end dropdowns and logic for new model ids
- document Perplexity API usage in README

## Testing
- `node perplexity-cli.js --help` *(fails: Cannot find module 'axios')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68804148576c8323b2d83b70ae22dcb2