### PR TITLE
Update perplexity CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,9 @@ chmod +x perplexity-cli.js
 
 The script outputs the answer and lists cited URLs if available.
 
+The CLI automatically strips any `perplexity/` or
+`openrouter/perplexity/` prefix from the model name and maps
+deprecated `pplx-*` identifiers to their Sonar equivalents. This
+prevents the **HTTP 400** errors that occur when old model strings are
+sent to the Perplexity API.
+

--- a/perplexity-cli.js
+++ b/perplexity-cli.js
@@ -15,13 +15,25 @@ const options = program.opts();
 const query = program.args.join(' ');
 const apiKey = options.key || process.env.PERPLEXITY_API_KEY;
 
+function normalizeModel(model) {
+  if (!model) return 'sonar-medium-online';
+  // Strip deprecated prefixes used by some clients
+  model = model.replace(/^openrouter\/perplexity\//, '');
+  model = model.replace(/^perplexity\//, '');
+  const aliases = {
+    'pplx-7b-online': 'sonar-small-online',
+    'pplx-70b-chat': 'sonar-medium-chat',
+  };
+  return aliases[model] || model;
+}
+
 if (!apiKey) {
   console.error('Error: API key required. Use --key or set PERPLEXITY_API_KEY');
   process.exit(1);
 }
 
 axios.post('https://api.perplexity.ai/chat/completions', {
-  model: options.model,
+  model: normalizeModel(options.model),
   messages: [{ role: 'user', content: query }],
 }, {
   headers: {


### PR DESCRIPTION
## Summary
- normalize model names in `perplexity-cli.js`
- document how the CLI strips deprecated prefixes

## Testing
- `node -e "require('./perplexity-cli.js');"` *(fails without API key as expected)*

------
https://chatgpt.com/codex/tasks/task_b_68804148576c8323b2d83b70ae22dcb2