### PR TITLE
Fix Sonar model detection

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -277,7 +277,8 @@ function parseProviderModel(model) {
     return { provider: "openrouter", shortModel: model.replace(/^deepseek\//, "") };
   } else if (model.startsWith("perplexity/")) {
     return { provider: "perplexity", shortModel: model.replace(/^perplexity\//, "") };
-  } else if (model.startsWith("sonar-") ||
+  } else if (model.startsWith("sonar") ||
+             model === "r1-1776" ||
              model.startsWith("mistral-") ||
              model.startsWith("llama-") ||
              model.startsWith("codellama-")) {


### PR DESCRIPTION
## Summary
- improve `parseProviderModel` to treat `sonar` and `r1-1776` models as Perplexity

## Testing
- `npm run start` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_68805bacb3888323b37d0976a635b9c2