### PR TITLE
Add input token counter to Aurora chat

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -324,6 +324,7 @@
         </button>
         <button id="chatGenImageBtn" class="send-btn" title="" hidden></button>
       </div>
+      <div id="inputTokenCount" class="token-counter">0 tokens</div>
       <div id="imagePreviewArea" style="margin:8px 0;"></div>
       <div id="imageProcessingIndicator" style="display:none; color:#f0f; margin:8px 0;">Processing image, please wait...</div>
     </div>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3379,6 +3379,21 @@ const chatInputEl = document.getElementById("chatInput");
 const chatSendBtnEl = document.getElementById("chatSendBtn");
 const waitingElem = document.getElementById("waitingCounter");
 const scrollDownBtnEl = document.getElementById("scrollDownBtn");
+const tokenCounterEl = document.getElementById("inputTokenCount");
+
+function updateInputTokenCount(){
+  if(!tokenCounterEl) return;
+  try{
+    const enc = getEncoding(modelName);
+    const count = countTokens(enc, chatInputEl.value);
+    tokenCounterEl.textContent = `${count} token${count===1?'':'s'}`;
+  }catch(e){
+    tokenCounterEl.textContent = '';
+  }
+}
+
+chatInputEl.addEventListener("input", updateInputTokenCount);
+updateInputTokenCount();
 
 setLoopUi(imageLoopEnabled);
 
@@ -3403,6 +3418,7 @@ chatInputEl.addEventListener("keydown", (e) => {
       setTimeout(() => {
         chatInputEl.setSelectionRange(chatInputEl.value.length, chatInputEl.value.length);
       }, 0);
+      updateInputTokenCount();
     }
     e.preventDefault();
   } else if (upArrowHistoryEnabled && e.key === "ArrowDown") {
@@ -3410,9 +3426,11 @@ chatInputEl.addEventListener("keydown", (e) => {
       if (inputHistoryPos >= 0 && inputHistoryPos < inputHistory.length - 1) {
         inputHistoryPos++;
         chatInputEl.value = inputHistory[inputHistoryPos] || "";
+        updateInputTokenCount();
       } else {
         inputHistoryPos = -1;
         chatInputEl.value = "";
+        updateInputTokenCount();
       }
       setTimeout(() => {
         chatInputEl.setSelectionRange(chatInputEl.value.length, chatInputEl.value.length);
@@ -3424,6 +3442,7 @@ chatInputEl.addEventListener("keydown", (e) => {
     if(chatSendBtnEl.disabled && chatQueueEnabled){
       queueMessage(chatInputEl.value.trim());
       chatInputEl.value = "";
+      updateInputTokenCount();
     } else {
       chatSendBtnEl.click();
     }
@@ -3503,6 +3522,7 @@ chatSendBtnEl.addEventListener("click", async () => {
   // If user typed nothing but we have desc subbubbles, we can still show them in a single bubble
   if(!userMessage && descsForThisSend.length>0){
     chatInputEl.value = "";
+    updateInputTokenCount();
   } else if(!userMessage && descsForThisSend.length===0){
     if (favElement) favElement.href = defaultFavicon;
     chatSendBtnEl.disabled = false;
@@ -3512,6 +3532,7 @@ chatSendBtnEl.addEventListener("click", async () => {
   }
 
   chatInputEl.value = "";
+  updateInputTokenCount();
 
   // Create the single chat-sequence
   const seqDiv = document.createElement("div");

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -774,6 +774,14 @@ body {
   margin-top: 10px;
 }
 
+/* Token counter shown below the chat input */
+.token-counter {
+  color: #aaa;
+  font-size: 0.8rem;
+  margin-top: 4px;
+  text-align: right;
+}
+
 /* Citation card shown below AI reply */
 .chat-citations {
   background: #2a2a2a;


### PR DESCRIPTION
## Summary
- show token counter under the chat input box
- style the new `.token-counter` element
- update `main.js` to calculate token usage as text is typed

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68804d888ca4832388c11630ac535e18