### PR TITLE
Support archived-context chats

### DIFF
--- a/Sterling/executable/server_webserver.js
+++ b/Sterling/executable/server_webserver.js
@@ -385,19 +385,22 @@ function getActiveInactiveChats(jsonObj) {
     const activeChats = [];
     const inactiveChats = [];
     const archivedChats = [];
+    const archivedContextChats = [];
     for (const key of Object.keys(jsonObj)) {
         const chatNumber = parseInt(key, 10);
         if (isNaN(chatNumber)) continue;
         const status = (jsonObj[key].status || "INACTIVE").toUpperCase();
         if (status === "ACTIVE") {
             activeChats.push({ number: chatNumber, status: "ACTIVE" });
+        } else if (status === "ARCHIVED_CONTEXT") {
+            archivedContextChats.push({ number: chatNumber, status: "ARCHIVED_CONTEXT" });
         } else if (status === "ARCHIVED") {
             archivedChats.push({ number: chatNumber, status: "ARCHIVED" });
         } else {
             inactiveChats.push({ number: chatNumber, status: "INACTIVE" });
         }
     }
-    return { activeChats, inactiveChats, archivedChats };
+    return { activeChats, inactiveChats, archivedChats, archivedContextChats };
 }
 
 /**

--- a/Sterling/executable/views/chat.ejs
+++ b/Sterling/executable/views/chat.ejs
@@ -179,12 +179,18 @@
                 <button type="submit" class="form-buttons">Deactivate</button>
             </form>
             <% } %>
-            <% if (status !== 'ARCHIVED') { %>
+            <% if (status !== 'ARCHIVED' && status !== 'ARCHIVED_CONTEXT') { %>
             <form action="/<%= gitRepoNameCLI %>/chat/<%= chatNumber %>/archive"
                   method="POST"
                   style="display:inline;"
                   onsubmit="return confirm('Archive this chat?');">
                 <button type="submit" class="form-buttons">Archive</button>
+            </form>
+            <form action="/<%= gitRepoNameCLI %>/chat/<%= chatNumber %>/archive_plain"
+                  method="POST"
+                  style="display:inline;"
+                  onsubmit="return confirm('Archive without context?');">
+                <button type="submit" class="form-buttons">Archive Only</button>
             </form>
             <% } else { %>
             <form action="/<%= gitRepoNameCLI %>/chat/<%= chatNumber %>/unarchive"

--- a/Sterling/executable/views/chats.ejs
+++ b/Sterling/executable/views/chats.ejs
@@ -55,11 +55,16 @@
                           onsubmit="return confirm('Are you sure you want to deactivate this chat?');">
                         <button type="submit">Deactivate</button>
                     </form>
-                    <!-- Archive form -->
+                    <!-- Archive form (default adds to context) -->
                     <form action="/<%= gitRepoNameCLI %>/chat/<%= chat.number %>/archive"
                           method="POST"
                           onsubmit="return confirm('Archive this chat?');">
                         <button type="submit">Archive</button>
+                    </form>
+                    <form action="/<%= gitRepoNameCLI %>/chat/<%= chat.number %>/archive_plain"
+                          method="POST"
+                          onsubmit="return confirm('Archive without context?');">
+                        <button type="submit">Archive Only</button>
                     </form>
                 </div>
             </li>
@@ -86,6 +91,11 @@
                           onsubmit="return confirm('Archive this chat?');">
                         <button type="submit">Archive</button>
                     </form>
+                    <form action="/<%= gitRepoNameCLI %>/chat/<%= chat.number %>/archive_plain"
+                          method="POST"
+                          onsubmit="return confirm('Archive without context?');">
+                        <button type="submit">Archive Only</button>
+                    </form>
                 </div>
             </li>
         <% }); %>
@@ -98,6 +108,27 @@
         <li>No archived chats available.</li>
     <% } else { %>
         <% archivedChats.forEach(function(chat) { %>
+            <li>
+                Chat <%= chat.number %> - Status: <%= chat.status %>
+                <div class="actions">
+                    <button onclick="window.location.href='/<%= gitRepoNameCLI %>/chat/<%= chat.number %>'">
+                        Enter Chat
+                    </button>
+                    <form action="/<%= gitRepoNameCLI %>/chat/<%= chat.number %>/unarchive" method="POST" onsubmit="return confirm('Unarchive this chat?');">
+                        <button type="submit">Unarchive</button>
+                    </form>
+                </div>
+            </li>
+        <% }); %>
+    <% } %>
+</ul>
+
+<h2>Archived-Context Chats:</h2>
+<ul class="chat-list">
+    <% if (archivedContextChats.length === 0) { %>
+        <li>No archived-context chats available.</li>
+    <% } else { %>
+        <% archivedContextChats.forEach(function(chat) { %>
             <li>
                 Chat <%= chat.number %> - Status: <%= chat.status %>
                 <div class="actions">

--- a/Sterling/executable/webserver/get_routes.js
+++ b/Sterling/executable/webserver/get_routes.js
@@ -68,13 +68,14 @@ function setupGetRoutes(deps) {
     app.get("/:repoName/chats", (req, res) => {
         const repoName = req.params.repoName;
         const dataObj = loadRepoJson(repoName);
-        const { activeChats, inactiveChats, archivedChats } = getActiveInactiveChats(dataObj);
+        const { activeChats, inactiveChats, archivedChats, archivedContextChats } = getActiveInactiveChats(dataObj);
 
         res.render("chats", {
             gitRepoNameCLI: repoName,
             activeChats,
             inactiveChats,
             archivedChats,
+            archivedContextChats,
         });
     });
 

--- a/Sterling/executable/webserver/post_routes.js
+++ b/Sterling/executable/webserver/post_routes.js
@@ -127,6 +127,18 @@ function setupPostRoutes(deps) {
     });
 
     app.post("/:repoName/chat/:chatNumber/archive", (req, res) => {
+        // Default archive behavior adds to archived-context
+        const { repoName, chatNumber } = req.params;
+        const dataObj = loadRepoJson(repoName);
+        const chatData = dataObj[chatNumber];
+        if (!chatData) return res.status(404).send("Chat not found.");
+        chatData.status = "ARCHIVED_CONTEXT";
+        dataObj[chatNumber] = chatData;
+        saveRepoJson(repoName, dataObj);
+        res.redirect(`/${repoName}/chats`);
+    });
+
+    app.post("/:repoName/chat/:chatNumber/archive_plain", (req, res) => {
         const { repoName, chatNumber } = req.params;
         const dataObj = loadRepoJson(repoName);
         const chatData = dataObj[chatNumber];


### PR DESCRIPTION
## Summary
- distinguish between archived and archived-context chats
- default archive button stores chats in `ARCHIVED_CONTEXT`
- support `Archive Only` for plain archived
- display archived-context chats separately

## Testing
- `npx ejs-lint Sterling/executable/views/chat.ejs Sterling/executable/views/chats.ejs` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_688092bdfd6c83239024f4b9ac267605