### PR TITLE
Add draggable project headers

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -861,6 +861,13 @@ body {
   display: flex;
   align-items: center;
 }
+#verticalTabsContainer .tab-project-header .drag-handle {
+  cursor: move;
+  margin-right: 4px;
+}
+#verticalTabsContainer .tab-project-header.drag-over {
+  border: 1px dashed #aaa;
+}
 #verticalTabsContainer .project-collapse-arrow {
   margin-right: 4px;
 }


### PR DESCRIPTION
## Summary
- add ability to reorder project headers with drag handles
- persist project header order in localStorage
- style project header drag handles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68816b7df2808323baf170d6c4a564c0