### PR TITLE
Enable collapsible archived tabs by project

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -861,6 +861,15 @@ body {
   display: flex;
   align-items: center;
 }
+#archivedTabsContainer .tab-project-header {
+  margin: 6px 0 2px;
+  font-size: 0.9rem;
+  color: #aaa;
+  font-weight: bold;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
 #verticalTabsContainer .tab-project-header .drag-handle {
   cursor: move;
   margin-right: 4px;
@@ -869,6 +878,9 @@ body {
   border: 1px dashed #aaa;
 }
 #verticalTabsContainer .project-collapse-arrow {
+  margin-right: 4px;
+}
+#archivedTabsContainer .project-collapse-arrow {
   margin-right: 4px;
 }
 
@@ -956,6 +968,9 @@ body {
   border-color: #aaa;
 }
 #verticalTabsContainer .project-indented {
+  margin-left: 10px;
+}
+#archivedTabsContainer .project-indented {
   margin-left: 10px;
 }
 


### PR DESCRIPTION
## Summary
- allow collapsed archive groups to persist using new `collapsedArchiveGroups` setting
- default archived project groups collapsed and sorted like chat tabs
- display collapsible headers and indent archived tab rows

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68816dd68f00832385973b9571ebbfbd