### PR TITLE
Add openrouter perplexity model options

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -618,11 +618,17 @@
       <label>AI Search Model:
         <select id="globalAiSearchModelSelect">
           <option value="sonar">sonar</option>
+          <option value="openrouter/perplexity/sonar">openrouter/perplexity/sonar</option>
           <option value="sonar-pro">sonar-pro</option>
+          <option value="openrouter/perplexity/sonar-pro">openrouter/perplexity/sonar-pro</option>
           <option value="sonar-reasoning">sonar-reasoning</option>
+          <option value="openrouter/perplexity/sonar-reasoning">openrouter/perplexity/sonar-reasoning</option>
           <option value="sonar-reasoning-pro">sonar-reasoning-pro</option>
+          <option value="openrouter/perplexity/sonar-reasoning-pro">openrouter/perplexity/sonar-reasoning-pro</option>
           <option value="sonar-deep-research">sonar-deep-research</option>
+          <option value="openrouter/perplexity/sonar-deep-research">openrouter/perplexity/sonar-deep-research</option>
           <option value="r1-1776">r1-1776</option>
+          <option value="openrouter/perplexity/r1-1776">openrouter/perplexity/r1-1776</option>
           <option value="openai/gpt-4o-mini-search-preview">openai/gpt-4o-mini-search-preview</option>
           <option value="openai/gpt-4o-search-preview">openai/gpt-4o-search-preview</option>
        </select>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4596,11 +4596,17 @@ async function renderSearchModels(){
   searchModelsContainer.innerHTML = '';
   const models = [
     { name: 'sonar', note: 'lightweight, web-grounded' },
+    { name: 'openrouter/perplexity/sonar', note: 'lightweight, web-grounded' },
     { name: 'sonar-pro', note: 'advanced search model' },
+    { name: 'openrouter/perplexity/sonar-pro', label: 'pro', note: 'advanced search model' },
     { name: 'sonar-reasoning', note: 'fast, real-time reasoning (search)' },
+    { name: 'openrouter/perplexity/sonar-reasoning', label: 'pro', note: 'fast, real-time reasoning (search)' },
     { name: 'sonar-reasoning-pro', note: 'higher-accuracy CoT reasoning' },
+    { name: 'openrouter/perplexity/sonar-reasoning-pro', label: 'pro', note: 'higher-accuracy CoT reasoning' },
     { name: 'sonar-deep-research', note: 'exhaustive long-form research' },
+    { name: 'openrouter/perplexity/sonar-deep-research', label: 'pro', note: 'exhaustive long-form research' },
     { name: 'r1-1776', note: 'offline conversational (no search)' },
+    { name: 'openrouter/perplexity/r1-1776', note: 'offline conversational (no search)' },
     { name: 'openai/gpt-4o-mini-search-preview' },
     { name: 'openai/gpt-4o-search-preview', label: 'pro' }
   ];


### PR DESCRIPTION
## Summary
- reintroduce openrouter/perplexity model choices alongside existing models
- update search model selector UI

## Testing
- `node -c Aurora/public/main.js`

------
https://chatgpt.com/codex/tasks/task_b_6880887d65488323955066d24ccbc3a6