### PR TITLE
Improve tab switching after archive

### DIFF
--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -705,7 +705,25 @@
       try{
         const r = await fetch('/api/chat/tabs/archive',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({tabId, archived})});
         if(r.ok){
+          const wasCurrent = archived && tabId === currentTabId;
           await loadTabs();
+          if(wasCurrent){
+            const idx = tabs.findIndex(t => t.id === tabId);
+            let next = null;
+            if(idx !== -1){
+              for(let i = idx + 1; i < tabs.length; i++){
+                if(!tabs[i].archived){ next = tabs[i]; break; }
+              }
+              if(!next){
+                for(let i = 0; i < idx; i++){
+                  if(!tabs[i].archived){ next = tabs[i]; break; }
+                }
+              }
+            }
+            if(next){
+              currentTabId = next.id;
+            }
+          }
           renderTabs();
           if(currentView === 'archive') {
             await loadArchivedTabs();
@@ -713,6 +731,7 @@
           }
           if(currentView === 'chat') loadHistory();
           if(currentView === 'tasks') loadTasksForCurrentProject();
+          applyTabView();
         }
       }catch(e){console.error(e);}
     }

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2431,11 +2431,35 @@ async function toggleArchiveTab(tabId, archived){
     body: JSON.stringify({ tabId, archived, sessionId })
   });
   if(r.ok){
+    const wasCurrent = archived && tabId === currentTabId;
     await loadTabs();
-    renderTabs();
-    renderSidebarTabs();
-    renderArchivedSidebarTabs();
-    updatePageTitle();
+    if(wasCurrent){
+      const idx = chatTabs.findIndex(t => t.id === tabId);
+      let next = null;
+      if(idx !== -1){
+        for(let i = idx + 1; i < chatTabs.length; i++){
+          if(!chatTabs[i].archived){ next = chatTabs[i]; break; }
+        }
+        if(!next){
+          for(let i = 0; i < idx; i++){
+            if(!chatTabs[i].archived){ next = chatTabs[i]; break; }
+          }
+        }
+      }
+      if(next){
+        await selectTab(next.id);
+      }else{
+        renderTabs();
+        renderSidebarTabs();
+        renderArchivedSidebarTabs();
+        updatePageTitle();
+      }
+    }else{
+      renderTabs();
+      renderSidebarTabs();
+      renderArchivedSidebarTabs();
+      updatePageTitle();
+    }
     if(chatTabs.length > 0 && chatTabs.every(t => t.archived)){
       location.href = '/index.html';
     }

--- a/Aurora/public/nexum.html
+++ b/Aurora/public/nexum.html
@@ -669,7 +669,25 @@
       try{
         const r = await fetch('/api/chat/tabs/archive',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({tabId, archived})});
         if(r.ok){
+          const wasCurrent = archived && tabId === currentTabId;
           await loadTabs();
+          if(wasCurrent){
+            const idx = tabs.findIndex(t => t.id === tabId);
+            let next = null;
+            if(idx !== -1){
+              for(let i = idx + 1; i < tabs.length; i++){
+                if(!tabs[i].archived){ next = tabs[i]; break; }
+              }
+              if(!next){
+                for(let i = 0; i < idx; i++){
+                  if(!tabs[i].archived){ next = tabs[i]; break; }
+                }
+              }
+            }
+            if(next){
+              currentTabId = next.id;
+            }
+          }
           renderTabs();
           if(currentView === 'archive') {
             await loadArchivedTabs();
@@ -677,6 +695,7 @@
           }
           if(currentView === 'chat') loadHistory();
           if(currentView === 'tasks') loadTasksForCurrentProject();
+          applyTabView();
         }
       }catch(e){console.error(e);}
     }


### PR DESCRIPTION
## Summary
- improve `toggleArchiveTab` to move to the next chat tab after archiving
- apply logic to Aurora landing pages so archiving the active tab automatically selects the next tab

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68817f8f2180832387882a1fba42cc0b