### PR TITLE
Add gradient animation for loading chat tabs

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -990,7 +990,17 @@ body {
 
 /* Highlight chat tab title while waiting for AI response */
 .tab-processing {
-  color: blue !important;
+  color: transparent !important;
+  background-image: linear-gradient(90deg, #1e90ff, #9be8ff, #1e90ff);
+  background-size: 200% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  animation: tab-wave 2s linear infinite;
+}
+
+@keyframes tab-wave {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
 }
 
 #verticalTabsContainer .task-id,


### PR DESCRIPTION
## Summary
- style `.tab-processing` with an animated blue gradient
- add `@keyframes tab-wave` animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68818a9351108323b53f7844ac2f24e8