### PR TITLE
Remove search icon from Aurora model header

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4439,7 +4439,7 @@ function runImageLoop(){
 function updateModelHud(){
   const hud = document.getElementById("modelHud");
   if(!hud) return;
-  const prefix = searchEnabled ? "\uD83D\uDD0D " : codexMiniEnabled ? "</> " : ""; // magnifying glass when searching or code icon
+  const prefix = codexMiniEnabled ? "</> " : ""; // code icon when codex mini is active
   hud.textContent = `Model: ${prefix}${modelName}`;
 }
 


### PR DESCRIPTION
## Summary
- adjust `updateModelHud` so search mode no longer prepends the magnifying glass icon

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68818af1d1cc8323949d25b2159646cd