### PR TITLE
Remove citation markers from Perplexity output

### DIFF
--- a/perplexity-cli.js
+++ b/perplexity-cli.js
@@ -28,6 +28,10 @@ const options = program.opts();
 const query = program.args.join(' ');
 const apiKey = options.key || process.env.PERPLEXITY_API_KEY;
 
+function stripCitationBrackets(text) {
+  return (text || '').replace(/\s*\[[0-9]+\]/g, '');
+}
+
 if (!VALID_MODELS.includes(options.model)) {
   console.error(`Invalid model. Choose one of: ${VALID_MODELS.join(', ')}`);
   process.exit(1);
@@ -50,7 +54,8 @@ axios.post('https://api.perplexity.ai/chat/completions', {
 .then(response => {
   const result = response.data.choices?.[0]?.message || {};
 
-  console.log(`\n${result.content}\n`);
+  const clean = stripCitationBrackets(result.content);
+  console.log(`\n${clean}\n`);
 
   if (result.citations && result.citations.length > 0) {
     console.log('Citations:');

--- a/pplx.js
+++ b/pplx.js
@@ -14,6 +14,10 @@ require('dotenv').config();
 const axios     = require('axios');
 const readline  = require('readline');
 
+function stripCitationBrackets(text){
+  return (text || '').replace(/\s*\[[0-9]+\]/g, '');
+}
+
 const MODELS = [
   { id: 'sonar',                 note: 'lightweight, web-grounded' },
   { id: 'sonar-pro',             note: 'advanced search model' },
@@ -62,7 +66,8 @@ function ask(q) {
     );
 
     const msg = data.choices?.[0]?.message || {};
-    console.log(msg.content || '(no content)\n');
+    const clean = stripCitationBrackets(msg.content);
+    console.log(clean || '(no content)\n');
 
     if (msg.citations?.length) {
       console.log('— citations —');


### PR DESCRIPTION
## Summary
- filter out `[number]` citation markers for Perplexity text
- apply filtering when using openrouter/perplexity models in the web server
- clean CLI outputs in `perplexity-cli.js` and `pplx.js`

## Testing
- `node --check Aurora/src/server.js`
- `node --check perplexity-cli.js`
- `node --check pplx.js`

------
https://chatgpt.com/codex/tasks/task_b_68818bdc97d08323ab851faec1e9a22b