### PR TITLE
Make image upload button styling consistent

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1544,6 +1544,16 @@ button:disabled {
   background: #0062cc;
   color: #fff;
 }
+#chatImageBtn {
+  background: #474747;
+  border: 1px solid #666;
+  color: #ddd;
+  padding: 4px 6px;
+  border-radius: 8px;
+  cursor: pointer;
+  margin-right: 0.5rem;
+}
+
 
 .reasoning-tooltip {
   position: absolute;


### PR DESCRIPTION
## Summary
- style `#chatImageBtn` to match the reasoning toggle button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68818ee602888323aee6d81a994d5d67