### PR TITLE
Prefix openrouter subtext

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4682,17 +4682,17 @@ async function renderSearchModels(){
   searchModelsContainer.innerHTML = '';
   const models = [
     { name: 'sonar', note: 'lightweight, web-grounded' },
-    { name: 'openrouter/perplexity/sonar', note: 'lightweight, web-grounded' },
+    { name: 'openrouter/perplexity/sonar', note: 'openrouter - lightweight, web-grounded' },
     { name: 'sonar-pro', note: 'advanced search model' },
-    { name: 'openrouter/perplexity/sonar-pro', label: 'pro', note: 'advanced search model' },
+    { name: 'openrouter/perplexity/sonar-pro', label: 'pro', note: 'openrouter - advanced search model' },
     { name: 'sonar-reasoning', note: 'fast, real-time reasoning (search)' },
-    { name: 'openrouter/perplexity/sonar-reasoning', label: 'pro', note: 'fast, real-time reasoning (search)' },
+    { name: 'openrouter/perplexity/sonar-reasoning', label: 'pro', note: 'openrouter - fast, real-time reasoning (search)' },
     { name: 'sonar-reasoning-pro', note: 'higher-accuracy CoT reasoning' },
-    { name: 'openrouter/perplexity/sonar-reasoning-pro', label: 'pro', note: 'higher-accuracy CoT reasoning' },
+    { name: 'openrouter/perplexity/sonar-reasoning-pro', label: 'pro', note: 'openrouter - higher-accuracy CoT reasoning' },
     { name: 'sonar-deep-research', note: 'exhaustive long-form research' },
-    { name: 'openrouter/perplexity/sonar-deep-research', label: 'pro', note: 'exhaustive long-form research' },
+    { name: 'openrouter/perplexity/sonar-deep-research', label: 'pro', note: 'openrouter - exhaustive long-form research' },
     { name: 'r1-1776', note: 'offline conversational (no search)' },
-    { name: 'openrouter/perplexity/r1-1776', note: 'offline conversational (no search)' },
+    { name: 'openrouter/perplexity/r1-1776', note: 'openrouter - offline conversational (no search)' },
     { name: 'openai/gpt-4o-mini-search-preview' },
     { name: 'openai/gpt-4o-search-preview', label: 'pro' }
   ];


### PR DESCRIPTION
## Summary
- add `openrouter -` prefix to notes for Perplexity models

## Testing
- `grep -n "openrouter -" -n Aurora/public/main.js | head`

------
https://chatgpt.com/codex/tasks/task_b_68819f153dac83238b667ca7eb9b9144