### PR TITLE
Fix R1 model placement

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -625,8 +625,6 @@
           <option value="openrouter/perplexity/sonar-reasoning-pro">openrouter/perplexity/sonar-reasoning-pro</option>
           <option value="sonar-deep-research">sonar-deep-research</option>
           <option value="openrouter/perplexity/sonar-deep-research">openrouter/perplexity/sonar-deep-research</option>
-          <option value="r1-1776">r1-1776</option>
-          <option value="openrouter/perplexity/r1-1776">openrouter/perplexity/r1-1776</option>
           <option value="openai/gpt-4o-mini-search-preview">openai/gpt-4o-mini-search-preview</option>
           <option value="openai/gpt-4o-search-preview">openai/gpt-4o-search-preview</option>
        </select>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4590,6 +4590,8 @@ async function renderReasoningModels(){
   ];
   const reasoningModels = [
     { name: 'deepseek/deepseek-r1-distill-llama-70b' },
+    { name: 'r1-1776' },
+    { name: 'openrouter/perplexity/r1-1776' },
     { name: 'openai/o4-mini', label: 'pro' },
     { name: 'openai/o4-mini-high', label: 'pro' },
     { name: 'openai/codex-mini', label: 'pro' },
@@ -4691,8 +4693,6 @@ async function renderSearchModels(){
     { name: 'openrouter/perplexity/sonar-reasoning-pro', label: 'pro', note: 'openrouter - higher-accuracy CoT reasoning' },
     { name: 'sonar-deep-research', note: 'exhaustive long-form research' },
     { name: 'openrouter/perplexity/sonar-deep-research', label: 'pro', note: 'openrouter - exhaustive long-form research' },
-    { name: 'r1-1776', note: 'offline conversational (no search)' },
-    { name: 'openrouter/perplexity/r1-1776', note: 'openrouter - offline conversational (no search)' },
     { name: 'openai/gpt-4o-mini-search-preview' },
     { name: 'openai/gpt-4o-search-preview', label: 'pro' }
   ];


### PR DESCRIPTION
## Summary
- adjust Aurora UI so `r1-1776` appears under reasoning models
- remove `r1-1776` from search model options

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6881a0ee17648323a7471a856e3aad12