### PR TITLE
Add collapsible child chat tabs

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -883,6 +883,11 @@ body {
 #archivedTabsContainer .project-collapse-arrow {
   margin-right: 4px;
 }
+#verticalTabsContainer .child-collapse-arrow,
+#archivedTabsContainer .child-collapse-arrow {
+  margin-right: 2px;
+  cursor: pointer;
+}
 
 #verticalTabsContainer .project-gear-btn {
   background: none;


### PR DESCRIPTION
## Summary
- add storage for collapsed child tabs
- render collapse/expand arrows for parent chat tabs
- persist collapsed state
- hide/show children on arrow click

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6881a41b5700832395a63a4aa53ef4f8