### PR TITLE
Update subtask drop logic

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -138,7 +138,7 @@ let collapsedArchiveGroups = {};  // archived tab group collapse states
 let chatTabOrder = {};            // per-project tab ordering
 let projectHeaderOrder = [];      // order of project headers
 let draggingTabRow = null;        // element of tab row being dragged
-let subDropTarget = null;         // tab row being hovered for subtask drop
+let subDropTarget = null;         // tab row being hovered to drop as child
 let draggingProjectHeader = null; // project header currently being dragged
 let projectAddTooltip = null;     // floating toolbar for project add button
 let projectAddTooltipProject = null;
@@ -1587,11 +1587,11 @@ function tabDragOver(e){
     e.preventDefault();
     const overHalf = e.offsetY > e.currentTarget.offsetHeight / 2;
     if(overHalf){
-      subDropTarget = e.currentTarget;
+      subDropTarget = null;
       e.currentTarget.classList.add('sub-drop-bar');
       e.currentTarget.classList.remove('drag-over');
     } else {
-      subDropTarget = null;
+      subDropTarget = e.currentTarget;
       e.currentTarget.classList.add('drag-over');
       e.currentTarget.classList.remove('sub-drop-bar');
     }


### PR DESCRIPTION
## Summary
- highlight tab row for nesting tasks when dragging over it
- use bottom line to reorder

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6881a3ee2994832388925e94ccc535f3