### PR TITLE
Display task priority on chat tabs

### DIFF
--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -375,7 +375,8 @@
         const taskIdSpan = document.createElement('span');
         taskIdSpan.className = 'task-id';
         if (t.task_id) {
-          taskIdSpan.textContent = `#${t.task_id}`;
+          const prio = t.priority ? ` ${t.priority}` : '';
+          taskIdSpan.textContent = `#${t.task_id}${prio}`;
         }
 
         item.appendChild(b);
@@ -442,7 +443,8 @@
       const taskIdSpan = document.createElement('span');
       taskIdSpan.className = 'task-id';
       if (t.task_id) {
-        taskIdSpan.textContent = `#${t.task_id}`;
+        const prio = t.priority ? ` ${t.priority}` : '';
+        taskIdSpan.textContent = `#${t.task_id}${prio}`;
       }
       item.appendChild(info);
       item.appendChild(unarch);

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2828,7 +2828,8 @@ function renderSidebarTabRow(container, tab, indented=false){
   const taskIdSpan = document.createElement("span");
   taskIdSpan.className = "task-id";
   if (tab.task_id) {
-    taskIdSpan.textContent = `#${tab.task_id}`;
+    const prio = tab.priority ? ` ${tab.priority}` : "";
+    taskIdSpan.textContent = `#${tab.task_id}${prio}`;
   }
 
   wrapper.appendChild(info);
@@ -2934,7 +2935,8 @@ function addArchivedRow(container, tab, indented=false){
   const taskIdSpan = document.createElement("span");
   taskIdSpan.className = "task-id";
   if (tab.task_id) {
-    taskIdSpan.textContent = `#${tab.task_id}`;
+    const prio = tab.priority ? ` ${tab.priority}` : "";
+    taskIdSpan.textContent = `#${tab.task_id}${prio}`;
   }
 
   wrapper.appendChild(icon);

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2128,13 +2128,20 @@ app.get("/api/chat/tabs", (req, res) => {
   );
   try {
     let tabs;
-    const includeArchived = showArchivedParam === "1" || showArchivedParam === "true";
+    const includeArchived =
+      showArchivedParam === "1" || showArchivedParam === "true";
     if (nexumParam === undefined) {
       tabs = db.listChatTabs(null, includeArchived, sessionId);
     } else {
       const flag = parseInt(nexumParam, 10);
       tabs = db.listChatTabs(flag ? 1 : 0, includeArchived, sessionId);
     }
+    tabs.forEach(t => {
+      if (t.task_id) {
+        const task = db.getTaskById(t.task_id);
+        if (task) t.priority = task.priority;
+      }
+    });
     res.json(tabs);
   } catch (err) {
     console.error("[TaskQueue] GET /api/chat/tabs error:", err);


### PR DESCRIPTION
## Summary
- show each chat tab's associated task priority when listing tabs
- include the priority from the server API
- append the priority to task number in UI code

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68819041b0e0832388955979fab7f20e