### PR TITLE
Fix Aurora chat drag ordering

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1635,7 +1635,7 @@ async function tabDrop(e){
       let to = rows.indexOf(target);
       parent.removeChild(draggingTabRow);
       if(from < to) to--;
-      parent.insertBefore(draggingTabRow, parent.children[to]);
+      parent.insertBefore(draggingTabRow, parent.children[to + 1] || null);
       updateChatTabOrder(target.dataset.project, parent);
     }
   }


### PR DESCRIPTION
## Summary
- fix reordering logic when dropping a chat tab below another tab

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_6881a70dffdc8323b46ced2359466358