### PR TITLE
Add priority editing from Aurora sidebar

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2926,6 +2926,32 @@ function renderSidebarTabRow(container, tab, indented=false, hasChildren=false){
   if (tab.task_id) {
     const prio = tab.priority ? ` ${tab.priority}` : "";
     taskIdSpan.textContent = `#${tab.task_id}${prio}`;
+    taskIdSpan.addEventListener("click", e => {
+      e.stopPropagation();
+      const sel = document.createElement("select");
+      ["Low","Medium","High"].forEach(v => {
+        const o = document.createElement("option");
+        o.value = v;
+        o.textContent = v;
+        if (v === tab.priority) o.selected = true;
+        sel.appendChild(o);
+      });
+      taskIdSpan.textContent = "";
+      taskIdSpan.appendChild(sel);
+      sel.focus();
+      sel.addEventListener("change", async () => {
+        await fetch("/api/tasks/priority", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: tab.task_id, priority: sel.value })
+        });
+        tab.priority = sel.value;
+        taskIdSpan.textContent = `#${tab.task_id} ${sel.value}`;
+      });
+      sel.addEventListener("blur", () => {
+        taskIdSpan.textContent = `#${tab.task_id}${tab.priority ? ` ${tab.priority}` : ""}`;
+      });
+    });
   }
 
   wrapper.appendChild(info);
@@ -3077,6 +3103,32 @@ function addArchivedRow(container, tab, indented=false, hasChildren=false){
   if (tab.task_id) {
     const prio = tab.priority ? ` ${tab.priority}` : "";
     taskIdSpan.textContent = `#${tab.task_id}${prio}`;
+    taskIdSpan.addEventListener("click", e => {
+      e.stopPropagation();
+      const sel = document.createElement("select");
+      ["Low","Medium","High"].forEach(v => {
+        const o = document.createElement("option");
+        o.value = v;
+        o.textContent = v;
+        if (v === tab.priority) o.selected = true;
+        sel.appendChild(o);
+      });
+      taskIdSpan.textContent = "";
+      taskIdSpan.appendChild(sel);
+      sel.focus();
+      sel.addEventListener("change", async () => {
+        await fetch("/api/tasks/priority", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: tab.task_id, priority: sel.value })
+        });
+        tab.priority = sel.value;
+        taskIdSpan.textContent = `#${tab.task_id} ${sel.value}`;
+      });
+      sel.addEventListener("blur", () => {
+        taskIdSpan.textContent = `#${tab.task_id}${tab.priority ? ` ${tab.priority}` : ""}`;
+      });
+    });
   }
 
   wrapper.appendChild(icon);

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1026,6 +1026,7 @@ body {
   color: var(--accent-light);
   font-size: 0.8rem;
   padding-left: 4px;
+  cursor: pointer;
 }
 
 /* Secure uploader file table */


### PR DESCRIPTION
## Summary
- allow users to click task priority in chat sidebar to change it
- show pointer cursor for sidebar task IDs

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6881a83309f48323a9eec6e675318251