### PR TITLE
Fix drag indicator for first chat

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -142,6 +142,7 @@ let projectHeaderOrder = [];      // order of project headers
 let draggingTabRow = null;        // element of tab row being dragged
 let subDropTarget = null;         // tab row being hovered to drop as child
 let draggingProjectHeader = null; // project header currently being dragged
+let topDropBar = null;            // drop target above first chat
 let projectAddTooltip = null;     // floating toolbar for project add button
 let projectAddTooltipProject = null;
 let projectAddTooltipTimer = null;
@@ -1593,6 +1594,27 @@ function handleDragEnd(){
 function tabDragStart(e){
   draggingTabRow = e.target.closest('.sidebar-tab-row');
   e.dataTransfer.effectAllowed = 'move';
+  const parent = draggingTabRow?.parentNode;
+  if(parent && !topDropBar){
+    topDropBar = document.createElement('div');
+    topDropBar.className = 'top-drop-bar';
+    parent.insertBefore(topDropBar, parent.firstChild);
+    topDropBar.addEventListener('dragover', ev => {
+      ev.preventDefault();
+      topDropBar.classList.add('drag-over');
+    });
+    const clearBar = () => topDropBar.classList.remove('drag-over');
+    topDropBar.addEventListener('dragleave', clearBar);
+    topDropBar.addEventListener('drop', ev => {
+      ev.preventDefault();
+      clearBar();
+      if(draggingTabRow){
+        parent.insertBefore(draggingTabRow, topDropBar.nextSibling);
+        updateChatTabOrder(draggingTabRow.dataset.project, parent);
+      }
+      tabDragEnd();
+    });
+  }
 }
 
 function tabDragOver(e){
@@ -1639,6 +1661,10 @@ async function tabDrop(e){
       updateChatTabOrder(target.dataset.project, parent);
     }
   }
+  if(topDropBar){
+    topDropBar.remove();
+    topDropBar = null;
+  }
   subDropTarget = null;
   draggingTabRow = null;
 }
@@ -1648,6 +1674,10 @@ function tabDragEnd(){
   $$('div.sidebar-tab-row.sub-drop-bar').forEach(el=>el.classList.remove('sub-drop-bar'));
   draggingTabRow = null;
   subDropTarget = null;
+  if(topDropBar){
+    topDropBar.remove();
+    topDropBar = null;
+  }
 }
 async function saveNewOrderToServer(){
   const ids = $$("#tasks tbody tr").map(r=>+r.dataset.taskId);

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -991,8 +991,18 @@ body {
 #verticalTabsContainer .sidebar-tab-row.sub-drop-bar {
   border-bottom: 2px solid #aaa;
 }
+#verticalTabsContainer .top-drop-bar {
+  border-top: 2px solid #aaa;
+  height: 0;
+  margin-bottom: 2px;
+}
 #archivedTabsContainer .sidebar-tab-row.sub-drop-bar {
   border-bottom: 2px solid #aaa;
+}
+#archivedTabsContainer .top-drop-bar {
+  border-top: 2px solid #aaa;
+  height: 0;
+  margin-bottom: 2px;
 }
 
 #verticalTabsContainer .sidebar-tab-row .drag-handle {


### PR DESCRIPTION
## Summary
- show a drop zone before the first chat row so you can drag there
- style the new zone as a simple top border

## Testing
- `npm run lint --prefix Aurora`
- `npm test --prefix AutoPR`
- `npm test --prefix Sterling` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6881c67c74588323a6536da7197bdedf