### PR TITLE
Add ChatGPT tab iframe support

### DIFF
--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -65,6 +65,7 @@
       </div>
 <!--      <h1>Nexum Chat</h1>-->
       <div id="modelInfo" style="margin-bottom:0.5rem; color:#aaa;"></div>
+      <iframe id="chatgptFrame" style="display:none;width:100%;height:80vh;border:none;"></iframe>
       <div id="chatPanel">
         <div id="suggestions"></div>
         <div id="chat"></div>
@@ -142,6 +143,9 @@
       </label>
       <label style="margin-top:8px;">Codex Chat URL:<br/>
         <input type="text" id="codexChatUrlInput" style="width:100%;" />
+      </label>
+      <label style="margin-top:8px;">ChatGPT URL:<br/>
+        <input type="text" id="chatgptUrlInput" style="width:100%;" />
       </label>
       <button id="codexImportBtn" style="margin-top:8px;">Codex/GitHub Import</button>
       <div style="margin-top:1rem;text-align:right;">
@@ -743,6 +747,8 @@
       document.getElementById('tabProjectInput').value = t.project_name || '';
       document.getElementById('tabRepoInput').value = t.repo_ssh_url || '';
       document.getElementById('tabTypeSelect').value = t.tab_type || 'chat';
+      const chatgptInput = document.getElementById('chatgptUrlInput');
+      if(chatgptInput) chatgptInput.value = t.chatgpt_url || '';
       const modal = document.getElementById('tabConfigModal');
       modal.dataset.tabId = tabId;
       modal.style.display = 'flex';
@@ -801,14 +807,23 @@
       if(newTabBtnEl) newTabBtnEl.style.display = v === 'archive' ? 'none' : '';
 
       const chatEl = document.getElementById('chat');
-      if(chatEl) chatEl.style.display = v === 'tasks' || v === 'archive' ? 'none' : '';
+      const t = tabs.find(tt => tt.id === currentTabId) || {};
+      if(chatEl) chatEl.style.display = (v === 'tasks' || v === 'archive' || (v === 'chat' && t.chatgpt_url)) ? 'none' : '';
       const suggestionsEl = document.getElementById('suggestions');
-      if(suggestionsEl) suggestionsEl.style.display = v === 'tasks' || v === 'archive' ? 'none' : '';
+      if(suggestionsEl) suggestionsEl.style.display = (v === 'tasks' || v === 'archive' || (v === 'chat' && t.chatgpt_url)) ? 'none' : '';
 
       const chatPanel = document.getElementById('chatPanel');
+      const chatgptFrame = document.getElementById('chatgptFrame');
       if(chatPanel){
         chatPanel.classList.toggle('tasks-view', v === 'tasks');
-        chatPanel.style.display = v === 'archive' ? 'none' : '';
+        const t = tabs.find(tt => tt.id === currentTabId) || {};
+        if(v === 'chat' && t.chatgpt_url){
+          chatPanel.style.display = 'none';
+          if(chatgptFrame){ chatgptFrame.style.display='block'; chatgptFrame.src = t.chatgpt_url; }
+        }else{
+          chatPanel.style.display = v === 'archive' ? 'none' : '';
+          if(chatgptFrame) chatgptFrame.style.display='none';
+        }
       }
 
       if(v === 'chat') {
@@ -1107,7 +1122,8 @@
       const project = document.getElementById('tabProjectInput').value;
       const repo = document.getElementById('tabRepoInput').value;
       const type = document.getElementById('tabTypeSelect').value;
-      await fetch('/api/chat/tabs/config', {method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({tabId, project, repo, type})});
+      const chatgptUrl = document.getElementById('chatgptUrlInput').value;
+      await fetch('/api/chat/tabs/config', {method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({tabId, project, repo, type, chatgptUrl})});
       modal.style.display = 'none';
       await loadTabs();
       renderTabs();

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2160,6 +2160,7 @@ app.post("/api/chat/tabs/new", (req, res) => {
     const taskId = req.body.taskId || 0;
     const type = req.body.type || 'chat';
     const sessionId = req.body.sessionId || '';
+    const chatgptUrl = req.body.chatgptUrl || '';
 
     const autoNaming = db.getSetting("chat_tab_auto_naming");
     const projectName = db.getSetting("sterling_project") || "";
@@ -2167,7 +2168,7 @@ app.post("/api/chat/tabs/new", (req, res) => {
       name = `${projectName}: ${name}`;
     }
 
-    const { id: tabId, uuid } = db.createChatTab(name, nexum, project, repo, extraProjects, taskId, type, sessionId);
+    const { id: tabId, uuid } = db.createChatTab(name, nexum, project, repo, extraProjects, taskId, type, sessionId, 1, chatgptUrl);
     res.json({ success: true, id: tabId, uuid });
     if (type === 'search') {
       const searchModel = db.getSetting('ai_search_model') || 'sonar-pro';
@@ -2261,7 +2262,7 @@ app.post("/api/chat/tabs/generate_images", (req, res) => {
 app.post("/api/chat/tabs/config", (req, res) => {
   console.debug("[Server Debug] POST /api/chat/tabs/config =>", req.body);
   try {
-    const { tabId, project = '', repo = '', extraProjects = '', taskId = 0, type = 'chat', sendProjectContext = 1, sessionId = '' } = req.body;
+    const { tabId, project = '', repo = '', extraProjects = '', taskId = 0, type = 'chat', sendProjectContext = 1, chatgptUrl = '', sessionId = '' } = req.body;
     if (!tabId) {
       return res.status(400).json({ error: "Missing tabId" });
     }
@@ -2269,7 +2270,7 @@ app.post("/api/chat/tabs/config", (req, res) => {
     if (!tab) {
       return res.status(403).json({ error: 'Forbidden' });
     }
-    db.setChatTabConfig(tabId, project, repo, extraProjects, taskId, type, sendProjectContext ? 1 : 0);
+    db.setChatTabConfig(tabId, project, repo, extraProjects, taskId, type, sendProjectContext ? 1 : 0, chatgptUrl);
     res.json({ success: true });
   } catch (err) {
     console.error("[TaskQueue] POST /api/chat/tabs/config error:", err);


### PR DESCRIPTION
## Summary
- support `chatgpt_url` column for chat tabs
- allow setting chatgpt URL in tab config
- show ChatGPT inside iframe when tab has a URL

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6883e51959d0832386cf2b7006b85db3