### PR TITLE
Add ChatGPT URL input to chat rename modal

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -448,7 +448,7 @@
 
 <div id="renameTabModal" class="modal">
   <div class="modal-content">
-    <h2>Rename Chat</h2>
+    <h2>Chat Settings Modal</h2>
     <label>New name:<br/>
       <input type="text" id="renameTabInput" style="width:100%;" />
     </label>
@@ -469,6 +469,9 @@
       <select id="renameTaskSelect" style="width:100%;"></select>
     </label>
     <label style="display:block;margin-top:8px;"><input type="checkbox" id="renameSendProjectContextCheck" checked/> Send project context</label>
+    <label style="display:block;margin-top:8px;">ChatGPT URL:<br/>
+      <input type="text" id="renameChatgptUrlInput" style="width:100%;" />
+    </label>
     <div class="modal-buttons">
       <button id="renameTabCreateTaskBtn">Create Task</button>
       <button id="renameTabSaveBtn">Save</button>

--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -200,7 +200,7 @@
   </div>
   <div id="renameTabModal" class="modal" style="display:none;">
     <div class="modal-content">
-      <h3>Rename Chat</h3>
+      <h3>Chat Settings Modal</h3>
       <label>New name:<br/>
         <input type="text" id="renameTabInput" style="width:100%;" />
       </label>
@@ -209,6 +209,9 @@
       </label>
       <label style="margin-top:8px;">Tertiary projects:<br/>
         <input type="text" id="renameExtraProjectsInput" style="width:100%;" placeholder="proj2, proj3" />
+      </label>
+      <label style="margin-top:8px;">ChatGPT URL:<br/>
+        <input type="text" id="renameChatgptUrlInput" style="width:100%;" />
       </label>
       <div class="modal-buttons">
         <button id="renameTabSaveBtn">Save</button>
@@ -684,6 +687,12 @@
     function openRenameTabModal(tabId){
       const t = tabs.find(tt => tt.id === tabId);
       document.getElementById('renameTabInput').value = t ? t.name : '';
+      const cg = document.getElementById('renameChatgptUrlInput');
+      if(cg) cg.value = t && t.chatgpt_url ? t.chatgpt_url : '';
+      const projSel = document.getElementById('renameProjectSelect');
+      if(projSel) projSel.value = t && t.project_name ? t.project_name : '';
+      const extraInp = document.getElementById('renameExtraProjectsInput');
+      if(extraInp) extraInp.value = t && t.extra_projects ? t.extra_projects : '';
       const modal = document.getElementById('renameTabModal');
       modal.dataset.tabId = tabId;
       modal.style.display = 'flex';
@@ -986,7 +995,17 @@
       const tabId = parseInt(modal.dataset.tabId, 10);
       const name = document.getElementById('renameTabInput').value.trim();
       if(name) await renameTab(tabId, name);
+      const cg = document.getElementById('renameChatgptUrlInput');
+      const chatgptUrl = cg ? cg.value.trim() : '';
+      const projSel = document.getElementById('renameProjectSelect');
+      const project = projSel ? projSel.value.trim() : '';
+      const extraInput = document.getElementById('renameExtraProjectsInput');
+      const extraProjects = extraInput ? extraInput.value.trim() : '';
+      const t = tabs.find(tt => tt.id === tabId) || {};
+      await fetch('/api/chat/tabs/config', {method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({tabId, project, repo:t.repo_ssh_url||'', type:t.tab_type||'chat', extraProjects, chatgptUrl})});
       modal.style.display = 'none';
+      await loadTabs();
+      renderTabs();
     });
     document.getElementById('renameTabCancelBtn').addEventListener('click', () => {
       document.getElementById('renameTabModal').style.display = 'none';

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2264,6 +2264,10 @@ async function openRenameTabModal(tabId){
   if(sendCtx){
     sendCtx.checked = t ? t.send_project_context !== 0 : true;
   }
+  const chatgptInp = $("#renameChatgptUrlInput");
+  if(chatgptInp){
+    chatgptInp.value = t && t.chatgpt_url ? t.chatgpt_url : '';
+  }
   const modal = $("#renameTabModal");
   if(!modal){
     renameTab(tabId);
@@ -2387,11 +2391,13 @@ $("#renameTabSaveBtn").addEventListener("click", async () => {
   let extraProjects = extraInp ? extraInp.value.trim() : '';
   const sendCtx = $("#renameSendProjectContextCheck");
   const sendProjectContext = sendCtx ? sendCtx.checked : true;
+  const chatgptInp = $("#renameChatgptUrlInput");
+  const chatgptUrl = chatgptInp ? chatgptInp.value.trim() : '';
   const repo = tab.repo_ssh_url || '';
   await fetch('/api/chat/tabs/config', {
     method:'POST',
     headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({tabId, project, repo, extraProjects, taskId, type, sendProjectContext, sessionId})
+    body: JSON.stringify({tabId, project, repo, extraProjects, taskId, type, sendProjectContext, chatgptUrl, sessionId})
   });
   await loadTabs();
   renderTabs();
@@ -2429,11 +2435,13 @@ $("#renameTabCreateTaskBtn").addEventListener("click", async () => {
   let extraProjects = extraInp ? extraInp.value.trim() : '';
   const sendCtx = $("#renameSendProjectContextCheck");
   const sendProjectContext = sendCtx ? sendCtx.checked : true;
+  const chatgptInp = $("#renameChatgptUrlInput");
+  const chatgptUrl = chatgptInp ? chatgptInp.value.trim() : '';
   const repo = tab.repo_ssh_url || '';
   await fetch('/api/chat/tabs/config', {
     method:'POST',
     headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({tabId, project, repo, extraProjects, taskId, type, sendProjectContext, sessionId})
+    body: JSON.stringify({tabId, project, repo, extraProjects, taskId, type, sendProjectContext, chatgptUrl, sessionId})
   });
   await loadTabs();
   renderTabs();


### PR DESCRIPTION
## Summary
- rename the Rename Chat modal to **Chat Settings Modal**
- support editing `chatgpt_url` when renaming a chat tab
- update event handlers in main.js to save the new field
- keep index.html version of the modal consistent

## Testing
- `npm run lint` *(prints `(no linter configured)`)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6883e93e8074832399be81af73036b30