### PR TITLE
Add global model setting

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -910,6 +910,11 @@
     <div id="newTabSearchSection" style="margin-top:10px;">
       <label><input type="checkbox" id="accountNewTabSearchCheck"/> Open /new in Search mode</label>
     </div>
+    <div id="defaultModelSection" style="margin-top:10px;">
+      <label>Default Model for New Chats:
+        <select id="defaultModelSelect"></select>
+      </label>
+    </div>
     <div class="modal-buttons">
       <button id="settingsCloseBtn">Close</button>
     </div>


### PR DESCRIPTION
## Summary
- allow selecting the default model in the Settings modal
- update main.js to load available models and store the selection

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68851119fa888323bbf4a4454647b2bc