### PR TITLE
Fix default model not saved on Close

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3416,9 +3416,16 @@ if(contactCloseBtn){
 
 const settingsCloseBtn = document.getElementById("settingsCloseBtn");
 if(settingsCloseBtn){
-  settingsCloseBtn.addEventListener("click", () =>
-    hideModal(document.getElementById("settingsModal"))
-  );
+  settingsCloseBtn.addEventListener("click", async () => {
+    if (defaultModelSelectEl) {
+      const val = defaultModelSelectEl.value.trim();
+      await setSetting('ai_model', val);
+      settingsCache.ai_model = val;
+      modelName = val || modelName;
+      updateModelHud();
+    }
+    hideModal(document.getElementById("settingsModal"));
+  });
 }
 
 const enableTotpBtn = document.getElementById('enableTotpBtn');


### PR DESCRIPTION
## Summary
- ensure closing the settings modal saves the selected default model

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_68852e1aaa8083239437588d86ae888b