### PR TITLE
Fix reasoning tooltip position

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4847,11 +4847,14 @@ async function initReasoningTooltip(){
 
 function showReasoningTooltip(e){
   initReasoningTooltip();
-  const rect = e.target.getBoundingClientRect();
+  const btn = document.getElementById('reasoningToggleBtn');
+  const rect = btn.getBoundingClientRect();
   reasoningTooltip.style.display = 'flex';
   reasoningTooltip.style.flexDirection = 'column';
-  reasoningTooltip.style.left = (rect.left + window.scrollX) + 'px';
-  reasoningTooltip.style.top = (rect.top + window.scrollY - reasoningTooltip.offsetHeight - 4) + 'px';
+  const tooltipWidth = reasoningTooltip.offsetWidth;
+  const tooltipHeight = reasoningTooltip.offsetHeight;
+  reasoningTooltip.style.left = (rect.left + rect.width / 2 - tooltipWidth / 2 + window.scrollX) + 'px';
+  reasoningTooltip.style.top = (rect.top + window.scrollY - tooltipHeight - 4) + 'px';
   clearTimeout(reasoningTooltipTimer);
 }
 


### PR DESCRIPTION
## Summary
- anchor reasoning tooltip relative to the toggle button

## Testing
- `node -v`
- `npm run start --help` *(fails: cannot install dependencies)*
- `node pplx.js --help` *(fails: missing dotenv module)*

------
https://chatgpt.com/codex/tasks/task_b_6885315e39d08323908130b54f2e6ec6