### PR TITLE
Enable reasoning model order config

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -991,6 +991,7 @@
   <button id="cookieAcceptBtn">Accept</button>
 </div>
 <script src="/session.js"></script>
+<script src="/reasoning_tooltip_config.js"></script>
 <script src="/main.js"></script>
 <script>
   if ('serviceWorker' in navigator) {

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4869,14 +4869,15 @@ async function renderReasoningModels(){
   await ensureAiModels();
   reasoningChatContainer.innerHTML = '';
   reasoningReasonContainer.innerHTML = '';
-  const chatModels = [
+  const cfg = window.REASONING_TOOLTIP_CONFIG || {};
+  const chatModels = cfg.chatModels || [
     { name: 'deepseek/deepseek-chat-v3-0324' },
     { name: 'openai/gpt-4o-mini' },
     { name: 'openai/gpt-4.1-mini' },
     { name: 'openai/gpt-4o', label: 'pro' },
     { name: 'openai/gpt-4.1', label: 'pro' }
   ];
-  const reasoningModels = [
+  const reasoningModels = cfg.reasoningModels || [
     { name: 'deepseek/deepseek-r1-distill-llama-70b' },
     { name: 'openai/o4-mini', label: 'pro' },
     { name: 'openai/o4-mini-high', label: 'pro' },

--- a/Aurora/public/reasoning_tooltip_config.js
+++ b/Aurora/public/reasoning_tooltip_config.js
@@ -1,0 +1,18 @@
+// Config for reasoning menu tooltip
+// Reorder chatModels or reasoningModels arrays to change the order shown
+window.REASONING_TOOLTIP_CONFIG = {
+  chatModels: [
+    { name: 'deepseek/deepseek-chat-v3-0324' },
+    { name: 'openai/gpt-4o-mini' },
+    { name: 'openai/gpt-4.1-mini' },
+    { name: 'openai/gpt-4o', label: 'pro' },
+    { name: 'openai/gpt-4.1', label: 'pro' }
+  ],
+  reasoningModels: [
+    { name: 'deepseek/deepseek-r1-distill-llama-70b' },
+    { name: 'openai/o4-mini', label: 'pro' },
+    { name: 'openai/o4-mini-high', label: 'pro' },
+    { name: 'openai/codex-mini', label: 'pro' },
+    { name: 'openai/o3', label: 'ultimate' }
+  ]
+};

--- a/README.md
+++ b/README.md
@@ -126,3 +126,9 @@ wrong and `401`/`403` for missing or invalid API keys. Use plain model names
 like `sonar`, `sonar-pro`, `sonar-reasoning`, `sonar-reasoning-pro`,
 `sonar-deep-research`, or `r1-1776` without any provider prefix.
 
+### Reasoning menu configuration
+
+The order of models shown in the reasoning tooltip can be customized.
+Edit `Aurora/public/reasoning_tooltip_config.js` and reorder the
+`chatModels` and `reasoningModels` arrays to suit your preferences.
+


### PR DESCRIPTION
## Summary
- add `reasoning_tooltip_config.js` for controlling reasoning tooltip layout
- load new config in `aurora.html`
- read config in `main.js` when rendering reasoning models
- document how to reorder models

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_688531416e848323969c4a5abd99cae7