### PR TITLE
Fix slow search start

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -6273,6 +6273,9 @@ thinPrintifyIcon?.addEventListener("touchstart", ev => {
         window.history.replaceState({}, '', `/chat/${ct.tab_uuid}`);
       }
     }
+    if(initialSearchMode){
+      await enableSearchMode(initialSearchQuery);
+    }
   }
 
   try {
@@ -6399,9 +6402,6 @@ thinPrintifyIcon?.addEventListener("touchstart", ev => {
     console.error("Error loading markdown content:", e);
   }
 
-  if(initialSearchMode){
-    await enableSearchMode(initialSearchQuery);
-  }
 })();
 
 function initChatScrollLoading(){


### PR DESCRIPTION
## Summary
- trigger search after chat history loads
- remove duplicate call at end of init

## Testing
- `npm run lint` *(fails: no linter configured)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_688535e4f2088323999723bc6725e841