### PR TITLE
Add Perplexity R1 models to reasoning favorites

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4887,7 +4887,8 @@ async function renderReasoningModels(){
     { name: 'openai/codex-mini', label: 'pro' },
     { name: 'openai/o3', label: 'ultimate' },
     { name: 'r1-1776', note: 'offline conversational (no search)' },
-    { name: 'openrouter/perplexity/r1-1776', note: 'openrouter - offline conversational (no search)' }
+    { name: 'openrouter/perplexity/r1-1776', note: 'openrouter - offline conversational (no search)' },
+    { name: 'perplexity/r1-1776', note: 'offline conversational (no search)' }
   ];
 
   function addModel(container, name, label){

--- a/Aurora/public/reasoning_tooltip_config.js
+++ b/Aurora/public/reasoning_tooltip_config.js
@@ -13,6 +13,8 @@ window.REASONING_TOOLTIP_CONFIG = {
     { name: 'openai/o4-mini', label: 'pro' },
     { name: 'openai/o4-mini-high', label: 'pro' },
     { name: 'openai/codex-mini', label: 'pro' },
-    { name: 'openai/o3', label: 'ultimate' }
+    { name: 'openai/o3', label: 'ultimate' },
+    { name: 'openrouter/perplexity/r1-1776', note: 'openrouter - offline conversational (no search)' },
+    { name: 'perplexity/r1-1776', note: 'offline conversational (no search)' }
   ]
 };


### PR DESCRIPTION
## Summary
- include the Perplexity `r1-1776` models in the reasoning tooltip config
- expose `perplexity/r1-1776` in the fallback reasoning model list

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68854dafa0f883239e7cd144dca8447c