### PR TITLE
Load AI model list on chat initialization

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -64,6 +64,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   loadChatTabOrder();
   loadProjectHeaderOrder();
   loadCollapsedChildTabs();
+  await ensureAiModels();
   // Project groups will be rendered within the sidebar tabs
   window.addEventListener('resize', () => {
     updateChatPanelVisibility();
@@ -4307,10 +4308,7 @@ async function openChatSettings(){
   $("#imageLoopMessageInput").disabled = true;
 
   try {
-    const modelListResp = await fetch("/api/ai/models");
-    if(modelListResp.ok){
-      const modelData = await modelListResp.json();
-      window.allAiModels = modelData.models || [];
+    await ensureAiModels();
 
       const aiModelSelect = $("#aiModelSelect");
 
@@ -4352,7 +4350,6 @@ async function openChatSettings(){
 
       const currentModel = await getSetting("ai_model");
       if(currentModel) aiModelSelect.value = currentModel;
-    }
   } catch(e){
     console.error("Error populating AI service/model lists:", e);
   } finally {
@@ -4398,10 +4395,7 @@ if(betaContinue){
 // React when AI service changes
 $("#aiServiceSelect").addEventListener("change", async ()=>{
   try {
-    const modelListResp = await fetch("/api/ai/models");
-    if(modelListResp.ok){
-      const modelData = modelListResp.json();
-      window.allAiModels = (await modelData).models || [];
+    await ensureAiModels();
 
       const aiModelSelect = $("#aiModelSelect");
 
@@ -4431,7 +4425,6 @@ $("#aiServiceSelect").addEventListener("change", async ()=>{
 
       const currentModel = await getSetting("ai_model");
       if(currentModel) aiModelSelect.value = currentModel;
-    }
   } catch(e){
     console.error("Error populating AI service/model lists:", e);
   }


### PR DESCRIPTION
## Summary
- fetch available AI models when the chat page loads
- reuse the cached model list when opening chat settings or switching services

## Testing
- `npx jest` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_68854fe99be48323b5b6ac0b65858ddf