### PR TITLE
Fix openai o3 streaming

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -223,10 +223,9 @@ function getOpenAiClient() {
   const currentModel = db.getSetting("ai_model") || "";
   const { provider } = parseProviderModel(currentModel);
 
-  if (currentModel.startsWith("openai/o3")) {
-    // Ensure OpenAI's o3 model always uses the OpenAI provider
-    service = "openai";
-  } else if (provider === "openrouter") {
+  // Default to the provider indicated by the model name unless
+  // explicitly overridden by the ai_service setting.
+  if (provider === "openrouter") {
     service = "openrouter";
   }
 


### PR DESCRIPTION
## Summary
- use provider from model name instead of forcing o3 to use OpenAI service

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68851e60684c83238b0e87a8d1645b14