### PR TITLE
Add favorites tooltip to model selection

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1640,6 +1640,19 @@ button:disabled {
   margin-left: 0;
 }
 
+/* Tooltip listing manually favorited models */
+.favorites-tooltip {
+  position: absolute;
+  background: #333;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 4px;
+  display: none;
+  z-index: 10000;
+  box-shadow: var(--shadow);
+  max-width: 240px;
+}
+
 
 /* Minimal markdown highlighting */
 .md-h1,.md-h2,.md-h3,.md-h4,.md-h5,.md-h6{


### PR DESCRIPTION
## Summary
- add `Manual Favorites` button on model selection tooltip
- show favorites tooltip next to the model menu

## Testing
- `node --check Aurora/public/main.js`

------
https://chatgpt.com/codex/tasks/task_b_688560009c048323a8db136cf623e360