### PR TITLE
Improve tooltip AI selector model labels

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4906,10 +4906,15 @@ async function renderReasoningModels(){
     }
     const b = document.createElement('button');
     b.dataset.model = name;
+    const { provider, shortModel } = parseProviderModel(name);
+    let display = name;
+    if (provider === 'openai' || provider === 'deepseek') {
+      display = `<span class="model-provider">${provider}</span> ${shortModel}`;
+    }
     if(label){
-      b.innerHTML = `<span class="model-label ${label}">${label}</span> ${name}`;
+      b.innerHTML = `<span class="model-label ${label}">${label}</span> ${display}`;
     } else {
-      b.textContent = name;
+      b.innerHTML = display;
     }
     b.classList.toggle('active',
         (container===reasoningChatContainer ? modelName===name && !reasoningEnabled
@@ -5006,9 +5011,12 @@ async function renderSearchModels(){
     }
     const b = document.createElement('button');
     b.dataset.model = name;
+    let { provider, shortModel } = parseProviderModel(name);
     let text = name;
     if(!text.includes('/')) {
       text = `perplexity/${text}`;
+    } else if (provider === 'openai' || provider === 'deepseek') {
+      text = `<span class="model-provider">${provider}</span> ${shortModel}`;
     }
     let html = label ? `<span class="model-label ${label}">${label}</span> ${text}` : text;
     if(note){

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1618,6 +1618,10 @@ button:disabled {
   color: #fff;
   text-transform: uppercase;
 }
+.reasoning-tooltip .model-provider {
+  color: #999;
+  margin-right: 4px;
+}
 .reasoning-tooltip .model-label.ultimate {
   background: #8e44ad;
 }


### PR DESCRIPTION
## Summary
- display `openai` or `deepseek` prefix beside model names in reasoning tooltip
- style provider label in grey

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_688561b4ef8083238dfc1b73bfaefe70