### PR TITLE
Keep reasoning tooltip open on favorites hover

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4877,7 +4877,10 @@ function initFavoritesTooltip(){
   if(favoritesTooltip) return;
   favoritesTooltip = document.createElement('div');
   favoritesTooltip.className = 'favorites-tooltip';
-  favoritesTooltip.addEventListener('mouseenter', () => clearTimeout(favoritesTooltipTimer));
+  favoritesTooltip.addEventListener('mouseenter', () => {
+    clearTimeout(favoritesTooltipTimer);
+    clearTimeout(reasoningTooltipTimer);
+  });
   favoritesTooltip.addEventListener('mouseleave', scheduleHideFavoritesTooltip);
   document.body.appendChild(favoritesTooltip);
 }


### PR DESCRIPTION
## Summary
- keep reasoning tooltip open while mouse is over the favorites tooltip

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6885638c4ad48323951a6caba0fe9cd5