### PR TITLE
Prioritize Pro perplexity model

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4878,9 +4878,9 @@ async function renderReasoningModels(){
     { name: 'openai/o4-mini', label: 'pro' },
     { name: 'openai/o4-mini-high', label: 'pro' },
     { name: 'openai/codex-mini', label: 'pro' },
+    { name: 'openrouter/perplexity/r1-1776', label: 'pro', note: 'openrouter - offline conversational (no search)' },
     { name: 'openai/o3', label: 'ultimate' },
     { name: 'r1-1776', note: 'offline conversational (no search)' },
-    { name: 'openrouter/perplexity/r1-1776', note: 'openrouter - offline conversational (no search)' },
     { name: 'perplexity/r1-1776', note: 'offline conversational (no search)' }
   ];
 

--- a/Aurora/public/reasoning_tooltip_config.js
+++ b/Aurora/public/reasoning_tooltip_config.js
@@ -13,8 +13,9 @@ window.REASONING_TOOLTIP_CONFIG = {
     { name: 'openai/o4-mini', label: 'pro' },
     { name: 'openai/o4-mini-high', label: 'pro' },
     { name: 'openai/codex-mini', label: 'pro' },
+    { name: 'openrouter/perplexity/r1-1776', label: 'pro', note: 'openrouter - offline conversational (no search)' },
     { name: 'openai/o3', label: 'ultimate' },
-    { name: 'openrouter/perplexity/r1-1776', note: 'openrouter - offline conversational (no search)' },
+    { name: 'r1-1776', note: 'offline conversational (no search)' },
     { name: 'perplexity/r1-1776', note: 'offline conversational (no search)' }
   ]
 };


### PR DESCRIPTION
## Summary
- mark `openrouter/perplexity/r1-1776` as a Pro model
- list it before the Ultimate model in the reasoning model menus

## Testing
- `npm test` *(fails: Missing script)*
- `cd AutoPR && npm test`
- `cd ../VMRunner && npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68856165a0008323ad1eaba7a3a0b88b