### PR TITLE
Add model selection to favorites tooltip

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4901,9 +4901,31 @@ async function renderFavoritesTooltip(){
     return;
   }
   favs.forEach(m => {
-    const div = document.createElement('div');
-    div.textContent = m.id;
-    favoritesTooltip.appendChild(div);
+    const btn = document.createElement('button');
+    btn.dataset.model = m.id;
+    btn.textContent = m.id;
+    btn.addEventListener('click', async ev => {
+      ev.stopPropagation();
+      if(!aiResponsesEnabled){
+        await toggleAiResponses();
+      }
+      if(reasoningEnabled){ await toggleReasoning(); }
+      if(searchEnabled){ await toggleSearch(); }
+      await setSetting('ai_model', m.id);
+      settingsCache.ai_model = m.id;
+      await fetch('/api/chat/tabs/model', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({tabId: currentTabId, model: m.id, sessionId})
+      });
+      tabModelOverride = m.id;
+      modelName = m.id;
+      updateModelHud();
+      highlightReasoningModel(m.id);
+      hideFavoritesTooltip();
+      showToast(`Model set to ${m.id}`);
+    });
+    favoritesTooltip.appendChild(btn);
   });
 }
 

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1656,6 +1656,22 @@ button:disabled {
   box-shadow: var(--shadow);
   max-width: 240px;
 }
+.favorites-tooltip button {
+  display: block;
+  margin: 2px 0;
+  padding: 2px 4px;
+  background: #474747;
+  border: 1px solid #666;
+  color: #ddd;
+  border-radius: 4px;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+}
+.favorites-tooltip button:hover {
+  background: #666;
+  color: #fff;
+}
 
 
 /* Minimal markdown highlighting */


### PR DESCRIPTION
## Summary
- allow setting current chat model from the Manual Favorites tooltip
- style favorites tooltip entries as interactive buttons

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_688567d2bd9483239df38862dbc5aabe