### PR TITLE
Adjust favorites tooltip layout

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4934,6 +4934,7 @@ function showFavoritesTooltip(){
   renderFavoritesTooltip();
   const rect = reasoningTooltip.getBoundingClientRect();
   favoritesTooltip.style.display = 'flex';
+  favoritesTooltip.style.flexDirection = 'column';
   favoritesTooltip.style.left = (rect.right + 8 + window.scrollX) + 'px';
   favoritesTooltip.style.top = rect.top + window.scrollY + 'px';
   clearTimeout(favoritesTooltipTimer);

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1654,7 +1654,6 @@ button:disabled {
   display: none;
   z-index: 10000;
   box-shadow: var(--shadow);
-  max-width: 240px;
 }
 .favorites-tooltip button {
   display: block;
@@ -1667,6 +1666,7 @@ button:disabled {
   cursor: pointer;
   width: 100%;
   text-align: left;
+  white-space: nowrap;
 }
 .favorites-tooltip button:hover {
   background: #666;


### PR DESCRIPTION
## Summary
- make favorites dropdown stack buttons vertically
- keep model names on a single line by preventing wrapping

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_68856c6defa483238e14b2bac5be96be