### PR TITLE
Add Claude Sonnet 4 ultimate tier model

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4960,7 +4960,8 @@ async function renderReasoningModels(){
     { name: 'openai/gpt-4o-mini' },
     { name: 'openai/gpt-4.1-mini' },
     { name: 'openai/gpt-4o', label: 'pro' },
-    { name: 'openai/gpt-4.1', label: 'pro' }
+    { name: 'openai/gpt-4.1', label: 'pro' },
+    { name: 'anthropic/claude-sonnet-4', label: 'ultimate' }
   ];
   const reasoningModels = cfg.reasoningModels || [
     { name: 'deepseek/deepseek-r1-distill-llama-70b' },

--- a/Aurora/public/reasoning_tooltip_config.js
+++ b/Aurora/public/reasoning_tooltip_config.js
@@ -6,7 +6,8 @@ window.REASONING_TOOLTIP_CONFIG = {
     { name: 'openai/gpt-4o-mini' },
     { name: 'openai/gpt-4.1-mini' },
     { name: 'openai/gpt-4o', label: 'pro' },
-    { name: 'openai/gpt-4.1', label: 'pro' }
+    { name: 'openai/gpt-4.1', label: 'pro' },
+    { name: 'anthropic/claude-sonnet-4', label: 'ultimate' }
   ],
   reasoningModels: [
     { name: 'deepseek/deepseek-r1-distill-llama-70b' },

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1509,6 +1509,7 @@ app.get("/api/ai/models", async (req, res) => {
     "openai/chatgpt-4o-latest": 128000,
     "openai/gpt-4o-2024-08-06": 128000,
     "openai/o3": 200000,
+    "anthropic/claude-sonnet-4": 200000,
     "openai/gpt-3.5-turbo": 16385,
     "openai/o3-mini-high": 200000,
     "openai/o1": 200000,
@@ -1560,6 +1561,7 @@ app.get("/api/ai/models", async (req, res) => {
     "openai/chatgpt-4o-latest": { input: "$5", output: "$15" },
     "openai/gpt-4o-2024-08-06": { input: "$2.50", output: "$10" },
     "openai/o3": { input: "$10", output: "$40" },
+    "anthropic/claude-sonnet-4": { input: "$3", output: "$15" },
     "openai/gpt-3.5-turbo": { input: "$0.50", output: "$1.50" },
     "openai/o3-mini-high": { input: "$1.10", output: "$4.40" },
     "openai/o1": { input: "$15", output: "$60" },
@@ -1667,7 +1669,8 @@ app.get("/api/ai/models", async (req, res) => {
       "openai/codex-mini",
       "openrouter/perplexity/r1-1776",
       "perplexity/r1-1776",
-      "r1-1776"
+      "r1-1776",
+      "anthropic/claude-sonnet-4"
     ];
     for (const id of forcedModels) {
       let entry = openAIModelData.find((m) => m.id === id) ||

--- a/README.md
+++ b/README.md
@@ -132,3 +132,7 @@ The order of models shown in the reasoning tooltip can be customized.
 Edit `Aurora/public/reasoning_tooltip_config.js` and reorder the
 `chatModels` and `reasoningModels` arrays to suit your preferences.
 
+The chat model list now includes **Anthropic Claude Sonnet 4** as an
+`ultimate` tier option. Pricing is $3 per million input tokens,
+$15 per million output tokens, and $4.80 per thousand input images.
+


### PR DESCRIPTION
## Summary
- include Anthropic Claude Sonnet 4 in reasoning tooltip config
- list the model as an ultimate tier option in the default UI
- expose context and pricing info server-side
- ensure model is forced into available model list
- document pricing in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68856de692dc8323955b2e78859cc4b1