### PR TITLE
Update reasoning models with Claude Opus 4

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4970,6 +4970,7 @@ async function renderReasoningModels(){
     { name: 'openai/codex-mini', label: 'pro' },
     { name: 'openrouter/perplexity/r1-1776', label: 'pro', note: 'openrouter - offline conversational (no search)' },
     { name: 'openai/o3', label: 'ultimate' },
+    { name: 'anthropic/claude-opus-4', label: 'ultimate' },
     { name: 'r1-1776', note: 'offline conversational (no search)' },
     { name: 'perplexity/r1-1776', note: 'offline conversational (no search)' }
   ];

--- a/Aurora/public/reasoning_tooltip_config.js
+++ b/Aurora/public/reasoning_tooltip_config.js
@@ -16,6 +16,7 @@ window.REASONING_TOOLTIP_CONFIG = {
     { name: 'openai/codex-mini', label: 'pro' },
     { name: 'openrouter/perplexity/r1-1776', label: 'pro', note: 'openrouter - offline conversational (no search)' },
     { name: 'openai/o3', label: 'ultimate' },
+    { name: 'anthropic/claude-opus-4', label: 'ultimate' },
     { name: 'r1-1776', note: 'offline conversational (no search)' },
     { name: 'perplexity/r1-1776', note: 'offline conversational (no search)' }
   ]

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1510,6 +1510,7 @@ app.get("/api/ai/models", async (req, res) => {
     "openai/gpt-4o-2024-08-06": 128000,
     "openai/o3": 200000,
     "anthropic/claude-sonnet-4": 200000,
+    "anthropic/claude-opus-4": 200000,
     "openai/gpt-3.5-turbo": 16385,
     "openai/o3-mini-high": 200000,
     "openai/o1": 200000,
@@ -1562,6 +1563,7 @@ app.get("/api/ai/models", async (req, res) => {
     "openai/gpt-4o-2024-08-06": { input: "$2.50", output: "$10" },
     "openai/o3": { input: "$10", output: "$40" },
     "anthropic/claude-sonnet-4": { input: "$3", output: "$15" },
+    "anthropic/claude-opus-4": { input: "$15", output: "$75" },
     "openai/gpt-3.5-turbo": { input: "$0.50", output: "$1.50" },
     "openai/o3-mini-high": { input: "$1.10", output: "$4.40" },
     "openai/o1": { input: "$15", output: "$60" },
@@ -1670,7 +1672,8 @@ app.get("/api/ai/models", async (req, res) => {
       "openrouter/perplexity/r1-1776",
       "perplexity/r1-1776",
       "r1-1776",
-      "anthropic/claude-sonnet-4"
+      "anthropic/claude-sonnet-4",
+      "anthropic/claude-opus-4"
     ];
     for (const id of forcedModels) {
       let entry = openAIModelData.find((m) => m.id === id) ||

--- a/README.md
+++ b/README.md
@@ -136,3 +136,7 @@ The chat model list now includes **Anthropic Claude Sonnet 4** as an
 `ultimate` tier option. Pricing is $3 per million input tokens,
 $15 per million output tokens, and $4.80 per thousand input images.
 
+**Anthropic Claude Opus 4** is also available under the `ultimate` tier.
+Created May 22, 2025 with a 200,000 token context limit, pricing is
+$15 per million input tokens and $75 per million output tokens.
+


### PR DESCRIPTION
## Summary
- document Anthropic Claude Opus 4 in README
- add Claude Opus 4 to reasoning menu configuration
- include Claude Opus 4 in default reasoning model list
- register token limits and pricing for Claude Opus 4

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6885700153a88323b5fe0675a4846bd0