### PR TITLE
Add DeepSeek R1-0528 model

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4965,6 +4965,7 @@ async function renderReasoningModels(){
   ];
   const reasoningModels = cfg.reasoningModels || [
     { name: 'deepseek/deepseek-r1-distill-llama-70b' },
+    { name: 'deepseek/deepseek-r1-0528' },
     { name: 'openai/o4-mini', label: 'pro' },
     { name: 'openai/o4-mini-high', label: 'pro' },
     { name: 'openai/codex-mini', label: 'pro' },

--- a/Aurora/public/reasoning_tooltip_config.js
+++ b/Aurora/public/reasoning_tooltip_config.js
@@ -11,6 +11,7 @@ window.REASONING_TOOLTIP_CONFIG = {
   ],
   reasoningModels: [
     { name: 'deepseek/deepseek-r1-distill-llama-70b' },
+    { name: 'deepseek/deepseek-r1-0528' },
     { name: 'openai/o4-mini', label: 'pro' },
     { name: 'openai/o4-mini-high', label: 'pro' },
     { name: 'openai/codex-mini', label: 'pro' },

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1744,6 +1744,13 @@ app.get("/api/ai/models", async (req, res) => {
       outputCost: "$2.18"
     },
     {
+      id: "deepseek/deepseek-r1-0528",
+      provider: "deepseek",
+      tokenLimit: 163840,
+      inputCost: "$0.272",
+      outputCost: "$0.272"
+    },
+    {
       id: "deepseek/deepseek-r1-distill-llama-70b",
       provider: "deepseek",
       tokenLimit: 131072,


### PR DESCRIPTION
## Summary
- expand reasoning model options with new DeepSeek model
- expose DeepSeek R1‑0528 in the models API including pricing

## Testing
- `npm run lint --prefix Aurora`

------
https://chatgpt.com/codex/tasks/task_b_6885720ac19c832384bc9a0151faf024