### PR TITLE
Add Claude 3.7 Sonnet reasoning model

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4971,6 +4971,7 @@ async function renderReasoningModels(){
     { name: 'openai/codex-mini', label: 'pro' },
     { name: 'openrouter/perplexity/r1-1776', label: 'pro', note: 'openrouter - offline conversational (no search)' },
     { name: 'openai/o3', label: 'ultimate' },
+    { name: 'anthropic/claude-3.7-sonnet:thinking', label: 'ultimate' },
     { name: 'anthropic/claude-opus-4', label: 'ultimate' },
     { name: 'r1-1776', note: 'offline conversational (no search)' },
     { name: 'perplexity/r1-1776', note: 'offline conversational (no search)' }

--- a/Aurora/public/reasoning_tooltip_config.js
+++ b/Aurora/public/reasoning_tooltip_config.js
@@ -17,6 +17,7 @@ window.REASONING_TOOLTIP_CONFIG = {
     { name: 'openai/codex-mini', label: 'pro' },
     { name: 'openrouter/perplexity/r1-1776', label: 'pro', note: 'openrouter - offline conversational (no search)' },
     { name: 'openai/o3', label: 'ultimate' },
+    { name: 'anthropic/claude-3.7-sonnet:thinking', label: 'ultimate' },
     { name: 'anthropic/claude-opus-4', label: 'ultimate' },
     { name: 'r1-1776', note: 'offline conversational (no search)' },
     { name: 'perplexity/r1-1776', note: 'offline conversational (no search)' }

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1511,6 +1511,7 @@ app.get("/api/ai/models", async (req, res) => {
     "openai/o3": 200000,
     "anthropic/claude-sonnet-4": 200000,
     "anthropic/claude-opus-4": 200000,
+    "anthropic/claude-3.7-sonnet:thinking": 200000,
     "openai/gpt-3.5-turbo": 16385,
     "openai/o3-mini-high": 200000,
     "openai/o1": 200000,
@@ -1566,6 +1567,7 @@ app.get("/api/ai/models", async (req, res) => {
     "openai/o3": { input: "$10", output: "$40" },
     "anthropic/claude-sonnet-4": { input: "$3", output: "$15" },
     "anthropic/claude-opus-4": { input: "$15", output: "$75" },
+    "anthropic/claude-3.7-sonnet:thinking": { input: "$3", output: "$15" },
     "openai/gpt-3.5-turbo": { input: "$0.50", output: "$1.50" },
     "openai/o3-mini-high": { input: "$1.10", output: "$4.40" },
     "openai/o1": { input: "$15", output: "$60" },
@@ -1677,7 +1679,8 @@ app.get("/api/ai/models", async (req, res) => {
       "perplexity/r1-1776",
       "r1-1776",
       "anthropic/claude-sonnet-4",
-      "anthropic/claude-opus-4"
+      "anthropic/claude-opus-4",
+      "anthropic/claude-3.7-sonnet:thinking"
     ];
     for (const id of forcedModels) {
       let entry = openAIModelData.find((m) => m.id === id) ||

--- a/README.md
+++ b/README.md
@@ -140,3 +140,8 @@ $15 per million output tokens, and $4.80 per thousand input images.
 Created May 22, 2025 with a 200,000 token context limit, pricing is
 $15 per million input tokens and $75 per million output tokens.
 
+**Anthropic Claude 3.7 Sonnet (thinking)** has been added to the reasoning
+menu as an `ultimate` tier option. Created Feb 24, 2025 with a 200,000 token
+context limit, pricing is $3 per million input tokens and $15 per million
+output tokens.
+


### PR DESCRIPTION
## Summary
- list `anthropic/claude-3.7-sonnet:thinking` in reasoning menus
- include new model in forced model list with token limit and pricing
- document the model and costs in README

## Testing
- `node --check Aurora/src/server.js`
- `node --check Aurora/public/reasoning_tooltip_config.js`
- `node --check Aurora/public/main.js`


------
https://chatgpt.com/codex/tasks/task_b_688573b3735083239e979722520e9ea9