### PR TITLE
Fix initial chat tab model display

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -6380,6 +6380,13 @@ thinPrintifyIcon?.addEventListener("touchstart", ev => {
       chk.disabled = currentTabType !== 'design';
     }
   }
+  {
+    const currentTab = chatTabs.find(t => t.id === currentTabId);
+    tabModelOverride = currentTab && currentTab.model_override ? currentTab.model_override : '';
+    const globalModel = await getSetting("ai_model");
+    modelName = tabModelOverride || globalModel || "unknown";
+    updateModelHud();
+  }
   renderTabs();
   renderSidebarTabs();
   renderArchivedSidebarTabs();


### PR DESCRIPTION
## Summary
- update initialization to show the correct model when opening a chat tab via direct URL

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_688576c7a40883238f4ee23f7a9d1691