### PR TITLE
Add pricing for sonar reasoning

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1548,6 +1548,9 @@ app.get("/api/ai/models", async (req, res) => {
     ,"openrouter/perplexity/r1-1776": 128000
     ,"perplexity/r1-1776": 128000
     ,"r1-1776": 128000
+    ,"openrouter/perplexity/sonar-reasoning": 127000
+    ,"perplexity/sonar-reasoning": 127000
+    ,"sonar-reasoning": 127000
   };
 
   // Known model costs are stored per one million tokens so that the
@@ -1604,7 +1607,10 @@ app.get("/api/ai/models", async (req, res) => {
     "openai/gpt-3.5-turbo-0301": { input: "--", output: "--" },
     "openrouter/perplexity/r1-1776": { input: "$2", output: "$8" },
     "perplexity/r1-1776": { input: "$2", output: "$8" },
-    "r1-1776": { input: "$2", output: "$8" }
+    "r1-1776": { input: "$2", output: "$8" },
+    "openrouter/perplexity/sonar-reasoning": { input: "$1", output: "$5" },
+    "perplexity/sonar-reasoning": { input: "$1", output: "$5" },
+    "sonar-reasoning": { input: "$1", output: "$5" }
   };
 
   let openAIModelData = [];
@@ -1680,6 +1686,9 @@ app.get("/api/ai/models", async (req, res) => {
       "openrouter/perplexity/r1-1776",
       "perplexity/r1-1776",
       "r1-1776",
+      "openrouter/perplexity/sonar-reasoning",
+      "perplexity/sonar-reasoning",
+      "sonar-reasoning",
       "anthropic/claude-3.7-sonnet",
       "anthropic/claude-sonnet-4",
       "anthropic/claude-opus-4",

--- a/README.md
+++ b/README.md
@@ -146,3 +146,7 @@ menu as an `ultimate` tier option. Created Feb 24, 2025 with a 200,000 token
 context limit, pricing is $3 per million input tokens and $15 per million
 output tokens.
 
+**perplexity/sonar-reasoning** has been added to the reasoning menu under the
+`pro` tier. Created Jan 29, 2025 with a 127,000 token context limit, pricing
+starts at $1 per million input tokens and $5 per million output tokens.
+


### PR DESCRIPTION
## Summary
- note sonar reasoning pricing
- show pricing in known costs
- document token limit and add forced listings

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68857712dc888323a5173666003eb7f8