### PR TITLE
Fix AI favorites caching

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -4171,6 +4171,9 @@ app.post("/api/ai/favorites", (req, res) => {
     }
 
     db.setSetting("favorite_ai_models", favList);
+    // Invalidate cached AI model list so favorites refresh immediately
+    aiModelsCache = null;
+    aiModelsCacheTs = 0;
     res.json({ success: true, favorites: favList });
   } catch (err) {
     console.error("Error in /api/ai/favorites:", err);


### PR DESCRIPTION
## Summary
- update /api/ai/favorites endpoint to clear the model cache when favorites are changed

## Testing
- `node --check Aurora/src/server.js`

------
https://chatgpt.com/codex/tasks/task_b_68862a267f60832391e68ad34c031e6b