### PR TITLE
Add Sonar Reasoning Pro pricing

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1564,6 +1564,9 @@ app.get("/api/ai/models", async (req, res) => {
     ,"openrouter/perplexity/sonar-reasoning": 127000
     ,"perplexity/sonar-reasoning": 127000
     ,"sonar-reasoning": 127000
+    ,"openrouter/perplexity/sonar-reasoning-pro": 128000
+    ,"perplexity/sonar-reasoning-pro": 128000
+    ,"sonar-reasoning-pro": 128000
   };
 
   // Known model costs are stored per one million tokens so that the
@@ -1626,6 +1629,9 @@ app.get("/api/ai/models", async (req, res) => {
     "openrouter/perplexity/sonar-reasoning": { input: "$1", output: "$5" },
     "perplexity/sonar-reasoning": { input: "$1", output: "$5" },
     "sonar-reasoning": { input: "$1", output: "$5" }
+    ,"openrouter/perplexity/sonar-reasoning-pro": { input: "$2", output: "$8" }
+    ,"perplexity/sonar-reasoning-pro": { input: "$2", output: "$8" }
+    ,"sonar-reasoning-pro": { input: "$2", output: "$8" }
   };
 
   let openAIModelData = [];

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ output tokens.
 `pro` tier. Created Jan 29, 2025 with a 127,000 token context limit, pricing
 starts at $1 per million input tokens and $5 per million output tokens.
 
+**perplexity/sonar-reasoning-pro** has been added to the reasoning menu under the
+`pro` tier. Created Mar 7, 2025 with a 128,000 token context limit, pricing
+starts at $2 per million input tokens and $8 per million output tokens.
+
 **Anthropic Claude 3.5 Haiku** has been added to the chat model menu under the
 `pro` tier. It offers enhanced speed, coding accuracy, and tool use, making it
 ideal for real-time applications like chat interactions and instant coding


### PR DESCRIPTION
## Summary
- document pricing for Perplexity's `sonar-reasoning-pro` model
- add server metadata so the API reports the new model cost and token limits

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_6887b49ac8908323a0bdb57247af0d04