### PR TITLE
Fix provider display in search models

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -5142,13 +5142,13 @@ async function renderSearchModels(){
       displayProvider = 'openrouter/perplexity';
       displayShort = name.replace(/^openrouter\/perplexity\//, '');
     }
-    let text = name;
-    if(!text.includes('/')) {
-      text = `perplexity/${text}`;
-    } else if (displayProvider === 'openai' || displayProvider === 'deepseek' || displayProvider === 'openrouter/perplexity') {
-      text = `<span class="model-provider">${displayProvider}</span> ${displayShort}`;
-    }
-    let html = label ? `<span class="model-label ${label}">${label}</span> ${text}` : text;
+
+    const providerPart = (displayProvider && displayProvider !== 'Unknown')
+      ? `<span class="model-row-provider">${displayProvider}/</span>` : '';
+    const namePart = `<span class="model-row-name">${displayShort}</span>`;
+    let header = `<div class="model-row-header">${providerPart}${namePart}</div>`;
+
+    let html = label ? `<span class="model-label ${label}">${label}</span> ${header}` : header;
     if(note){
       html += `<span class="model-note">${note}</span>`;
     }

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1622,6 +1622,14 @@ button:disabled {
   color: #999;
   margin-right: 4px;
 }
+.reasoning-tooltip .model-row-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+.reasoning-tooltip .model-row-provider { color: #999; }
+.reasoning-tooltip .model-row-name { color: #fff; font-weight: 500; }
 .reasoning-tooltip .model-label.ultimate {
   background: #8e44ad;
 }


### PR DESCRIPTION
## Summary
- display provider and model in same line for search model rows
- add styles for model row header, provider and name

## Testing
- `npm run lint` in `Aurora`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6887b59e40f88323b0e7d3cbd2291bc1