### PR TITLE
Fix search model label layout

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -5146,9 +5146,10 @@ async function renderSearchModels(){
     const providerPart = (displayProvider && displayProvider !== 'Unknown')
       ? `<span class="model-row-provider">${displayProvider}/</span>` : '';
     const namePart = `<span class="model-row-name">${displayShort}</span>`;
-    let header = `<div class="model-row-header">${providerPart}${namePart}</div>`;
+    const labelPart = label ? `<span class="model-label ${label}">${label}</span>` : '';
+    let header = `<div class="model-row-header">${labelPart}${providerPart}${namePart}</div>`;
 
-    let html = label ? `<span class="model-label ${label}">${label}</span> ${header}` : header;
+    let html = header;
     if(note){
       html += `<span class="model-note">${note}</span>`;
     }


### PR DESCRIPTION
## Summary
- keep pro/ultimate labels inline with provider and model names for search models

## Testing
- `npm test` *(fails: Missing script)*
- `npx jest` *(fails: 403 Forbidden to fetch jest)*

------
https://chatgpt.com/codex/tasks/task_b_6887f2e0805c8323b5a45b93ef96c319