### PR TITLE
Fix directory picker to avoid uploading files

### DIFF
--- a/Sterling/executable/views/add_repository.ejs
+++ b/Sterling/executable/views/add_repository.ejs
@@ -28,7 +28,10 @@
         const dirPicker = document.getElementById('dirPicker');
         const localPathInput = document.getElementById('gitRepoLocalPath');
 
-        browseBtn.addEventListener('click', () => dirPicker.click());
+        browseBtn.addEventListener('click', () => {
+            dirPicker.disabled = false;
+            dirPicker.click();
+        });
         dirPicker.addEventListener('change', (ev) => {
             const file = ev.target.files && ev.target.files[0];
             if (!file) return;
@@ -42,6 +45,8 @@
                 const sep = fullPath.includes('\\') ? /\\[^\\]*$/ : /\/[^/]*$/;
                 localPathInput.value = fullPath.replace(sep, '');
             }
+            // Disable the file input so directory contents are not uploaded
+            dirPicker.disabled = true;
         });
     </script>
 


### PR DESCRIPTION
## Summary
- disable directory file input after selecting a folder so the form does not upload all files

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_b_688ce4739c4c8323a04a419bd04b228a