### PR TITLE
Show server cwd in repo form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 TaskQueue/.env
 *.env
 printifyQueue.json
+
+# Ignore global node modules and lock files
+node_modules/
+package-lock.json
  
 mosaic/
 jobsHistory.json

--- a/Sterling/executable/views/add_repository.ejs
+++ b/Sterling/executable/views/add_repository.ejs
@@ -7,6 +7,8 @@
 </head>
 <body>
     <h1>Add New Repository</h1>
+    <p>Server working directory: <code><%= serverCWD %></code></p>
+    <p>Please provide an absolute path accessible by the server.</p>
 
     <form action="/repositories/add" method="POST">
         <label for="repoName">Repository Name:</label><br>

--- a/Sterling/executable/webserver/get_routes.js
+++ b/Sterling/executable/webserver/get_routes.js
@@ -56,7 +56,8 @@ function setupGetRoutes(deps) {
     });
 
     app.get("/repositories/add", (_req, res) => {
-        res.render("add_repository");
+        const serverCWD = process.cwd();
+        res.render("add_repository", { serverCWD });
     });
 
     /* ---------- Repo helper redirects ---------- */


### PR DESCRIPTION
## Summary
- display server's working directory on the Add Repository page
- ignore root-level node modules

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688d21a6ceec8323891f2cd3eb763336