### PR TITLE
Add subscription plan dropdown

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -841,6 +841,16 @@
       </div>
       <p id="totpEnabledMsg" style="display:none;">2FA Enabled</p>
     </div>
+    <div id="planSection" style="margin-top:10px;">
+      <label>Subscription Plan:<br/>
+        <select id="accountPlan">
+          <option value="Free">Free</option>
+          <option value="Pro">Pro</option>
+          <option value="Ultimate">Ultimate</option>
+        </select>
+      </label>
+      <button id="planSaveBtn" style="margin-top:8px;">Save</button>
+    </div>
     <div id="passwordSection" style="margin-top:10px;">
       <button id="showChangePasswordBtn">Change Password</button>
       <div id="passwordForm" style="display:none; margin-top:10px;">

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -757,6 +757,8 @@ function openAccountModal(e){
       if(enabledMsg) enabledMsg.style.display = 'none';
       if(enableBtn) enableBtn.style.display = 'inline-block';
     }
+    const planSelect = document.getElementById('accountPlan');
+    if(planSelect) planSelect.value = accountInfo.plan || 'Free';
   }
   showModal(document.getElementById("accountModal"));
 }
@@ -3294,6 +3296,9 @@ if (signupSubmitBtn) {
         showToast("Registered!");
         hideModal(document.getElementById("authModal"));
         updateAccountButton({exists:true, id:data.id, email, totpEnabled: data.totpEnabled});
+        fetch('/api/account')
+          .then(r => r.ok ? r.json() : null)
+          .then(info => { if(info) updateAccountButton(info); });
       } else {
         showToast(data?.error || "Registration failed");
       }
@@ -3359,6 +3364,9 @@ if (loginSubmitBtn) {
         const lbl = document.getElementById('totpLoginLabel');
         if(lbl) lbl.style.display = 'none';
         updateAccountButton({exists:true, id:data.id, email, totpEnabled: data.totpEnabled});
+        fetch('/api/account')
+          .then(r => r.ok ? r.json() : null)
+          .then(info => { if(info) updateAccountButton(info); });
       } else {
         if(data?.error === 'totp required' || data?.error === 'invalid totp') {
           const lbl = document.getElementById('totpLoginLabel');
@@ -3457,6 +3465,25 @@ if(timezoneSaveBtn){
       showToast('Timezone saved');
     } else {
       showToast(data?.error || 'Failed to save timezone');
+    }
+  });
+}
+
+const planSaveBtn = document.getElementById('planSaveBtn');
+if(planSaveBtn){
+  planSaveBtn.addEventListener('click', async () => {
+    const plan = document.getElementById('accountPlan').value;
+    const resp = await fetch('/api/account/plan', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan })
+    });
+    const data = await resp.json().catch(() => null);
+    if(resp.ok && data && data.success){
+      if(accountInfo) accountInfo.plan = plan;
+      showToast('Plan saved');
+    } else {
+      showToast(data?.error || 'Failed to save plan');
     }
   });
 }

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1374,7 +1374,8 @@ app.get("/api/account", (req, res) => {
       id: account.id,
       email: account.email,
       totpEnabled: !!account.totp_secret,
-      timezone: account.timezone || ''
+      timezone: account.timezone || '',
+      plan: account.plan || 'Free'
     });
   } catch(err) {
     console.error("[TaskQueue] GET /api/account failed:", err);
@@ -1391,6 +1392,18 @@ app.post("/api/account/timezone", (req, res) => {
     return res.status(400).json({ error: "timezone required" });
   }
   db.setAccountTimezone(account.id, timezone);
+  res.json({ success: true });
+});
+
+app.post("/api/account/plan", (req, res) => {
+  const sessionId = getSessionIdFromRequest(req);
+  const account = sessionId ? db.getAccountBySession(sessionId) : null;
+  if (!account) return res.status(401).json({ error: "not logged in" });
+  const { plan } = req.body || {};
+  if (typeof plan !== 'string') {
+    return res.status(400).json({ error: "plan required" });
+  }
+  db.setAccountPlan(account.id, plan);
   res.json({ success: true });
 });
 


### PR DESCRIPTION
## Summary
- include plan in account table and API
- add account plan update endpoint on server
- show subscription plan dropdown in Account modal
- handle saving and fetching plan in frontend

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_688d3bc1ce08832384d9929c62b99b97