### PR TITLE
Remove image counter and gate design tabs

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -25,8 +25,6 @@
         <div id="versionInfo" class="version-info" style="margin-bottom: 5px;"><span id="versionSpan">beta-...</span> <a href="/about.html" target="_blank" style="color: cyan">about</a> <a href="https://dev.alfe.sh/search?q=" target="_blank" style="color: cyan; margin-left:4px;">search</a></div>
     <span id="sessionIdText" class="session-id"></span>
     <button id="hideSidebarBtn" class="hide-sidebar-btn">Hide Sidebar</button>
-    <span id="imageLimitInfo" class="session-limit"></span>
-    <span id="imageLimitCountdown" class="session-limit"></span>
     <div id="navSpinner" style="text-align:center; margin-top:1rem;"><span class="loading-spinner"></span></div>
     <ul id="navSkeletonList" style="list-style:none;padding:0 1rem;display:none;">
       <li class="nav-placeholder"></li>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -7,7 +7,6 @@ let chatAutoScroll = false;
 document.addEventListener('DOMContentLoaded', async () => {
   const sessEl = document.getElementById('sessionIdText');
   if (sessEl) sessEl.textContent = sessionId;
-  updateImageLimitInfo();
   document.title = defaultTitle;
 
   // theming disabled; always use default stylesheet
@@ -849,6 +848,7 @@ function updateAccountButton(info){
     }
     togglePortfolioMenu(info.id === 1);
     toggleImageIdColumn();
+    toggleDesignTabs(info.plan === 'Pro' || info.plan === 'Ultimate');
   } else {
     accountInfo = null;
     btn.textContent = "Sign Up / Login";
@@ -858,6 +858,7 @@ function updateAccountButton(info){
     }
     togglePortfolioMenu(false);
     toggleImageIdColumn();
+    toggleDesignTabs(false);
   }
 }
 
@@ -4725,6 +4726,23 @@ function toggleImageIdColumn(){
   if(header) header.style.display = '';
   document.querySelectorAll('#secureFilesList td.id-col').forEach(td => {
     td.style.display = '';
+  });
+}
+
+function toggleDesignTabs(allowed){
+  document.querySelectorAll('[data-type="design"]').forEach(el => {
+    if(el.tagName === 'BUTTON'){
+      el.style.display = allowed ? '' : 'none';
+      el.disabled = !allowed;
+      el.classList.toggle('disabled', !allowed);
+    }
+  });
+  document.querySelectorAll('option[value="design"]').forEach(opt => {
+    opt.disabled = !allowed;
+    if(!allowed && opt.selected){
+      const sel = opt.closest('select');
+      if(sel) sel.value = sel.querySelector('option:not([disabled])')?.value || 'chat';
+    }
   });
 }
 function toggleNewTabProjectField(visible){

--- a/Aurora/public/nexum_tabs.html
+++ b/Aurora/public/nexum_tabs.html
@@ -163,7 +163,27 @@ document.querySelectorAll('#newTabTypeButtons .start-type-btn').forEach(btn => {
   });
 });
 
+let designAllowed = false;
+async function checkAccountPlan(){
+  try{
+    const r = await fetch('/api/account');
+    if(r.ok){
+      const info = await r.json();
+      designAllowed = info.plan === 'Pro' || info.plan === 'Ultimate';
+    }
+  }catch(e){ console.error(e); }
+  toggleDesignButtons();
+}
+function toggleDesignButtons(){
+  document.querySelectorAll('#newTabTypeButtons .start-type-btn[data-type="design"]').forEach(b => {
+    b.style.display = designAllowed ? '' : 'none';
+    b.disabled = !designAllowed;
+    b.classList.toggle('disabled', !designAllowed);
+  });
+}
+
 (async function(){
+  await checkAccountPlan();
   try{
     const r = await fetch('/api/settings/new_tab_project_enabled');
     if(r.ok){

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -699,31 +699,6 @@ body {
   user-select: text;
 }
 
-/* Display current session image count under the ID */
-#imageLimitInfo.session-limit {
-  position: absolute;
-  top: 32px;
-  left: 60px;
-  font-size: 0.75rem;
-  color: #aaa;
-  z-index: 1000;
-}
-
-#imageLimitCountdown.session-limit {
-  position: absolute;
-  top: 44px;
-  left: 60px;
-  font-size: 0.7rem;
-  color: #aaa;
-  z-index: 1000;
-}
-
-/* Hide counters when sidebar is collapsed */
-.app.sidebar-collapsed #imageLimitInfo,
-.app.sidebar-collapsed #imageLimitCountdown {
-  display: none !important;
-}
-
 /* Button to hide the sidebar */
 #hideSidebarBtn.hide-sidebar-btn {
   position: absolute;
@@ -744,34 +719,6 @@ body {
   display: none !important;
 }
 
-/* When the image generation limit is reached (50/50),
-   highlight the info text in dark red for visibility
-   by applying a new "limit-reached" class via JavaScript.
-   This class is added dynamically when the count hits the limit.
-   The base class `session-limit` keeps default styling.
-   We add the color rule separately so it overrides the default.
-   This ensures normal color is used until the limit is hit.
-
-   Example HTML after update:
-     <span id="imageLimitInfo" class="session-limit limit-reached">Images: 50/50 (IP 50/50)</span>
-
-   The dark red color uses the named color `darkred` for clarity.
-   It roughly corresponds to #8B0000.
-
-   This rule must follow the base styling to take precedence.
-   See main.js for the logic that toggles this class.
-
-   Added per user request to visually indicate when the
-   generation limit has been fully consumed.
-
-   The instructions in AGENTS.md mention nothing about CSS color,
-   so we implement as straightforwardly as possible.
-
-   Additional comments for maintainers: none. */
-
-#imageLimitInfo.session-limit.limit-reached {
-  color: darkred;
-}
 
 /* Token count indicator in bottom-right corner of subbubble */
 .token-indicator {


### PR DESCRIPTION
## Summary
- drop image generation counter from sidebar and related CSS
- prevent design tabs unless user has Pro or Ultimate plan
- hide design tab option on the Nexum tabs page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_688d45756ae8832391dbfc5bd2c3bbd4