### PR TITLE
Update design tab visibility

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -408,17 +408,10 @@
         <div class="icon">🎨</div>
         <div>Design</div>
       </button>
-      <button data-type="pm_agi" class="start-type-btn">
-        <div class="icon">🤖</div>
-        <div>PM AGI</div>
-      </button>
+      <div id="designProBanner" class="pro-banner" style="display:none;">Available on Pro</div>
       <button data-type="search" class="start-type-btn">
         <div class="icon">🔍</div>
         <div>Search</div>
-      </button>
-      <button data-type="task" class="start-type-btn">
-        <div class="icon">📋</div>
-        <div>Tasks</div>
       </button>
     </div>
   </div>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4732,7 +4732,7 @@ function toggleImageIdColumn(){
 function toggleDesignTabs(allowed){
   document.querySelectorAll('[data-type="design"]').forEach(el => {
     if(el.tagName === 'BUTTON'){
-      el.style.display = allowed ? '' : 'none';
+      el.style.display = '';
       el.disabled = !allowed;
       el.classList.toggle('disabled', !allowed);
     }
@@ -4744,6 +4744,8 @@ function toggleDesignTabs(allowed){
       if(sel) sel.value = sel.querySelector('option:not([disabled])')?.value || 'chat';
     }
   });
+  const banner = document.getElementById('designProBanner');
+  if(banner) banner.style.display = allowed ? 'none' : 'block';
 }
 function toggleNewTabProjectField(visible){
   const lbl = document.getElementById("newTabProjectLabel");

--- a/Aurora/public/nexum_tabs.html
+++ b/Aurora/public/nexum_tabs.html
@@ -31,6 +31,7 @@
             <div class="icon">🎨</div>
             <div>Design</div>
           </button>
+          <div id="designProBanner" class="pro-banner" style="display:none;">Available on Pro</div>
         </div>
         <label style="margin-top:8px;">Project Name:<br/>
           <input type="text" id="newTabProjectInput" style="width:100%;" />
@@ -176,10 +177,12 @@ async function checkAccountPlan(){
 }
 function toggleDesignButtons(){
   document.querySelectorAll('#newTabTypeButtons .start-type-btn[data-type="design"]').forEach(b => {
-    b.style.display = designAllowed ? '' : 'none';
+    b.style.display = '';
     b.disabled = !designAllowed;
     b.classList.toggle('disabled', !designAllowed);
   });
+  const banner = document.getElementById('designProBanner');
+  if(banner) banner.style.display = designAllowed ? 'none' : 'block';
 }
 
 (async function(){

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1483,6 +1483,14 @@ button:disabled {
   cursor: pointer;
 }
 
+/* Banner shown when a feature requires Pro plan */
+.pro-banner {
+  margin-top: 0.5rem;
+  text-align: center;
+  color: #aaa;
+  font-size: 0.9rem;
+}
+
 
 /* Project search input and button */
 #projectSearchInput {


### PR DESCRIPTION
## Summary
- remove PM AGI and Tasks from the New Tab menu
- always show the Design button but disable it on Free accounts
- display a small banner saying "Available on Pro"

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_688d4b43b3c08323a5bf4862ecc86c47