### PR TITLE
Show image generation costs

### DIFF
--- a/Aurora/public/generated_images.html
+++ b/Aurora/public/generated_images.html
@@ -34,6 +34,21 @@
   <div id="grid" class="grid"></div>
   <script src="/session.js"></script>
   <script>
+    const imageModelCosts = {
+      "openai/gpt-image-1": 0.04,
+      "openai/dall-e-2": 0.016,
+      "openai/dall-e-3": 0.08,
+      "stable-diffusion": 0
+    };
+
+    function getImageCost(modelId){
+      if(!modelId) return null;
+      const key = modelId.toLowerCase();
+      return Object.prototype.hasOwnProperty.call(imageModelCosts, key)
+        ? imageModelCosts[key]
+        : null;
+    }
+
     async function loadImages(){
       try {
         const resp = await fetch('/api/upload/list?sessionId=' + encodeURIComponent(sessionId));
@@ -51,6 +66,17 @@
           img.alt = f.title || f.name;
           link.appendChild(img);
           wrapper.appendChild(link);
+
+          if(f.model){
+            const cost = getImageCost(f.model);
+            const meta = document.createElement('div');
+            meta.style.fontSize = '0.9rem';
+            meta.style.marginTop = '4px';
+            meta.textContent = cost !== null
+              ? `${f.model} | $${cost.toFixed(4)}`
+              : f.model;
+            wrapper.appendChild(meta);
+          }
 
           const dl = document.createElement('button');
           dl.className = 'download-chat-btn pair-download-btn';

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3733,6 +3733,21 @@ function parseProviderModel(model) {
   return { provider: "Unknown", shortModel: model };
 }
 
+const imageModelCosts = {
+  "openai/gpt-image-1": 0.04,
+  "openai/dall-e-2": 0.016,
+  "openai/dall-e-3": 0.08,
+  "stable-diffusion": 0
+};
+
+function getImageModelCost(modelId){
+  if(!modelId) return null;
+  const key = modelId.toLowerCase();
+  return Object.prototype.hasOwnProperty.call(imageModelCosts, key)
+    ? imageModelCosts[key]
+    : null;
+}
+
 function getModelCost(modelId, inputTokens, outputTokens) {
   if (!window.allAiModels) return null;
   const info = window.allAiModels.find(m => m.id === modelId);
@@ -7090,6 +7105,14 @@ function addChatMessage(pairId, userText, userTs, aiText, aiTs, model, systemCon
       const modelLabel = document.createElement("div");
       modelLabel.textContent = `${model}`;
       metaContainer.appendChild(modelLabel);
+      if(imageUrl){
+        const imgCost = getImageModelCost(model);
+        if(imgCost !== null){
+          const costLabel = document.createElement("div");
+          costLabel.textContent = `Cost: $${imgCost.toFixed(4)}`;
+          metaContainer.appendChild(costLabel);
+        }
+      }
     }
 
     let tokObj = null;

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2587,12 +2587,13 @@ app.get("/api/upload/list", (req, res) => {
       const title = db.getImageTitleForUrl(`/uploads/${name}`);
       const id = db.getImageIdForUrl(`/uploads/${name}`);
       const uuid = db.getImageUuidForUrl(`/uploads/${name}`);
+      const model = db.getImageModelForUrl(`/uploads/${name}`);
       const source = db.isGeneratedImage(`/uploads/${name}`) ? 'Generated' : 'Uploaded';
       const status = db.getImageStatusForUrl(`/uploads/${name}`) || (source === 'Generated' ? 'Generated' : 'Uploaded');
       const portfolio = db.getImagePortfolioForUrl(`/uploads/${name}`) ? 1 : 0;
       const productUrl = db.getProductUrlForImage(`/uploads/${name}`);
       const ebayUrl = db.getEbayUrlForImage(`/uploads/${name}`);
-      files.push({ id, uuid, name, size, mtime, title, source, status, portfolio, hidden, productUrl, ebayUrl });
+      files.push({ id, uuid, name, size, mtime, title, source, status, portfolio, hidden, productUrl, ebayUrl, model });
     }
 
     // Sort by database id (highest first)

--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -1257,6 +1257,13 @@ export default class TaskDB {
     return row ? row.id : null;
   }
 
+  getImageModelForUrl(url) {
+    const row = this.db
+        .prepare("SELECT model FROM chat_pairs WHERE image_url=? ORDER BY id DESC LIMIT 1")
+        .get(url);
+    return row ? row.model : "";
+  }
+
   getImageUuidForUrl(url) {
     const row = this.db
         .prepare("SELECT id, image_uuid FROM chat_pairs WHERE image_url=? ORDER BY id DESC LIMIT 1")


### PR DESCRIPTION
## Summary
- expose saved image model info from chat pairs to the upload list API
- compute and display per-model image generation prices in image history and chat metadata

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_6890e70d0dc883239dbce2a5e50a55be