### PR TITLE
Prevent Enter key from stopping Aurora chat output

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3885,6 +3885,14 @@ if (scrollDownBtnEl) {
 chatInputEl.addEventListener("keydown", (e) => {
   if (enterSubmitsMessage && e.key === "Enter" && !e.shiftKey) {
     e.preventDefault();
+    if(chatSendBtnEl.dataset.mode !== 'send'){
+      if(chatQueueEnabled){
+        queueMessage(chatInputEl.value.trim());
+        chatInputEl.value = "";
+        updateInputTokenCount();
+      }
+      return;
+    }
     if(chatSendBtnEl.disabled && chatQueueEnabled){
       queueMessage(chatInputEl.value.trim());
       chatInputEl.value = "";


### PR DESCRIPTION
## Summary
- avoid aborting the streaming response when Enter is pressed while the send button is in stop mode
- optionally queue the message instead of stopping the stream

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68962253b6408323a9ce8fff79cf3283