### PR TITLE
feat: support .env for Printify price updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .patchfiles_ignore/*
 TaskQueue/.env
 *.env
+!PrintifyPriceUpdater/sample.env
 printifyQueue.json
 
 # Ignore global node modules

--- a/PrintifyPriceUpdater/README.md
+++ b/PrintifyPriceUpdater/README.md
@@ -4,8 +4,10 @@ This script updates pricing for all variants of a Printify product.
 
 ## Usage
 
+1. Copy `sample.env` to `.env` and fill in your Printify credentials.
+2. Run the script:
+
 ```bash
-PRINTIFY_SHOP_ID=your_shop_id PRINTIFY_API_TOKEN=your_api_token \
 node update-pricing-by-size.js <product_id>
 ```
 

--- a/PrintifyPriceUpdater/sample.env
+++ b/PrintifyPriceUpdater/sample.env
@@ -1,0 +1,2 @@
+PRINTIFY_SHOP_ID=your_printify_shop_id
+PRINTIFY_API_TOKEN=your_printify_api_token

--- a/PrintifyPriceUpdater/update-pricing-by-size.js
+++ b/PrintifyPriceUpdater/update-pricing-by-size.js
@@ -1,3 +1,5 @@
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env') });
 const axios = require('axios');
 
 const API_BASE = 'https://api.printify.com/v1';


### PR DESCRIPTION
## Summary
- load `update-pricing-by-size.js` settings from a `.env` file
- document env setup and usage
- provide `sample.env`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node PrintifyPriceUpdater/update-pricing-by-size.js fake-product-id` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68963d6b340883238ccec5f7fc930021