### PR TITLE
Filter disabled variants when updating Printify pricing

### DIFF
--- a/PrintifyPriceUpdater/README.md
+++ b/PrintifyPriceUpdater/README.md
@@ -1,6 +1,6 @@
 # Printify Price Updater
 
-This script updates pricing for all variants of a Printify product.
+This script updates pricing for the enabled variants of a Printify product.
 
 ## Usage
 
@@ -11,7 +11,8 @@ This script updates pricing for all variants of a Printify product.
 node update-pricing-by-size.js <product_id>
 ```
 
-Prices are applied per size:
+Prices are applied per size. Disabled variants are ignored to avoid
+exceeding Printify's 100-variant limit:
 
 | Size | Price (USD) |
 | --- | --- |


### PR DESCRIPTION
## Summary
- Avoid Printify API 8251 error by only updating variants that are already enabled
- Clarify documentation that disabled variants are ignored and mention the 100-variant limit

## Testing
- `node PrintifyPriceUpdater/update-pricing-by-size.js` *(fails: Please set PRINTIFY_SHOP_ID and PRINTIFY_API_TOKEN environment variables)*

------
https://chatgpt.com/codex/tasks/task_b_68966690c3408323b8e463e8bd34544a