### PR TITLE
Log all updated variants during Printify price updates

### DIFF
--- a/PrintifyPriceUpdater/update-pricing-by-size.js
+++ b/PrintifyPriceUpdater/update-pricing-by-size.js
@@ -121,10 +121,9 @@ async function updatePricing() {
       };
     });
 
-    // Optional: log a quick summary for verification
-    const preview = updatedVariants.slice(0, 5).map(u => u);
+    // Log all updated variants for verification
     console.log('Found size option:', { index: sizeOptionIndex, name: sizeOption.name, type: sizeOption.type });
-    console.log(`Updating ${updatedVariants.length} enabled variants (first 5 shown):`, preview);
+    console.log(`Updating ${updatedVariants.length} enabled variants:`, updatedVariants);
 
     await axios.put(
       `${API_BASE}/shops/${SHOP_ID}/products/${productId}.json`,


### PR DESCRIPTION
## Summary
- Remove 5-item preview limit when logging updated variants
- Log every enabled variant to help verify price changes

## Testing
- `node --check PrintifyPriceUpdater/update-pricing-by-size.js`
- `node PrintifyPriceUpdater/update-pricing-by-size.js` *(fails: Please set PRINTIFY_SHOP_ID and PRINTIFY_API_TOKEN environment variables.)*

------
https://chatgpt.com/codex/tasks/task_b_689669f228c08323a2210eb8bcad3744