### PR TITLE
Parse variant size from title and log updated prices

### DIFF
--- a/PrintifyPriceUpdater/README.md
+++ b/PrintifyPriceUpdater/README.md
@@ -1,6 +1,10 @@
 # Printify Price Updater
 
 This script updates pricing for the enabled variants of a Printify product.
+Sizes are inferred from each variant's title (e.g. `"Black / M"`), so
+it works even if the size option metadata is missing. After updating, the
+script retrieves the product again and prints the variant JSON with the new
+prices for verification.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- derive variant size directly from variant title instead of relying on option metadata
- fetch product after update and print variant JSON with new prices
- document size parsing and post-update logging in README

## Testing
- `node update-pricing-by-size.js 12345` *(fails: Please set PRINTIFY_SHOP_ID and PRINTIFY_API_TOKEN environment variables)*


------
https://chatgpt.com/codex/tasks/task_b_6896884d74a8832394864dbd0d4a3b18