### PR TITLE
Add CLI for tracking Printify SKUs with SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ PrintifyPriceUpdater/.patchfiles_ignore/
 
 
 # package lock files are intentionally tracked
+
+PrintifyPriceUpdater/skus.db

--- a/PrintifyPriceUpdater/README.md
+++ b/PrintifyPriceUpdater/README.md
@@ -26,3 +26,23 @@ exceeding Printify's 100-variant limit:
 | 3XL | 26.01 |
 | 4XL, 5XL | 27.38 |
 
+
+## SKU Tracker
+
+Use the included CLI to maintain a list of Printify SKUs in a local SQLite database.
+
+### Commands
+
+List stored SKUs:
+
+```bash
+node sku-tracker.js list
+```
+
+Add a new SKU:
+
+```bash
+node sku-tracker.js add <sku>
+```
+
+SKUs are persisted in `skus.db` inside this directory.

--- a/PrintifyPriceUpdater/package-lock.json
+++ b/PrintifyPriceUpdater/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "printify-sku-tracker",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "printify-sku-tracker",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/PrintifyPriceUpdater/package.json
+++ b/PrintifyPriceUpdater/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "printify-sku-tracker",
+  "version": "1.0.0",
+  "description": "CLI for tracking Printify SKUs using a SQLite database.",
+  "main": "sku-tracker.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node sku-tracker.js",
+    "test": "node sku-tracker.js list"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/PrintifyPriceUpdater/sku-tracker.js
+++ b/PrintifyPriceUpdater/sku-tracker.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const path = require('path');
+const dbPath = path.join(__dirname, 'skus.db');
+
+function initDb() {
+  execSync(
+    `sqlite3 ${dbPath} "CREATE TABLE IF NOT EXISTS skus (id INTEGER PRIMARY KEY AUTOINCREMENT, sku TEXT UNIQUE NOT NULL)"`
+  );
+}
+
+function listSkus() {
+  initDb();
+  try {
+    const output = execSync(
+      `sqlite3 ${dbPath} "SELECT id || ': ' || sku FROM skus ORDER BY id"`
+    )
+      .toString()
+      .trim();
+    if (output) {
+      console.log(output);
+    } else {
+      console.log('No SKUs found.');
+    }
+  } catch (err) {
+    console.error('Error listing SKUs:', err.message);
+  }
+}
+
+function addSku(sku) {
+  initDb();
+  if (!sku) {
+    console.error('Please provide a SKU to add.');
+    process.exit(1);
+  }
+  const escapedSku = sku.replace(/'/g, "''");
+  try {
+    execSync(
+      `sqlite3 ${dbPath} "INSERT INTO skus (sku) VALUES ('${escapedSku}')"`
+    );
+    console.log(`Added SKU ${sku}.`);
+  } catch (err) {
+    const msg = err.stderr ? err.stderr.toString().trim() : err.message;
+    console.error('Failed to add SKU:', msg);
+    process.exit(1);
+  }
+}
+
+const [, , command, value] = process.argv;
+
+switch (command) {
+  case 'list':
+    listSkus();
+    break;
+  case 'add':
+    addSku(value);
+    break;
+  default:
+    console.log('Usage: node sku-tracker.js [list | add <sku>]');
+}


### PR DESCRIPTION
## Summary
- add simple Node.js CLI to store and list Printify SKUs in a SQLite database
- include package configuration and ignore the generated database file
- document how to use the SKU tracker

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6896913878f08323a98988bff2e7ddd6