### PR TITLE
Load env variables for SKU tracker

### DIFF
--- a/PrintifyPriceUpdater/README.md
+++ b/PrintifyPriceUpdater/README.md
@@ -30,7 +30,7 @@ exceeding Printify's 100-variant limit:
 
 ## SKU Tracker
 
-Use the included CLI to maintain a list of Printify SKUs in a local SQLite database.
+Use the included CLI to maintain a list of Printify SKUs in a local SQLite database. The tracker reads your Printify credentials from a `.env` file in this directory, so ensure `PRINTIFY_SHOP_ID` and `PRINTIFY_API_TOKEN` are set before adding SKUs.
 
 ### Commands
 

--- a/PrintifyPriceUpdater/sku-tracker.js
+++ b/PrintifyPriceUpdater/sku-tracker.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const { execSync } = require('child_process');
 const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env') });
 const dbPath = path.join(__dirname, 'skus.db');
 
 async function fetchTitle(sku) {


### PR DESCRIPTION
## Summary
- load `.env` before accessing Printify credentials in `sku-tracker.js`
- document `.env` usage for SKU tracker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6896a35d9e8883239c275ff91e3b9ed7