### PR TITLE
Add shipping policy setter for eBay listings

### DIFF
--- a/PrintifyPriceUpdater/public/index.html
+++ b/PrintifyPriceUpdater/public/index.html
@@ -34,6 +34,24 @@
           loadSkus();
         });
         li.appendChild(btn);
+        const shipBtn = document.createElement('button');
+        shipBtn.textContent = 'Set Shipping Policy';
+        shipBtn.disabled = !s.ebayId;
+        shipBtn.addEventListener('click', async () => {
+          if (!s.ebayId) return alert('Set eBay ID first');
+          const resp = await fetch('/api/ebay/set-shipping-policy', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ listingId: s.ebayId })
+          });
+          if (resp.ok) {
+            alert('Shipping policy updated');
+          } else {
+            const msg = await resp.text();
+            alert('Failed to update policy: ' + msg);
+          }
+        });
+        li.appendChild(shipBtn);
         list.appendChild(li);
       });
     }

--- a/PrintifyPriceUpdater/sample.env
+++ b/PrintifyPriceUpdater/sample.env
@@ -1,2 +1,4 @@
 PRINTIFY_SHOP_ID=your_printify_shop_id
 PRINTIFY_API_TOKEN=your_printify_api_token
+PROGRAMATIC_PUPPET_API_BASE=https://localhost:3005
+EBAY_SHIPPING_POLICY_ID=your_shipping_policy_id


### PR DESCRIPTION
## Summary
- add UI button to apply eBay shipping policy via ProgramaticPuppet
- forward listing IDs to ProgramaticPuppet with shipping policy from env
- document ProgramaticPuppet base and shipping policy ID in sample env

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6897619d38448323a4fd460f53623ebd