### PR TITLE
feat: improve shipping policy debugging

### DIFF
--- a/PrintifyPriceUpdater/public/index.html
+++ b/PrintifyPriceUpdater/public/index.html
@@ -39,16 +39,22 @@
         shipBtn.disabled = !s.ebayId;
         shipBtn.addEventListener('click', async () => {
           if (!s.ebayId) return alert('Set eBay ID first');
-          const resp = await fetch('/api/ebay/set-shipping-policy', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ listingId: s.ebayId })
-          });
-          if (resp.ok) {
-            alert('Shipping policy updated');
-          } else {
-            const msg = await resp.text();
-            alert('Failed to update policy: ' + msg);
+          try {
+            const resp = await fetch('/api/ebay/set-shipping-policy', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ listingId: s.ebayId })
+            });
+            if (resp.ok) {
+              alert('Shipping policy updated');
+            } else {
+              const msg = await resp.text();
+              console.error('Shipping policy update failed', resp.status, msg);
+              alert('Failed to update policy: ' + msg);
+            }
+          } catch (err) {
+            console.error('Shipping policy request failed', err);
+            alert('Failed to update policy: ' + err.message);
           }
         });
         li.appendChild(shipBtn);


### PR DESCRIPTION
## Summary
- add detailed logging and context for ProgramaticPuppet shipping policy updates
- return full stack traces on server errors for easier debugging
- handle fetch failures in the front-end and log verbose errors

## Testing
- `node --check PrintifyPriceUpdater/sku-tracker.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_689767c347e883238815d7bf08f9706f