### PR TITLE
Allow self-signed certificates for requests

### DIFF
--- a/PrintifyPriceUpdater/sku-tracker.js
+++ b/PrintifyPriceUpdater/sku-tracker.js
@@ -3,6 +3,8 @@ const { execSync } = require('child_process');
 const path = require('path');
 const express = require('express');
 const https = require('https');
+// Allow requests to proceed even when using self-signed certificates
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 require('dotenv').config({ path: path.join(__dirname, '.env') });
 const dbPath = path.join(__dirname, 'skus.db');
 


### PR DESCRIPTION
## Summary
- allow requests to proceed against self-signed TLS certs in the SKU tracker

## Testing
- `cd PrintifyPriceUpdater && npm test`

------
https://chatgpt.com/codex/tasks/task_b_689771dfdba0832388a2dc273bdd556c