### PR TITLE
Use port 3101 for SKU tracker

### DIFF
--- a/PrintifyPriceUpdater/README.md
+++ b/PrintifyPriceUpdater/README.md
@@ -59,4 +59,4 @@ Run the tracker without any arguments to start a small web server with a simple 
 node sku-tracker.js
 ```
 
-Then visit [http://localhost:3000](http://localhost:3000) in your browser.
+Then visit [http://localhost:3101](http://localhost:3101) in your browser.

--- a/PrintifyPriceUpdater/sku-tracker.js
+++ b/PrintifyPriceUpdater/sku-tracker.js
@@ -143,7 +143,7 @@ async function setShippingPolicy(listingId) {
 
 function startServer() {
   const app = express();
-  const port = process.env.PORT || 3000;
+  const port = process.env.PORT || 3101;
 
   app.use(express.json());
   app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
## Summary
- default SKU tracker to port 3101 instead of 3000
- update documentation to match new port

## Testing
- `cd PrintifyPriceUpdater; npm test`


------
https://chatgpt.com/codex/tasks/task_b_689776c605308323b3ef1e5a16e33a58