### PR TITLE
feat: make Printify publish optional

### DIFF
--- a/PrintifyPriceUpdater/README.md
+++ b/PrintifyPriceUpdater/README.md
@@ -4,12 +4,16 @@ This script updates pricing for the enabled variants of a Printify product and
 sets a detailed product description. Sizes are inferred from each variant's
 title (e.g. `"Black / M"`), so it works even if the size option metadata is
 missing. After updating, the script retrieves the product again, prints the
-variant JSON with the new prices for verification, and publishes the product to
-the connected store (e.g. eBay).
+variant JSON with the new prices for verification. Publishing to the connected
+store (e.g. eBay) is optional and controlled by the `PRINTIFY_PUBLISH`
+environment variable. If `PRINTIFY_PUBLISH` is set to `true`, the script will
+publish after updating. By default, publishing is skipped.
 
 ## Usage
 
-1. Copy `sample.env` to `.env` and fill in your Printify credentials.
+1. Copy `sample.env` to `.env` and fill in your Printify credentials. Set
+   `PRINTIFY_PUBLISH=true` if you want the script to publish the product after
+   updating; omit or set to `false` to skip publishing.
 2. Run the script:
 
 ```bash

--- a/PrintifyPriceUpdater/sample.env
+++ b/PrintifyPriceUpdater/sample.env
@@ -2,3 +2,5 @@ PRINTIFY_SHOP_ID=your_printify_shop_id
 PRINTIFY_API_TOKEN=your_printify_api_token
 PROGRAMATIC_PUPPET_API_BASE=https://localhost:3005
 EBAY_SHIPPING_POLICY_ID=your_shipping_policy_id
+# Uncomment to publish products after updating
+#PRINTIFY_PUBLISH=true

--- a/PrintifyPriceUpdater/update-pricing-by-size.js
+++ b/PrintifyPriceUpdater/update-pricing-by-size.js
@@ -5,6 +5,7 @@ const axios = require('axios');
 const API_BASE = 'https://api.printify.com/v1';
 const SHOP_ID = process.env.PRINTIFY_SHOP_ID;
 const API_TOKEN = process.env.PRINTIFY_API_TOKEN;
+const SHOULD_PUBLISH = (process.env.PRINTIFY_PUBLISH || '').toLowerCase() === 'true';
 
 if (!SHOP_ID || !API_TOKEN) {
   console.error('Please set PRINTIFY_SHOP_ID and PRINTIFY_API_TOKEN environment variables.');
@@ -180,7 +181,11 @@ async function publishProduct() {
 
 async function main() {
   await updatePricing();
-  await publishProduct();
+  if (SHOULD_PUBLISH) {
+    await publishProduct();
+  } else {
+    console.log('Skipping publish step; set PRINTIFY_PUBLISH=true to enable publishing.');
+  }
 }
 
 main();


### PR DESCRIPTION
## Summary
- allow `update-pricing-by-size.js` to skip publishing unless `PRINTIFY_PUBLISH=true`
- document new `PRINTIFY_PUBLISH` option and default behavior in README and sample.env

## Testing
- `cd PrintifyPriceUpdater && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_b_6898050044688323b9d46b1d5abd9a9a