### PR TITLE
feat: add Done button to SKU tracker

### DIFF
--- a/PrintifyPriceUpdater/README.md
+++ b/PrintifyPriceUpdater/README.md
@@ -64,3 +64,4 @@ node sku-tracker.js
 ```
 
 Then visit [http://localhost:3101](http://localhost:3101) in your browser.
+Each SKU row includes buttons to update eBay ID, run a price update, set the shipping policy, or mark the entry as **Done**.

--- a/PrintifyPriceUpdater/public/index.html
+++ b/PrintifyPriceUpdater/public/index.html
@@ -90,6 +90,14 @@
         });
         actions.appendChild(shipBtn);
 
+        const doneBtn = document.createElement('button');
+        doneBtn.textContent = 'Done';
+        doneBtn.addEventListener('click', async () => {
+          await fetch(`/api/skus/${s.id}/done`, { method: 'POST' });
+          loadSkus();
+        });
+        actions.appendChild(doneBtn);
+
         tr.appendChild(actions);
         tbody.appendChild(tr);
       });

--- a/PrintifyPriceUpdater/sku-tracker.js
+++ b/PrintifyPriceUpdater/sku-tracker.js
@@ -238,6 +238,16 @@ function startServer() {
     }
   });
 
+  app.post('/api/skus/:id/done', (req, res) => {
+    const { id } = req.params;
+    try {
+      const result = updateStatus(id, 'Done');
+      res.json(result);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
   app.listen(port, () => {
     console.log(`Server listening on http://localhost:${port}`);
   });


### PR DESCRIPTION
## Summary
- allow marking SKUs as Done via new `/api/skus/:id/done` endpoint
- show Done button in SKU tracker web UI
- document the Done action in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689953e5c15083239ecb8f2c301cafe8