### PR TITLE
feat: add delete for SKU tracker

### DIFF
--- a/PrintifyPriceUpdater/public/index.html
+++ b/PrintifyPriceUpdater/public/index.html
@@ -98,6 +98,15 @@
         });
         actions.appendChild(doneBtn);
 
+        const delBtn = document.createElement('button');
+        delBtn.textContent = 'Delete';
+        delBtn.addEventListener('click', async () => {
+          if (!confirm('Delete this SKU?')) return;
+          await fetch(`/api/skus/${s.id}`, { method: 'DELETE' });
+          loadSkus();
+        });
+        actions.appendChild(delBtn);
+
         tr.appendChild(actions);
         tbody.appendChild(tr);
       });

--- a/PrintifyPriceUpdater/sku-tracker.js
+++ b/PrintifyPriceUpdater/sku-tracker.js
@@ -194,6 +194,14 @@ function runPriceUpdate(id) {
   updateStatus(id, 'Price Updated');
 }
 
+function deleteSku(id) {
+  initDb();
+  execSync(
+    `sqlite3 ${dbPath} "DELETE FROM skus WHERE id=${Number(id)}"`
+  );
+  return { id: Number(id) };
+}
+
 function startServer() {
   const app = express();
   const port = process.env.PORT || 3101;
@@ -263,15 +271,25 @@ function startServer() {
     }
   });
 
-  app.post('/api/skus/:id/done', (req, res) => {
-    const { id } = req.params;
-    try {
-      const result = updateStatus(id, 'Done');
-      res.json(result);
-    } catch (err) {
-      res.status(400).json({ error: err.message });
-    }
-  });
+    app.post('/api/skus/:id/done', (req, res) => {
+      const { id } = req.params;
+      try {
+        const result = updateStatus(id, 'Done');
+        res.json(result);
+      } catch (err) {
+        res.status(400).json({ error: err.message });
+      }
+    });
+
+    app.delete('/api/skus/:id', (req, res) => {
+      const { id } = req.params;
+      try {
+        const result = deleteSku(id);
+        res.json(result);
+      } catch (err) {
+        res.status(400).json({ error: err.message });
+      }
+    });
 
   app.listen(port, () => {
     console.log(`Server listening on http://localhost:${port}`);


### PR DESCRIPTION
## Summary
- add deleteSku handler and API endpoint
- allow web UI to remove SKU entries

## Testing
- `cd PrintifyPriceUpdater && npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d056bae6483239ed66c5bdb1ed7de