### PR TITLE
Improve eBay ID lookup error handling in SKU tracker

### DIFF
--- a/PrintifyPriceUpdater/public/index.html
+++ b/PrintifyPriceUpdater/public/index.html
@@ -35,8 +35,17 @@
         const btn = document.createElement('button');
         btn.textContent = s.ebayId ? 'Refresh eBay ID' : 'Fetch eBay ID';
         btn.addEventListener('click', async () => {
-          await fetch(`/api/skus/${s.id}/ebay`, { method: 'POST' });
-          loadSkus();
+          try {
+            const resp = await fetch(`/api/skus/${s.id}/ebay`, { method: 'POST' });
+            if (resp.ok) {
+              loadSkus();
+            } else {
+              const msg = await resp.text();
+              alert('Failed to fetch eBay ID: ' + msg);
+            }
+          } catch (err) {
+            alert('Failed to fetch eBay ID: ' + err.message);
+          }
         });
         actions.appendChild(btn);
 


### PR DESCRIPTION
## Summary
- Add client-side error handling for eBay ID fetch button
- Validate eBay API responses and surface errors to the user
- Gracefully skip eBay lookups when token is missing during SKU addition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d0f6a2cf08323aed8dfd046f146d2