### PR TITLE
Disable chat input autocomplete

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -290,7 +290,7 @@
         <button id="chatImageBtn" class="send-btn" title="Upload Image" style="display:none;">📤</button>
         <button id="reasoningToggleBtn" class="send-btn reasoning-toggle-btn" title="Reasoning">🤖</button>
 
-        <textarea id="chatInput" placeholder="Type your message..."></textarea>
+        <textarea id="chatInput" placeholder="Type your message..." autocomplete="off"></textarea>
         <button id="chatSendBtn" class="send-btn">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                stroke-linecap="round" stroke-linejoin="round" class="feather feather-send">


### PR DESCRIPTION
## Summary
- Turn off chat input autocomplete to stop browser history suggestions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a0deb86a108323ae84d0836cb490a4